### PR TITLE
Fix memory path handling on case-sensitive systems

### DIFF
--- a/flask_proxy.py
+++ b/flask_proxy.py
@@ -23,7 +23,9 @@ def load_user_memory():
     if not user_key:
         abort(403, description="Access denied for this user.")
 
-    user_folder = os.path.join("memory", user_key)
+    # The memory directory is capitalized in this project ("Memory"),
+    # so use the correct case to avoid issues on case-sensitive systems.
+    user_folder = os.path.join("Memory", user_key)
     try:
         with open(os.path.join(user_folder, "core.json"), "r") as f:
             memory = json.load(f)


### PR DESCRIPTION
## Summary
- fix `Memory` folder path case in `flask_proxy.py`

## Testing
- `python -m py_compile flask_proxy.py plugins/web_search.py rex_speak_api.py rex_loop.py wakeword_listener.py record_wakeword.py test_search.py test_whisper.py`

------
https://chatgpt.com/codex/tasks/task_e_6846911d6898832aae385f78da6cb21e