### PR TITLE
Add environment-driven configuration for proxy and profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,39 @@
 ```bash
 git clone https://github.com/Blueibear/rex-ai-assistant.git
 cd rex-ai-assistant
+
+---
+
+## ⚙️ Configuration
+
+Rex reads several environment variables at start-up so you can tune
+authentication, search plugins, and the default memory profile. Restart
+the assistant or proxy after changing any of the values.
+
+### Web search
+
+- `SERPAPI_KEY` — enables the SerpAPI integration in
+  `plugins/web_search.py`. When unset, Rex falls back to DuckDuckGo
+  scraping.
+- `SERPAPI_ENGINE` *(optional)* — overrides the SerpAPI engine (defaults
+  to `google`).
+
+### Proxy authentication
+
+- `REX_PROXY_TOKEN` — shared-secret used by `flask_proxy.py`. Provide it
+  via an `Authorization: Bearer <token>` header or the
+  `X-Rex-Proxy-Token` header.
+- `REX_PROXY_ALLOW_LOCAL` — set to `1` while debugging to allow
+  loopback traffic without Cloudflare Access. Leave unset in
+  production.
+
+Requests that come through Cloudflare Access must continue to include
+the `Cf-Access-Authenticated-User-Email` header so the proxy can pick
+the correct memory profile.
+
+### Active memory profile
+
+- `REX_ACTIVE_USER` — selects the default user profile. Accepts a memory
+  folder name (for example `james`) or an email address listed in
+  `users.json`. The CLI assistant and Flask services load this profile
+  on start-up.

--- a/flask_proxy.py
+++ b/flask_proxy.py
@@ -1,41 +1,89 @@
 import os
 import json
 from flask import Flask, request, abort, jsonify
+
+from memory_utils import load_memory_profile, load_users_map, resolve_user_key
 from plugins.web_search import search_web
 
 app = Flask(__name__)
 
-# Load user map from users.json
-with open("users.json", "r") as f:
-    users = json.load(f)
+USERS_MAP = load_users_map()
+PROXY_TOKEN = os.getenv("REX_PROXY_TOKEN")
+ALLOW_LOCAL = os.getenv("REX_PROXY_ALLOW_LOCAL") == "1"
+
+
+def _extract_shared_secret() -> str | None:
+    """Return the shared-secret token provided with the request, if any."""
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header[7:].strip()
+        if token:
+            return token
+
+    header_token = request.headers.get("X-Rex-Proxy-Token")
+    if header_token:
+        return header_token.strip()
+
+    return None
+
+
+def _is_loopback_address(address: str | None) -> bool:
+    """Return ``True`` when the request originates from the local machine."""
+    if not address:
+        return False
+
+    if address.startswith("::ffff:"):
+        address = address.split("::ffff:", 1)[1]
+
+    return address in {"127.0.0.1", "::1"}
+
 
 @app.before_request
 def load_user_memory():
     global user_key, memory, user_folder
 
     email = request.headers.get("Cf-Access-Authenticated-User-Email")
-    if not email:
-        abort(403, description="No authenticated email provided.")
+    shared_secret = _extract_shared_secret()
+    remote_addr = request.remote_addr
 
-    email = email.lower()
-    user_key = users.get(email)
+    if email:
+        user_key_candidate = resolve_user_key(email, USERS_MAP)
+        if not user_key_candidate:
+            abort(403, description="Access denied for this user.")
+    elif shared_secret:
+        if not PROXY_TOKEN:
+            abort(403, description="Shared secret authentication is not configured.")
+        if shared_secret != PROXY_TOKEN:
+            abort(403, description="Invalid proxy token.")
 
-    if not user_key:
-        abort(403, description="Access denied for this user.")
+        configured_user = resolve_user_key(os.getenv("REX_ACTIVE_USER"), USERS_MAP)
+        if not configured_user:
+            abort(403, description="REX_ACTIVE_USER is not configured or invalid.")
+        user_key_candidate = configured_user
+    elif ALLOW_LOCAL and _is_loopback_address(remote_addr):
+        configured_user = resolve_user_key(os.getenv("REX_ACTIVE_USER"), USERS_MAP)
+        if not configured_user:
+            abort(403, description="Local access requested but REX_ACTIVE_USER is not configured or invalid.")
+        user_key_candidate = configured_user
+    else:
+        abort(403, description="No authenticated identity provided.")
 
-    # The memory directory is capitalized in this project ("Memory"),
-    # so use the correct case to avoid issues on case-sensitive systems.
+    user_key = user_key_candidate
     user_folder = os.path.join("Memory", user_key)
+
     try:
-        with open(os.path.join(user_folder, "core.json"), "r") as f:
-            memory = json.load(f)
+        memory = load_memory_profile(user_key)
     except FileNotFoundError:
-        abort(500, description="Memory file not found for this user.")
+        abort(500, description=f"Memory file not found for user '{user_key}'.")
+    except json.JSONDecodeError:
+        abort(500, description=f"Memory file for user '{user_key}' is invalid JSON.")
+
 
 # ✅ Root route: status check
 @app.route("/")
 def index():
     return "🧠 Rex is online. Ask away."
+
 
 # ✅ Whoami route: returns active memory profile
 @app.route("/whoami")
@@ -44,6 +92,7 @@ def whoami():
         "user": user_key,
         "memory": memory
     })
+
 
 # ✅ Search route: performs live web search
 @app.route("/search")
@@ -58,7 +107,6 @@ def search():
         "result": result
     })
 
+
 if __name__ == "__main__":
     app.run(port=5000, host="0.0.0.0")
-
-

--- a/memory_utils.py
+++ b/memory_utils.py
@@ -1,0 +1,135 @@
+"""Helper utilities for loading Rex memory profiles and metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, Optional
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+MEMORY_ROOT = os.path.join(REPO_ROOT, "Memory")
+USERS_PATH = os.path.join(REPO_ROOT, "users.json")
+
+
+def load_users_map(users_path: str = USERS_PATH) -> Dict[str, str]:
+    """Return the email-to-user mapping defined in ``users.json``.
+
+    Parameters
+    ----------
+    users_path:
+        Optional override for the location of ``users.json``.
+
+    Returns
+    -------
+    Dict[str, str]
+        Normalised mapping of lowercase email addresses to lowercase user keys.
+    """
+    try:
+        with open(users_path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        return {}
+
+    mapping: Dict[str, str] = {}
+    for email, user in data.items():
+        if isinstance(email, str) and isinstance(user, str):
+            mapping[email.lower()] = user.lower()
+    return mapping
+
+
+def resolve_user_key(
+    identifier: Optional[str],
+    users_map: Dict[str, str],
+    *,
+    memory_root: str = MEMORY_ROOT,
+    profiles: Optional[Dict[str, dict]] = None,
+) -> Optional[str]:
+    """Resolve a user identifier to a memory folder key.
+
+    The identifier can be an email address, an existing memory folder name,
+    or a profile name stored in ``core.json``.
+
+    Parameters
+    ----------
+    identifier:
+        Email address, folder name, or display name to resolve.
+    users_map:
+        Mapping of email addresses to folder names from :func:`load_users_map`.
+    memory_root:
+        Base directory that contains user memory folders.
+    profiles:
+        Optional mapping of folder keys to the parsed ``core.json`` contents.
+
+    Returns
+    -------
+    Optional[str]
+        Lowercase memory key if it can be resolved; otherwise ``None``.
+    """
+    if not identifier:
+        return None
+
+    key = identifier.strip().lower()
+    if profiles and key in profiles:
+        return key
+
+    if key in users_map.values():
+        return key
+
+    mapped = users_map.get(key)
+    if mapped:
+        return mapped
+
+    if profiles:
+        for candidate, profile in profiles.items():
+            name = profile.get("name") if isinstance(profile, dict) else None
+            if isinstance(name, str) and name.strip().lower() == key:
+                return candidate
+
+    if os.path.isdir(os.path.join(memory_root, key)):
+        return key
+
+    return None
+
+
+def load_memory_profile(user_key: str, memory_root: str = MEMORY_ROOT) -> dict:
+    """Load the ``core.json`` file for a specific user."""
+    core_path = os.path.join(memory_root, user_key, "core.json")
+    with open(core_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_all_profiles(memory_root: str = MEMORY_ROOT) -> Dict[str, dict]:
+    """Load all user profiles found in the memory directory."""
+    profiles: Dict[str, dict] = {}
+    if not os.path.isdir(memory_root):
+        return profiles
+
+    for entry in os.listdir(memory_root):
+        path = os.path.join(memory_root, entry)
+        if not os.path.isdir(path):
+            continue
+
+        key = entry.lower()
+        try:
+            profile = load_memory_profile(entry, memory_root)
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
+
+        profiles[key] = profile
+
+    return profiles
+
+
+def extract_voice_reference(profile: dict) -> Optional[str]:
+    """Return the best available voice reference path from a profile."""
+    voice_sample = profile.get("voice_sample")
+    if isinstance(voice_sample, str):
+        return voice_sample
+
+    voice = profile.get("voice") if isinstance(profile, dict) else None
+    if isinstance(voice, dict):
+        candidate = voice.get("sample_path") or voice.get("sample")
+        if isinstance(candidate, str):
+            return candidate
+
+    return None

--- a/plugins/web_search.py
+++ b/plugins/web_search.py
@@ -1,15 +1,23 @@
+import os
+
 import requests
 from bs4 import BeautifulSoup
 
-SERPAPI_KEY = "fcf4910ff42a2366c27241343aabd9d4296534065f7b7688d4303971f6f479b3"
+SERPAPI_URL = "https://serpapi.com/search"
 
 def search_serpapi(query):
+    api_key = os.getenv("SERPAPI_KEY")
+    if not api_key:
+        print("[Search] SERPAPI_KEY not set; skipping SerpAPI.")
+        return None
+
+    engine = os.getenv("SERPAPI_ENGINE", "google") or "google"
+
     print("[Search] Using SerpAPI...")
-    url = "https://serpapi.com/search"
     params = {
         "q": query,
-        "api_key": SERPAPI_KEY,
-        "engine": "google",
+        "api_key": api_key,
+        "engine": engine,
         "num": "3"
     }
     headers = {
@@ -17,7 +25,7 @@ def search_serpapi(query):
     }
 
     try:
-        response = requests.get(url, params=params, headers=headers, timeout=10)
+        response = requests.get(SERPAPI_URL, params=params, headers=headers, timeout=10)
         response.raise_for_status()
         data = response.json()
         results = data.get("organic_results", [])

--- a/rex_speak_api.py
+++ b/rex_speak_api.py
@@ -1,28 +1,56 @@
-from flask import Flask, request, send_file, jsonify
-from TTS.api import TTS
 import os
 import uuid
 
+from flask import Flask, request, send_file, jsonify
+from TTS.api import TTS
+
+from memory_utils import (
+    extract_voice_reference,
+    load_all_profiles,
+    load_users_map,
+    resolve_user_key,
+)
+
 app = Flask(__name__)
 
-# Define paths for user voice references. 
-# Use None values when a specific speaker reference is not available.
+USERS_MAP = load_users_map()
+USER_PROFILES = load_all_profiles()
+DEFAULT_USER = resolve_user_key(os.getenv("REX_ACTIVE_USER"), USERS_MAP, profiles=USER_PROFILES)
+
+if not DEFAULT_USER:
+    if USER_PROFILES:
+        DEFAULT_USER = sorted(USER_PROFILES.keys())[0]
+    else:
+        DEFAULT_USER = "james"
+
 USER_VOICES = {
-    "james": None,
-    "cole": None
+    user: extract_voice_reference(profile)
+    for user, profile in USER_PROFILES.items()
 }
+
+if DEFAULT_USER not in USER_VOICES:
+    USER_VOICES[DEFAULT_USER] = None
 
 # Load XTTS model at app startup
 xtts = TTS(model_name="tts_models/multilingual/multi-dataset/xtts_v2", progress_bar=False, gpu=False)
 
+
 @app.route("/speak", methods=["POST"])
 def speak():
-    data = request.get_json()
+    data = request.get_json() or {}
     text = data.get("text")
-    user = data.get("user", "james").lower()
+    user_param = data.get("user")
 
     if not text:
         return jsonify({"error": "Missing text parameter"}), 400
+
+    if user_param:
+        user = str(user_param).lower()
+    else:
+        user = DEFAULT_USER
+
+    if user not in USER_VOICES:
+        user = DEFAULT_USER
 
     speaker_wav = USER_VOICES.get(user)
 


### PR DESCRIPTION
## Summary
- load the SerpAPI API key and engine from the environment instead of hard-coding credentials
- add shared-secret, local debugging, and active-user handling to the Flask proxy with reusable memory helpers
- let the CLI assistant and TTS API honour REX_ACTIVE_USER and document the new configuration knobs

## Testing
- python -m compileall plugins/web_search.py flask_proxy.py rex_assistant.py rex_speak_api.py memory_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe7b13f2c832a9e4c562d3c45386d