### PR TITLE
fix(lint): resolve ruff, black, and mypy failures across 35 files

### DIFF
--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -11,6 +11,7 @@ from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from .assistant_errors import IntegrationNotConfiguredError
 from .calendar_service import get_calendar_service
@@ -506,11 +507,11 @@ class Assistant:
         _sug_engine = getattr(self, "_suggestion_engine", None)
         if _sug_engine is not None and _sug_engine.has_pending:
             if _sug_engine.is_accept(transcript):
-                reply = _sug_engine.handle_yes()
+                reply = cast(str, _sug_engine.handle_yes())
                 self._record_completion(transcript, reply)
                 return reply
             elif _sug_engine.is_dismiss(transcript):
-                reply = _sug_engine.handle_dismiss()
+                reply = cast(str, _sug_engine.handle_dismiss())
                 self._record_completion(transcript, reply)
                 return reply
 
@@ -567,7 +568,7 @@ class Assistant:
             _music_response = _music_handler.handle(transcript)
             if _music_response is not None:
                 self._record_completion(transcript, _music_response)
-                return _music_response
+                return cast(str, _music_response)
 
         # Device state queries (US-028)
         _ds_handler = getattr(self, "_device_state_handler", None)
@@ -575,7 +576,7 @@ class Assistant:
             _ds_response = _ds_handler.handle(transcript)
             if _ds_response is not None:
                 self._record_completion(transcript, _ds_response)
-                return _ds_response
+                return cast(str, _ds_response)
 
         # Per-user credential/history scoping: swap self._user_id for the
         # duration of this call so history, transcripts, and tool calls use

--- a/rex/audit.py
+++ b/rex/audit.py
@@ -18,7 +18,7 @@ import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field
 
@@ -182,9 +182,9 @@ class AuditLogger:
             action_id=entry.action_id,
             task_id=entry.task_id,
             tool=entry.tool,
-            tool_call_args=redacted_args,  # type: ignore[arg-type]
+            tool_call_args=redacted_args,
             policy_decision=entry.policy_decision,
-            tool_result=redacted_result,  # type: ignore[arg-type]
+            tool_result=redacted_result,
             error=entry.error,
             redacted=True,
             requested_by=entry.requested_by,
@@ -272,7 +272,7 @@ class AuditLogger:
                     try:
                         entry = LogEntry.model_validate_json(line)
                         if entry.action_id == action_id:
-                            return entry
+                            return cast(LogEntry | None, entry)
                     except Exception:
                         continue
         except OSError as e:

--- a/rex/autonomy/preference_learner.py
+++ b/rex/autonomy/preference_learner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import cast
 
 from rex.autonomy.history import ExecutionRecord
 from rex.autonomy.preferences import UserPreferenceProfile
@@ -88,7 +89,7 @@ class PreferenceLearner:
             )
 
         updated.last_updated = datetime.now(UTC)
-        return updated
+        return cast(UserPreferenceProfile, updated)
 
 
 # ---------------------------------------------------------------------------

--- a/rex/autonomy/preferences.py
+++ b/rex/autonomy/preferences.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from pydantic import BaseModel, Field
 
@@ -86,7 +87,7 @@ class PreferenceStore:
             return UserPreferenceProfile()
         try:
             raw = self._path.read_text(encoding="utf-8")
-            return UserPreferenceProfile.model_validate_json(raw)
+            return cast(UserPreferenceProfile, UserPreferenceProfile.model_validate_json(raw))
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "PreferenceStore: failed to parse %s — returning defaults. Error: %s",

--- a/rex/autonomy/runner.py
+++ b/rex/autonomy/runner.py
@@ -323,7 +323,7 @@ def _write_history(
     record = ExecutionRecord(
         goal=plan.goal,
         plan=plan,
-        outcome=_outcome_from_plan(plan),  # type: ignore[arg-type]
+        outcome=_outcome_from_plan(plan),
         duration_s=duration_s,
         replan_count=replan_count,
         error_summary=error_summary,

--- a/rex/cli.py
+++ b/rex/cli.py
@@ -693,17 +693,17 @@ def cmd_memory(args: argparse.Namespace) -> int:
                 print("Use formats like: 7d, 24h, 30m, 1w, 10s")
                 return 1
 
-        entry = ltm.add_entry(  # type: ignore[assignment]
+        entry = ltm.add_entry(
             category=category,
             content=content,
             expires_in=expires_in,
             sensitive=args.sensitive,
         )
 
-        print(f"Added memory entry: {entry.entry_id}")  # type: ignore[attr-defined]
-        print(f"  Category: {entry.category}")  # type: ignore[attr-defined]
-        print(f"  Expires: {entry.expires_at or 'never'}")  # type: ignore[attr-defined]
-        print(f"  Sensitive: {entry.sensitive}")  # type: ignore[attr-defined]
+        print(f"Added memory entry: {entry.entry_id}")
+        print(f"  Category: {entry.category}")
+        print(f"  Expires: {entry.expires_at or 'never'}")
+        print(f"  Sensitive: {entry.sensitive}")
         return 0
 
     if subcommand == "search":
@@ -726,19 +726,19 @@ def cmd_memory(args: argparse.Namespace) -> int:
         print("=" * 60)
         print()
 
-        for entry in results:  # type: ignore[assignment]
-            print(f"{entry.entry_id} [{entry.category}]")  # type: ignore[attr-defined]
-            print(f"  Created: {entry.created_at}")  # type: ignore[attr-defined]
-            if entry.expires_at:  # type: ignore[attr-defined]
-                print(f"  Expires: {entry.expires_at}")  # type: ignore[attr-defined]
-            if entry.sensitive:  # type: ignore[attr-defined]
+        for entry in results:
+            print(f"{entry.entry_id} [{entry.category}]")
+            print(f"  Created: {entry.created_at}")
+            if entry.expires_at:
+                print(f"  Expires: {entry.expires_at}")
+            if entry.sensitive:
                 print("  [SENSITIVE]")
                 if show_sensitive:
-                    print(f"  Content: {json.dumps(entry.content, indent=4)}")  # type: ignore[attr-defined]
+                    print(f"  Content: {json.dumps(entry.content, indent=4)}")
                 else:
                     print("  Content: <hidden - use --show-sensitive>")
             else:
-                print(f"  Content: {json.dumps(entry.content, indent=4)}")  # type: ignore[attr-defined]
+                print(f"  Content: {json.dumps(entry.content, indent=4)}")
             print()
 
         print(f"Total: {len(results)} entries found")

--- a/rex/compat/transformers_shims.py
+++ b/rex/compat/transformers_shims.py
@@ -73,7 +73,7 @@ def ensure_transformers_compatibility() -> None:
                 return
 
         # Monkey-patch transformers to expose BeamSearchScorer at top level
-        transformers.BeamSearchScorer = beam_search_scorer  # type: ignore[attr-defined]
+        transformers.BeamSearchScorer = beam_search_scorer
         logger.info("Successfully patched transformers.BeamSearchScorer for backward compatibility")
 
     except ImportError:

--- a/rex/computers/agent_server.py
+++ b/rex/computers/agent_server.py
@@ -196,12 +196,12 @@ def create_app(
         if not _token:
             # Server is misconfigured — refuse all requests.
             logger.error("Agent token is not configured; refusing request")
-            return jsonify({"error": "Server misconfigured: token not set"}), 401  # type: ignore[return-value]
+            return jsonify({"error": "Server misconfigured: token not set"}), 401
         if not provided:
-            return jsonify({"error": "Missing auth token"}), 401  # type: ignore[return-value]
+            return jsonify({"error": "Missing auth token"}), 401
         if not hmac.compare_digest(provided, _token):
             logger.warning("Rejected request from %s: invalid token", request.remote_addr)
-            return jsonify({"error": "Invalid auth token"}), 401  # type: ignore[return-value]
+            return jsonify({"error": "Invalid auth token"}), 401
         return None
 
     # ------------------------------------------------------------------
@@ -213,7 +213,7 @@ def create_app(
         key = request.remote_addr or "unknown"
         if not limiter.is_allowed(key):
             logger.warning("Rate limit exceeded for %s", key)
-            return jsonify({"error": "Too many requests"}), 429  # type: ignore[return-value]
+            return jsonify({"error": "Too many requests"}), 429
         return None
 
     # ------------------------------------------------------------------

--- a/rex/computers/app_launcher.py
+++ b/rex/computers/app_launcher.py
@@ -28,9 +28,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_REGISTRY_PATH = Path("config") / "app_registry.json"
 
 # Sentinel returned when an app is not found in the registry.
-APP_NOT_FOUND_MESSAGE = (
-    "I don't know how to open that. You can add it in settings."
-)
+APP_NOT_FOUND_MESSAGE = "I don't know how to open that. You can add it in settings."
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +46,7 @@ def _default_registry_path() -> Path:
         return _DEFAULT_REGISTRY_PATH
 
 
-def load_app_registry(registry_path: "str | Path | None" = None) -> dict[str, str]:
+def load_app_registry(registry_path: str | Path | None = None) -> dict[str, str]:
     """Load the app registry from *registry_path*.
 
     The registry is a JSON object mapping lowercase app names to executable
@@ -90,7 +88,7 @@ def load_app_registry(registry_path: "str | Path | None" = None) -> dict[str, st
 
 def _launch_windows(executable: str) -> None:
     """Launch *executable* on Windows using os.startfile."""
-    os.startfile(executable)  # noqa: SC200
+    os.startfile(executable)  # type: ignore[attr-defined]  # noqa: SC200
 
 
 def _launch_macos(executable: str) -> None:
@@ -121,7 +119,7 @@ def _platform_launch(executable: str) -> None:
 
 def launch_app(
     name: str,
-    registry_path: "str | Path | None" = None,
+    registry_path: str | Path | None = None,
 ) -> str:
     """Launch a desktop application by its registry name.
 

--- a/rex/computers/config.py
+++ b/rex/computers/config.py
@@ -31,7 +31,7 @@ Security notes
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -154,7 +154,7 @@ def load_computers_config(raw_config: dict[str, Any]) -> ComputersConfig:
     computers_section = raw_config.get("computers")
     if not computers_section or not isinstance(computers_section, list):
         return ComputersConfig()
-    return ComputersConfig.model_validate({"computers": computers_section})
+    return cast(ComputersConfig, ComputersConfig.model_validate({"computers": computers_section}))
 
 
 __all__ = [

--- a/rex/computers/file_ops.py
+++ b/rex/computers/file_ops.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import fnmatch
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
@@ -44,8 +43,8 @@ def _default_allowed_roots() -> list[str]:
 
 
 def _resolve_and_check(
-    path: "str | Path",
-    allowed_roots: "list[str] | None",
+    path: str | Path,
+    allowed_roots: list[str] | None,
 ) -> Path:
     """Resolve *path* to an absolute path and verify it is within *allowed_roots*.
 
@@ -82,8 +81,8 @@ def _resolve_and_check(
 
 
 def read_file(
-    path: "str | Path",
-    allowed_roots: "list[str] | None" = None,
+    path: str | Path,
+    allowed_roots: list[str] | None = None,
     encoding: str = "utf-8",
 ) -> str:
     """Read and return the text content of a file.
@@ -109,9 +108,9 @@ def read_file(
 
 
 def write_file(
-    path: "str | Path",
+    path: str | Path,
     content: str,
-    allowed_roots: "list[str] | None" = None,
+    allowed_roots: list[str] | None = None,
     encoding: str = "utf-8",
 ) -> None:
     """Write *content* to a file, creating parent directories as needed.
@@ -132,8 +131,8 @@ def write_file(
 
 
 def list_dir(
-    path: "str | Path",
-    allowed_roots: "list[str] | None" = None,
+    path: str | Path,
+    allowed_roots: list[str] | None = None,
 ) -> list[str]:
     """Return a sorted list of entry names in *path*.
 
@@ -161,8 +160,8 @@ def list_dir(
 
 
 def summarize_file(
-    path: "str | Path",
-    allowed_roots: "list[str] | None" = None,
+    path: str | Path,
+    allowed_roots: list[str] | None = None,
     max_chars: int = 8000,
 ) -> str:
     """Summarise the text content of a file using the LLM.
@@ -185,9 +184,7 @@ def summarize_file(
     """
     content = read_file(path, allowed_roots)
     snippet = content[:max_chars]
-    prompt = (
-        f"Please summarise the following document concisely:\n\n{snippet}"
-    )
+    prompt = f"Please summarise the following document concisely:\n\n{snippet}"
 
     try:
         from rex.config import load_config
@@ -205,9 +202,9 @@ def summarize_file(
 
 
 def search_files(
-    directory: "str | Path",
+    directory: str | Path,
     query: str,
-    allowed_roots: "list[str] | None" = None,
+    allowed_roots: list[str] | None = None,
     pattern: str = "*.txt",
 ) -> list[dict[str, Any]]:
     """Search text files in *directory* for lines matching *query*.

--- a/rex/computers/pc_run_policy.py
+++ b/rex/computers/pc_run_policy.py
@@ -39,7 +39,7 @@ import hashlib
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from rex.contracts import ToolCall
 from rex.policy import PolicyDecision
@@ -177,7 +177,7 @@ def find_pending_or_approved_approval(
                 and approval.step_id == step_id
                 and approval.status in ("pending", "approved")
             ):
-                return approval
+                return cast(WorkflowApproval | None, approval)
         except Exception:  # noqa: BLE001
             continue
 

--- a/rex/computers/safety.py
+++ b/rex/computers/safety.py
@@ -35,8 +35,8 @@ Usage example
 from __future__ import annotations
 
 import logging
-from enum import Enum
-from typing import Callable
+from collections.abc import Callable
+from enum import StrEnum
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ _DANGEROUS_ACTIONS: frozenset[str] = frozenset(
 )
 
 
-class ActionType(str, Enum):
+class ActionType(StrEnum):
     """Classification of a computer-control action."""
 
     safe = "safe"
@@ -113,8 +113,7 @@ class SafetyLayer:
     def __init__(self, mode: str = "dangerous_only") -> None:
         if mode not in _VALID_MODES:
             raise ValueError(
-                f"Invalid confirmation mode: {mode!r}. "
-                f"Must be one of: {sorted(_VALID_MODES)}"
+                f"Invalid confirmation mode: {mode!r}. " f"Must be one of: {sorted(_VALID_MODES)}"
             )
         self._mode = mode
 
@@ -145,7 +144,7 @@ class SafetyLayer:
         self,
         action_name: str,
         description: str = "",
-        confirm_fn: "Callable[[str], bool] | None" = None,
+        confirm_fn: Callable[[str], bool] | None = None,
     ) -> bool:
         """Check whether *action_name* is permitted to proceed.
 
@@ -183,7 +182,7 @@ class SafetyLayer:
         return allowed
 
     @classmethod
-    def from_config(cls) -> "SafetyLayer":
+    def from_config(cls) -> SafetyLayer:
         """Create a :class:`SafetyLayer` from the active ``AppConfig``.
 
         Falls back to ``"dangerous_only"`` if config cannot be loaded.

--- a/rex/config.py
+++ b/rex/config.py
@@ -532,9 +532,7 @@ def _merge_profile_config(base_config: dict) -> dict:
         profile = load_profile(profile_name, profiles_dir=profiles_dir)
     except FileNotFoundError:
         if profile_name != "default":
-            LOGGER.warning(
-                "Profile '%s' not found; falling back to 'default'.", profile_name
-            )
+            LOGGER.warning("Profile '%s' not found; falling back to 'default'.", profile_name)
             profile = load_profile("default", profiles_dir=profiles_dir)
             profile_name = "default"
         else:

--- a/rex/email_backends/account_config.py
+++ b/rex/email_backends/account_config.py
@@ -27,7 +27,7 @@ Example config fragment::
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -134,7 +134,7 @@ def load_email_config(raw_config: dict[str, Any]) -> EmailConfig:
     email_section = raw_config.get("email")
     if not email_section or not isinstance(email_section, dict):
         return EmailConfig()
-    return EmailConfig.model_validate(email_section)
+    return cast(EmailConfig, EmailConfig.model_validate(email_section))
 
 
 __all__ = [

--- a/rex/gui_app.py
+++ b/rex/gui_app.py
@@ -153,6 +153,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
         turns = _history_store.load_history(user["id"])
         return jsonify(turns), 200
 
@@ -161,6 +162,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
         _history_store.clear_history(user["id"])
         return jsonify({"ok": True}), 200
 
@@ -169,6 +171,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
 
         data: dict[str, Any] = request.get_json(silent=True) or {}
         user_text = (data.get("message") or "").strip()
@@ -184,6 +187,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
             from datetime import UTC, datetime
 
             reply = _generate_reply(user_text)
+            assert user is not None
             _history_store.save_turn(user["id"], "assistant", reply, datetime.now(UTC))
             payload = json.dumps({"content": reply, "done": True})
             yield f"data: {payload}\n\n"
@@ -417,6 +421,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
         from rex.permissions import get_permissions
 
         return jsonify({"permissions": get_permissions(user["id"])}), 200
@@ -427,6 +432,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
         from rex.permissions import Permission, check_permission, grant_permission
 
         if not check_permission(user["id"], Permission.admin):
@@ -452,6 +458,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
         from rex.permissions import Permission, check_permission, revoke_permission
 
         if not check_permission(user["id"], Permission.admin):
@@ -503,6 +510,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
         from rex.identity import get_user_profile
 
         profile = get_user_profile(user["id"])
@@ -515,6 +523,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
         updates: dict[str, Any] = request.get_json(silent=True) or {}
         from rex.identity import create_user_profile, get_user_profile, update_user_preferences
 
@@ -552,6 +561,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
 
         if "file" not in request.files:
             return jsonify({"error": "no file uploaded"}), 400
@@ -570,7 +580,8 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         except Exception:
             return jsonify({"error": "invalid image file"}), 400
 
-        img = img.resize(_AVATAR_SIZE, Image.LANCZOS)
+        resample = getattr(Image, "Resampling", Image).LANCZOS
+        img = img.resize(_AVATAR_SIZE, resample)
 
         _AVATAR_DIR.mkdir(parents=True, exist_ok=True)
         avatar_path = _AVATAR_DIR / f"{user['id']}.jpg"
@@ -813,13 +824,23 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         import urllib.error
         import urllib.request
 
+        from rex.config import load_config
+
         cfg = load_config()
         base_url = (cfg.ha_base_url or "").rstrip("/")
         token = cfg.ha_token or ""
 
         if not base_url:
-            return jsonify({"ok": False, "not_configured": True,
-                            "error": "Home Assistant is not configured"}), 200
+            return (
+                jsonify(
+                    {
+                        "ok": False,
+                        "not_configured": True,
+                        "error": "Home Assistant is not configured",
+                    }
+                ),
+                200,
+            )
 
         url = f"{base_url}/api/states"
         headers = {
@@ -881,6 +902,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
         return jsonify({"quick_actions": _get_quick_actions(user["id"])}), 200
 
     @app.route("/api/quick-actions", methods=["POST"])
@@ -889,6 +911,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
 
         data: dict[str, Any] = request.get_json(silent=True) or {}
         label = (data.get("label") or "").strip()
@@ -911,6 +934,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
 
         actions = _get_quick_actions(user["id"])
         new_actions = [a for a in actions if a.get("id") != action_id]
@@ -925,6 +949,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
         user, err = _require_auth()
         if err:
             return err
+        assert user is not None
 
         actions = _get_quick_actions(user["id"])
         action = next((a for a in actions if a.get("id") == action_id), None)
@@ -1012,9 +1037,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
             return jsonify({"integrations": []}), 200
 
         search_configured = bool(
-            os.getenv("SERPAPI_API_KEY")
-            or os.getenv("BRAVE_API_KEY")
-            or os.getenv("GOOGLE_CSE_ID")
+            os.getenv("SERPAPI_API_KEY") or os.getenv("BRAVE_API_KEY") or os.getenv("GOOGLE_CSE_ID")
         )
 
         integrations = [
@@ -1131,7 +1154,16 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
                 "is_all_day": e.is_all_day,
             }
 
-        return jsonify({"ok": True, "events": [_event_to_dict(e) for e in events], "configured": configured}), 200
+        return (
+            jsonify(
+                {
+                    "ok": True,
+                    "events": [_event_to_dict(e) for e in events],
+                    "configured": configured,
+                }
+            ),
+            200,
+        )
 
     @app.route("/api/email/inbox", methods=["GET"])
     def _email_inbox() -> Any:
@@ -1172,7 +1204,16 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
                 "priority": m.priority,
             }
 
-        return jsonify({"ok": True, "messages": [_msg_to_dict(m) for m in messages], "configured": configured}), 200
+        return (
+            jsonify(
+                {
+                    "ok": True,
+                    "messages": [_msg_to_dict(m) for m in messages],
+                    "configured": configured,
+                }
+            ),
+            200,
+        )
 
     @app.route("/api/sms/threads", methods=["GET"])
     def _sms_threads() -> Any:
@@ -1214,7 +1255,16 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
                 "unread_count": t.unread_count,
             }
 
-        return jsonify({"ok": True, "threads": [_thread_to_dict(t) for t in threads], "configured": configured}), 200
+        return (
+            jsonify(
+                {
+                    "ok": True,
+                    "threads": [_thread_to_dict(t) for t in threads],
+                    "configured": configured,
+                }
+            ),
+            200,
+        )
 
     @app.route("/api/capabilities", methods=["GET"])
     def _list_capabilities() -> Any:

--- a/rex/ha_bridge.py
+++ b/rex/ha_bridge.py
@@ -644,4 +644,4 @@ def create_blueprint(bridge: HABridge | None = None) -> Blueprint:
             logger.warning("Failed to execute Home Assistant script: %s", exc)
             return error_response(INTERNAL_ERROR, str(exc), 500)
 
-    return bp  # type: ignore[no-any-return]
+    return bp

--- a/rex/ha_tts/config.py
+++ b/rex/ha_tts/config.py
@@ -33,6 +33,8 @@ allow_http
 
 from __future__ import annotations
 
+from typing import cast
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -58,6 +60,6 @@ def load_ha_tts_config() -> HaTtsConfig:
 
         cfg = load_config()
         raw = cfg.get("notifications", {}).get("ha_tts", {})
-        return HaTtsConfig.model_validate(raw)
+        return cast(HaTtsConfig, HaTtsConfig.model_validate(raw))
     except Exception:
         return HaTtsConfig()

--- a/rex/integrations/telegram/receiver.py
+++ b/rex/integrations/telegram/receiver.py
@@ -93,9 +93,7 @@ class TelegramReceiver:
                 "TelegramReceiver: not configured (set telegram_chat_id in rex_config.json)"
             )
         if self._assistant is None:
-            raise IntegrationNotConfiguredError(
-                "TelegramReceiver: no assistant provided"
-            )
+            raise IntegrationNotConfiguredError("TelegramReceiver: no assistant provided")
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/rex/knowledge_base.py
+++ b/rex/knowledge_base.py
@@ -34,7 +34,7 @@ import uuid
 from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
@@ -682,7 +682,7 @@ class KnowledgeBase:
         self._save()
 
         logger.info(f"Refreshed document: {doc_id} - {updated.title}")
-        return updated
+        return cast(KnowledgeDocument | None, updated)
 
     def refresh_all(self) -> dict[str, str]:
         """Refresh all documents that have a source path.

--- a/rex/llm_client.py
+++ b/rex/llm_client.py
@@ -356,9 +356,7 @@ class OllamaStrategy:
                     prompt_eval_count = int(response.get("prompt_eval_count") or 0)
                 else:
                     eval_count = int(getattr(response, "eval_count", None) or 0)
-                    prompt_eval_count = int(
-                        getattr(response, "prompt_eval_count", None) or 0
-                    )
+                    prompt_eval_count = int(getattr(response, "prompt_eval_count", None) or 0)
                 record_usage(
                     model=self.model_name,
                     prompt_tokens=prompt_eval_count,

--- a/rex/memory.py
+++ b/rex/memory.py
@@ -32,7 +32,7 @@ import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
@@ -245,7 +245,7 @@ class MemoryEntry(BaseModel):
         data = self.model_dump()
         if self.sensitive:
             data["content"] = {"[SENSITIVE]": "Content hidden"}
-        return data
+        return cast(dict[str, Any], data)
 
     model_config = {
         "json_schema_extra": {

--- a/rex/notifications/models.py
+++ b/rex/notifications/models.py
@@ -120,8 +120,8 @@ def _from_row(row: tuple[object, ...]) -> Notification:
         title=str(row[1]),
         body=str(row[2]),
         source=str(row[3]),
-        priority=str(row[4]),  # type: ignore[arg-type]
-        channel=str(row[5]),  # type: ignore[arg-type]
+        priority=str(row[4]),
+        channel=str(row[5]),
         digest_eligible=bool(row[6]),
         quiet_hours_exempt=bool(row[7]),
         created_at=datetime.fromisoformat(str(row[8])),

--- a/rex/notifications/push.py
+++ b/rex/notifications/push.py
@@ -12,10 +12,10 @@ Usage::
 
 from __future__ import annotations
 
-import logging
-import urllib.request
-import urllib.error
 import json
+import logging
+import urllib.error
+import urllib.request
 from typing import TYPE_CHECKING
 
 from rex.assistant_errors import IntegrationNotConfiguredError
@@ -49,7 +49,7 @@ def send_push(
     message: str,
     priority: str = "normal",
     *,
-    config: "AppConfig | None" = None,
+    config: AppConfig | None = None,
 ) -> None:
     """Send a push notification via the configured provider.
 
@@ -85,9 +85,7 @@ def send_push(
         )
 
 
-def _send_ntfy(
-    title: str, message: str, priority: str, config: "AppConfig"
-) -> None:
+def _send_ntfy(title: str, message: str, priority: str, config: AppConfig) -> None:
     topic = (config.push_topic or "").strip()
     if not topic:
         raise IntegrationNotConfiguredError(
@@ -113,20 +111,14 @@ def _send_ntfy(
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
             status = resp.status
     except urllib.error.HTTPError as exc:
-        raise RuntimeError(
-            f"ntfy push notification failed: HTTP {exc.code} {exc.reason}"
-        ) from exc
+        raise RuntimeError(f"ntfy push notification failed: HTTP {exc.code} {exc.reason}") from exc
     except urllib.error.URLError as exc:
-        raise RuntimeError(
-            f"ntfy push notification failed: {exc.reason}"
-        ) from exc
+        raise RuntimeError(f"ntfy push notification failed: {exc.reason}") from exc
 
     logger.debug("ntfy push sent to topic '%s' (HTTP %s)", topic, status)
 
 
-def _send_pushover(
-    title: str, message: str, priority: str, config: "AppConfig"
-) -> None:
+def _send_pushover(title: str, message: str, priority: str, config: AppConfig) -> None:
     token = (config.push_token or "").strip()
     topic = (config.push_topic or "").strip()  # topic = user key for Pushover
     if not token or not topic:
@@ -158,8 +150,6 @@ def _send_pushover(
             f"Pushover push notification failed: HTTP {exc.code} {exc.reason}"
         ) from exc
     except urllib.error.URLError as exc:
-        raise RuntimeError(
-            f"Pushover push notification failed: {exc.reason}"
-        ) from exc
+        raise RuntimeError(f"Pushover push notification failed: {exc.reason}") from exc
 
     logger.debug("Pushover push sent (HTTP %s)", status)

--- a/rex/permissions.py
+++ b/rex/permissions.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 _DB_PATH = Path(os.getenv("REX_DATA_DIR", "data")) / "users.db"
 
 
-class Permission(str, Enum):
+class Permission(StrEnum):
     """Enumeration of all supported permissions."""
 
     computer_control = "computer_control"
@@ -74,7 +74,7 @@ def _init_schema(conn: sqlite3.Connection) -> None:
 # ---------------------------------------------------------------------------
 
 
-def grant_permission(user_id: str, permission: "Permission | str") -> None:
+def grant_permission(user_id: str, permission: Permission | str) -> None:
     """Grant *permission* to *user_id*.
 
     Silently succeeds if the permission is already granted.
@@ -96,7 +96,7 @@ def grant_permission(user_id: str, permission: "Permission | str") -> None:
     logger.info("Granted %s to user %s", perm.value, user_id)
 
 
-def revoke_permission(user_id: str, permission: "Permission | str") -> None:
+def revoke_permission(user_id: str, permission: Permission | str) -> None:
     """Revoke *permission* from *user_id*.
 
     Silently succeeds if the permission was not held.
@@ -118,7 +118,7 @@ def revoke_permission(user_id: str, permission: "Permission | str") -> None:
     logger.info("Revoked %s from user %s", perm.value, user_id)
 
 
-def check_permission(user_id: str, permission: "Permission | str") -> bool:
+def check_permission(user_id: str, permission: Permission | str) -> bool:
     """Return ``True`` if *user_id* holds *permission*, ``False`` otherwise.
 
     Args:

--- a/rex/profile_manager.py
+++ b/rex/profile_manager.py
@@ -88,9 +88,7 @@ def ensure_default_profile(profiles_dir: str = DEFAULT_PROFILES_DIR) -> bool:
         dest.write_text(example.read_text(encoding="utf-8"), encoding="utf-8")
         logger.info("Created profiles/default.json from default.example.json")
     else:
-        dest.write_text(
-            json.dumps(_MINIMAL_DEFAULT_PROFILE, indent=2), encoding="utf-8"
-        )
+        dest.write_text(json.dumps(_MINIMAL_DEFAULT_PROFILE, indent=2), encoding="utf-8")
         logger.info("Created profiles/default.json with minimal defaults")
 
     return True

--- a/rex/tts_utils.py
+++ b/rex/tts_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from importlib.util import find_spec
+from typing import cast
 
 _SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
 
@@ -171,14 +172,11 @@ def get_tts_engine(engine: str) -> type:
     """
     if engine == "xtts":
         if find_spec("TTS") is None:
-            raise ImportError(
-                "Coqui TTS is not installed. "
-                "Install it with: pip install TTS"
-            )
+            raise ImportError("Coqui TTS is not installed. " "Install it with: pip install TTS")
         apply_xtts_safe_globals()
-        from TTS.api import TTS  # type: ignore[import-untyped]
+        from TTS.api import TTS
 
-        return TTS  # type: ignore[return-value]
+        return cast(type, TTS)
     raise ValueError(f"Unknown TTS engine: {engine!r}")
 
 

--- a/rex/voice_loop.py
+++ b/rex/voice_loop.py
@@ -1139,21 +1139,22 @@ class VoiceLoop:
                         if llm_response and not llm_response.endswith("."):
                             llm_response = llm_response + "."
 
-                        try:
-                            await asyncio.wait_for(
-                                self._speak(llm_response), timeout=self._tts_timeout
-                            )
-                        except TimeoutError:
-                            logger.error(
-                                "TTS stage timed out after %.0fs — resetting pipeline",
-                                self._tts_timeout,
-                                extra={
-                                    "event": "pipeline_timeout",
-                                    "stage": "tts",
-                                    "llm_response": llm_response,
-                                },
-                            )
-                            continue
+                        if llm_response is not None:
+                            try:
+                                await asyncio.wait_for(
+                                    self._speak(llm_response), timeout=self._tts_timeout
+                                )
+                            except TimeoutError:
+                                logger.error(
+                                    "TTS stage timed out after %.0fs — resetting pipeline",
+                                    self._tts_timeout,
+                                    extra={
+                                        "event": "pipeline_timeout",
+                                        "stage": "tts",
+                                        "llm_response": llm_response,
+                                    },
+                                )
+                                continue
                     tracker.mark("tts_synthesis_end")
                     tracker.mark("playback_start")
                     tracker.log_summary()

--- a/rex/wakeword/embedding.py
+++ b/rex/wakeword/embedding.py
@@ -16,7 +16,9 @@ else:
 
 _torch: ModuleType | None = None
 try:  # pragma: no cover - optional dependency
-    import torch as _torch
+    import torch
+
+    _torch = torch
 except Exception:  # pragma: no cover - optional dependency
     pass
 

--- a/rex/woocommerce/config.py
+++ b/rex/woocommerce/config.py
@@ -30,7 +30,7 @@ Security notes
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -136,7 +136,7 @@ def load_woocommerce_config(raw_config: dict[str, Any]) -> WooCommerceConfig:
     sites = section.get("sites")
     if not sites or not isinstance(sites, list):
         return WooCommerceConfig()
-    return WooCommerceConfig.model_validate({"sites": sites})
+    return cast(WooCommerceConfig, WooCommerceConfig.model_validate({"sites": sites}))
 
 
 __all__ = [

--- a/rex/wordpress/config.py
+++ b/rex/wordpress/config.py
@@ -30,7 +30,7 @@ Security notes
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -153,7 +153,7 @@ def load_wordpress_config(raw_config: dict[str, Any]) -> WordPressConfig:
     sites = section.get("sites")
     if not sites or not isinstance(sites, list):
         return WordPressConfig()
-    return WordPressConfig.model_validate({"sites": sites})
+    return cast(WordPressConfig, WordPressConfig.model_validate({"sites": sites}))
 
 
 __all__ = [

--- a/rex/workflow.py
+++ b/rex/workflow.py
@@ -39,7 +39,7 @@ import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field
 
@@ -302,7 +302,7 @@ class WorkflowApproval(BaseModel):
 
         try:
             with open(file_path, encoding="utf-8") as f:
-                return cls.model_validate_json(f.read())
+                return cast(WorkflowApproval | None, cls.model_validate_json(f.read()))
         except Exception as e:
             logger.warning("Failed to load approval %s: %s", approval_id, e)
             return None
@@ -501,7 +501,7 @@ class Workflow(BaseModel):
 
         try:
             with open(file_path, encoding="utf-8") as f:
-                return cls.model_validate_json(f.read())
+                return cast(Workflow | None, cls.model_validate_json(f.read()))
         except Exception as e:
             logger.warning("Failed to load workflow %s: %s", workflow_id, e)
             return None
@@ -531,7 +531,7 @@ class Workflow(BaseModel):
             raise ValueError(f"Failed to read workflow file: {e}") from e
 
         try:
-            return cls.model_validate_json(content)
+            return cast(Workflow, cls.model_validate_json(content))
         except Exception as e:
             raise ValueError(f"Invalid workflow JSON: {e}") from e
 

--- a/rex/workflow_runner.py
+++ b/rex/workflow_runner.py
@@ -36,12 +36,15 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import logging
+import subprocess
+import sys
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from rex.audit import AuditLogger, LogEntry, get_audit_logger
 from rex.contracts import ToolCall
@@ -726,7 +729,7 @@ class WorkflowRunner:
                 task_id=self.workflow.workflow_id,
                 tool=step.tool_call.tool,
                 tool_call_args=step.tool_call.args,
-                policy_decision=decision,  # type: ignore
+                policy_decision=decision,
                 tool_result=result,
                 error=error,
                 requested_by=f"workflow:{self.workflow.workflow_id}",
@@ -876,31 +879,23 @@ __all__ = [
 # Reads simple name/schedule/action task definitions from config and runs
 # due tasks when the voice loop or daemon calls run_due_tasks().
 
-import json as _json
-import subprocess as _subprocess
-import sys as _sys
-from dataclasses import dataclass as _dataclass, field as _field
-from datetime import UTC as _UTC, datetime as _datetime
-from pathlib import Path as _Path
-from typing import Any as _Any
-
-_REPO_ROOT = _Path(__file__).parent.parent
+_REPO_ROOT = Path(__file__).parent.parent
 _DEFAULT_CONFIG_PATH = _REPO_ROOT / "config" / "rex_config.json"
 _DEFAULT_STATE_PATH = _REPO_ROOT / "data" / "workflow_runner_state.json"
 
 # Built-in example tasks shown when no tasks are configured. All disabled
 # by default — users opt-in by adding them to rex_config.json.
-_EXAMPLE_TASKS: list[dict[str, _Any]] = [
+_EXAMPLE_TASKS: list[dict[str, Any]] = [
     {
         "name": "daily_weather",
         "schedule": "interval:86400",
-        "action": "chat --no-tts --prompt \"What is the weather today?\"",
+        "action": 'chat --no-tts --prompt "What is the weather today?"',
         "enabled": False,
     }
 ]
 
 
-@_dataclass
+@dataclass
 class ScheduledTask:
     """A scheduled workflow task read from config.
 
@@ -926,7 +921,7 @@ class ScheduledTask:
                 return None
         return None
 
-    def is_due(self, last_run: _datetime | None) -> bool:
+    def is_due(self, last_run: datetime | None) -> bool:
         """Return True if enough time has elapsed since *last_run*."""
         interval = self.interval_seconds()
         if interval is None:
@@ -936,10 +931,10 @@ class ScheduledTask:
             return False
         if last_run is None:
             return True
-        return (_datetime.now(_UTC) - last_run).total_seconds() >= interval
+        return (datetime.now(UTC) - last_run).total_seconds() >= interval
 
 
-@_dataclass
+@dataclass
 class ScheduledTaskRunner:
     """Reads task definitions from config and executes due tasks.
 
@@ -963,8 +958,8 @@ class ScheduledTaskRunner:
     State (last-run timestamps) is persisted to ``data/workflow_runner_state.json``.
     """
 
-    config_path: _Path = _field(default_factory=lambda: _DEFAULT_CONFIG_PATH)
-    state_path: _Path = _field(default_factory=lambda: _DEFAULT_STATE_PATH)
+    config_path: Path = field(default_factory=lambda: _DEFAULT_CONFIG_PATH)
+    state_path: Path = field(default_factory=lambda: _DEFAULT_STATE_PATH)
 
     def __post_init__(self) -> None:
         self._tasks: list[ScheduledTask] = self._load_tasks()
@@ -975,12 +970,12 @@ class ScheduledTaskRunner:
     # ------------------------------------------------------------------
 
     def _load_tasks(self) -> list[ScheduledTask]:
-        raw: list[dict[str, _Any]] = []
+        raw: list[dict[str, Any]] = []
         if self.config_path.exists():
             try:
-                data = _json.loads(self.config_path.read_text(encoding="utf-8"))
+                data = json.loads(self.config_path.read_text(encoding="utf-8"))
                 raw = data.get("workflows", {}).get("tasks", [])
-            except (_json.JSONDecodeError, OSError) as exc:
+            except (json.JSONDecodeError, OSError) as exc:
                 logger.warning("ScheduledTaskRunner: failed to read config: %s", exc)
 
         if not raw:
@@ -1007,23 +1002,23 @@ class ScheduledTaskRunner:
     def _load_state(self) -> dict[str, str]:
         if self.state_path.exists():
             try:
-                return _json.loads(self.state_path.read_text(encoding="utf-8"))
-            except (_json.JSONDecodeError, OSError) as exc:
+                return cast(dict[str, str], json.loads(self.state_path.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError) as exc:
                 logger.warning("ScheduledTaskRunner: failed to read state: %s", exc)
         return {}
 
     def _save_state(self) -> None:
         self.state_path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            self.state_path.write_text(_json.dumps(self._state, indent=2), encoding="utf-8")
+            self.state_path.write_text(json.dumps(self._state, indent=2), encoding="utf-8")
         except OSError as exc:
             logger.error("ScheduledTaskRunner: failed to save state: %s", exc)
 
-    def _last_run(self, name: str) -> _datetime | None:
+    def _last_run(self, name: str) -> datetime | None:
         ts = self._state.get(name)
         if ts:
             try:
-                return _datetime.fromisoformat(ts)
+                return datetime.fromisoformat(ts)
             except ValueError:
                 pass
         return None
@@ -1034,12 +1029,10 @@ class ScheduledTaskRunner:
 
     def _run_task(self, task: ScheduledTask) -> bool:
         """Execute *task*, returning True on success.  Never raises."""
-        logger.info(
-            "ScheduledTaskRunner: executing '%s' (action: %s)", task.name, task.action
-        )
+        logger.info("ScheduledTaskRunner: executing '%s' (action: %s)", task.name, task.action)
         try:
-            cmd = [_sys.executable, "-m", "rex"] + task.action.split()
-            result = _subprocess.run(
+            cmd = [sys.executable, "-m", "rex"] + task.action.split()
+            result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
@@ -1056,7 +1049,7 @@ class ScheduledTaskRunner:
                 return False
             logger.info("ScheduledTaskRunner: task '%s' succeeded", task.name)
             return True
-        except _subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired:
             logger.error("ScheduledTaskRunner: task '%s' timed out after 120s", task.name)
             return False
         except Exception as exc:
@@ -1079,7 +1072,7 @@ class ScheduledTaskRunner:
                 continue
             triggered.append(task.name)
             # Persist last-run before executing so crashes don't cause retries.
-            self._state[task.name] = _datetime.now(_UTC).isoformat()
+            self._state[task.name] = datetime.now(UTC).isoformat()
             self._save_state()
             try:
                 self._run_task(task)

--- a/scripts/export_contract_schemas.py
+++ b/scripts/export_contract_schemas.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 # Ensure the project root is in the path
@@ -94,7 +94,7 @@ def export_schemas(output_dir: Path | None = None) -> dict[str, str]:
     # Generate index file
     index = {
         "contract_version": CONTRACT_VERSION,
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": datetime.now(UTC).isoformat(),
         "schemas": schema_entries,
     }
 

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -26,7 +26,6 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 # Paths excluded from self-scan: this script and its dedicated test file, both of
 # which contain the marker patterns intentionally (pattern definitions / test fixtures).
@@ -177,7 +176,7 @@ def scan_file(
     filepath: Path,
     *,
     strict_markdown_secrets: bool = False,
-    allowlisted_paths: Optional[set[Path]] = None,
+    allowlisted_paths: set[Path] | None = None,
 ) -> tuple[list[str], list[str], list[str]]:
     """Scan a file and return lists of issues found.
 
@@ -325,7 +324,7 @@ def get_tracked_files(repo_root: Path) -> tuple[list[Path], int]:
     return files, excluded
 
 
-def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description="Security audit for Rex AI Assistant repository.")
     parser.add_argument(
@@ -351,7 +350,7 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     """Run security audit."""
     _configure_text_io()
     args = _parse_args(argv)


### PR DESCRIPTION
Fixes StrEnum migration, unused type-ignores, no-any-return casts, dict-indexing narrowing in gui_app, and E402 import ordering in workflow_runner.

## Summary
- 

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] chore

## Changes
- 

## Verification
- [ ] `python -m compileall -q .`
- [ ] `python scripts/security_audit.py`
- [ ] `pytest -q`

## CLAUDE.md
- [ ] Not needed
- [ ] Updated in this PR

If updated, why:
- 

## Notes

<!-- Keep PR title Conventional: e.g., "rex: add runtime compat shim" -->
