### PR TITLE
feat(gui): add empty-state helper text to integrations settings

### DIFF
--- a/gui/src/pages/SettingsPage.tsx
+++ b/gui/src/pages/SettingsPage.tsx
@@ -3166,6 +3166,10 @@ function IntegrationsPanel(): React.ReactElement {
           </div>
         </div>
 
+        <p className="text-xs text-text-secondary mb-4">
+          Optional. Lets Rex read and send mail. Create OAuth credentials in the Google Console linked above.
+        </p>
+
         <div className="mb-4">
           <div className="flex items-center justify-between mb-1.5">
             <label htmlFor="emailProvider" className="text-sm font-medium text-text-primary">Provider</label>
@@ -3408,6 +3412,10 @@ function IntegrationsPanel(): React.ReactElement {
           </div>
         </div>
 
+        <p className="text-xs text-text-secondary mb-4">
+          Optional. Lets Rex read and create events on your calendar. Use the Google Console link above for OAuth credentials.
+        </p>
+
         <div className="mb-4">
           <div className="flex items-center justify-between mb-1.5">
             <label htmlFor="calendarProvider" className="text-sm font-medium text-text-primary">Provider</label>
@@ -3498,6 +3506,10 @@ function IntegrationsPanel(): React.ReactElement {
           </div>
         </div>
 
+        <p className="text-xs text-text-secondary mb-4">
+          Optional. Lets Rex send text messages through Twilio. Grab the SID, token, and a sender number from the Twilio Console link above.
+        </p>
+
         <div className="mb-4">
           <div className="flex items-center justify-between mb-1.5">
             <div className="flex items-center gap-1.5">
@@ -3582,6 +3594,10 @@ function IntegrationsPanel(): React.ReactElement {
           </div>
         </div>
 
+        <p className="text-xs text-text-secondary mb-4">
+          Optional. Lets Rex control your smart home. Create a long-lived access token from your Home Assistant user profile page.
+        </p>
+
         <div className="mb-4">
           <div className="flex items-center justify-between mb-1.5">
             <label htmlFor="haUrl" className="text-sm font-medium text-text-primary">Base URL</label>
@@ -3647,6 +3663,10 @@ function IntegrationsPanel(): React.ReactElement {
             />
           </div>
         </div>
+
+        <p className="text-xs text-text-secondary mb-4">
+          Optional. Lets Rex place voice calls through Twilio. Use the same Twilio Console link above to copy your credentials.
+        </p>
 
         <div className="mb-4">
           <div className="flex items-center justify-between mb-1.5">
@@ -3782,6 +3802,10 @@ function IntegrationsPanel(): React.ReactElement {
             hasCredentials={form.telegramBotToken.trim() !== '' && form.telegramChatId.trim() !== ''}
           />
         </div>
+
+        <p className="text-xs text-text-secondary mb-4">
+          Optional. Lets Rex send messages to a Telegram chat. Create a bot through @BotFather to get a token, then message it to find your chat ID.
+        </p>
 
         <div className="mb-4">
           <div className="flex items-center justify-between mb-1.5">


### PR DESCRIPTION
## Summary
Adds short helper text under each sub-section header in the Integrations settings panel. New users opening Settings → Integrations had no in-app indication of what each integration controlled, whether it was required, or where the credentials came from — this fills that gap with a one-line description per integration.

## Changes
- `gui/src/pages/SettingsPage.tsx`: insert a `<p className="text-xs text-text-secondary mb-4">` helper line directly under the Email, Calendar, SMS, Home Assistant, Phone, and Telegram sub-section headers in `IntegrationsPanel`.
- Copy for each line: marks the integration as optional, states what it enables in one sentence, and points to the existing console/profile link already rendered next to the header (Google Console for Email/Calendar, Twilio Console for SMS/Phone, Home Assistant profile page for HA, @BotFather for Telegram).

## Testing
- `cd gui && npm test --silent` — passes locally.
- Manual check: opened Settings → Integrations with no values configured and confirmed each sub-section now shows the helper line under its header without disturbing the existing `max-w-lg` column layout.

## Notes
- Scope limited to the Integrations panel, since the issue only required at least one settings page and the other panels (Voice/AI/Notifications) already have inline labels next to their controls. Extending the same treatment to those panels would be a reasonable follow-up.
- Pure copy/markup change — no new components, state, props, or types.

Closes #243