### PR TITLE
docs: add first-time contributor checklist to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,64 @@ If you are new to the project, start with issues labeled:
 
 You can also open a GitHub Discussion if you are not sure where to begin.
 
+## First-time contributor checklist
+
+New to the project? Follow these steps from fork to pull request. Each step links to the section below with more detail.
+
+1. **Fork the repository.** On GitHub, click **Fork** at the top right of the [AskRex Assistant repo](https://github.com/Blueibear/AskRex-Assistant) to create a copy under your account, then clone your fork locally:
+
+   ```bash
+   git clone https://github.com/<your-username>/AskRex-Assistant.git
+   cd AskRex-Assistant
+   ```
+
+2. **Create a branch from `master`.** Use a short, descriptive name. See [Branch strategy](#branch-strategy) and [Commit message format](#commit-message-format) for naming and commit conventions.
+
+   ```bash
+   git checkout master
+   git pull
+   git checkout -b docs/short-description
+   ```
+
+3. **Install dependencies.** AskRex targets Python 3.11. Create a virtual environment and install the project, plus the dev tools used by tests and linters. See the [Quick Start in the README](README.md#quick-start) for full setup options (CPU/GPU stacks, GUI, voice).
+
+   ```bash
+   python3.11 -m venv .venv
+   source .venv/bin/activate   # Windows PowerShell: .\.venv\Scripts\Activate.ps1
+   python -m pip install --upgrade pip setuptools wheel
+   pip install .
+   pip install -r requirements-dev.txt
+   ```
+
+4. **Run basic checks.** Make sure the test suite, linters, and the built-in health check pass before opening a PR:
+
+   ```bash
+   pytest -q
+   ruff check .
+   black --check .
+   python -m rex doctor
+   ```
+
+5. **Commit your changes.** Use [Conventional Commits](#commit-message-format) (for example `docs: clarify install steps`). Push the branch to your fork:
+
+   ```bash
+   git push -u origin docs/short-description
+   ```
+
+6. **Open a pull request against `master`.** From your fork on GitHub, click **Compare & pull request**. Target the `master` branch of `Blueibear/AskRex-Assistant`. The PR template will guide you; see also the [Pull request checklist](#pull-request-checklist) below.
+
+### What to include in the PR description
+
+The PR template covers most of this, but at a minimum your description should have:
+
+- **Summary** — one or two sentences explaining what the change does.
+- **Type** — feat, fix, docs, refactor, perf, or chore.
+- **Verification** — which checks you ran (for example `pytest -q`, `ruff check`, `black --check`).
+- **How you tested it** — manual steps, sample commands, or screenshots if the change is user-facing.
+- **Related issue** — link to the issue this PR closes, if any (for example `Closes #123`).
+
+If you get stuck on any step, open a GitHub Discussion — questions are welcome.
+
 ## Ways to contribute
 
 Useful contributions include:


### PR DESCRIPTION
## Summary
Adds a first-time contributor checklist to `CONTRIBUTING.md` so new contributors have a single scannable path from fork to pull request. Previously the steps (fork, branch, install, run checks, commit, open PR) were spread across `CONTRIBUTING.md`, the README quick start, and `CLAUDE.md`, which is a rough first experience for someone landing on the repo cold.

## Changes
- `CONTRIBUTING.md`: insert a new **First-time contributor checklist** section after the "Good places to start" intro, with six numbered steps (fork, branch from `master`, install on Python 3.11, run `pytest -q` / `ruff` / `black` / `rex doctor`, commit using Conventional Commits, open a PR against `master`).
- `CONTRIBUTING.md`: add a **What to include in the PR description** subsection listing summary, type, verification, how-tested, and related issue, cross-linking to the existing `Branch strategy`, `Commit message format`, and `Pull request checklist` sections rather than duplicating them.

## Testing
Docs-only change; no test command run. Verified by reading the rendered Markdown and confirming the anchor links (`#branch-strategy`, `#commit-message-format`, `#pull-request-checklist`) point at sections that already exist in `CONTRIBUTING.md`, and that the install/check commands match those in `CLAUDE.md` (Python 3.11 venv, `pip install .`, `pip install -r requirements-dev.txt`, `pytest -q`, `python -m rex doctor`).

## Notes
- Branch target is `master`, consistent with the branch strategy already documented in `CONTRIBUTING.md` and `CLAUDE.md`.
- The checklist intentionally points at existing sections instead of restating naming rules or the full PR checklist, to avoid drift between the two.

Closes #242