### PR TITLE
fix(ci): resolve CodeFactor quality findings

### DIFF
--- a/flask_proxy.py
+++ b/flask_proxy.py
@@ -178,58 +178,76 @@ _DASHBOARD_PREFIXES = (
 _WEBHOOK_PREFIXES = ("/webhooks/",)
 
 
+def _is_memory_exempt_path(path: str) -> bool:
+    return (
+        path in _PUBLIC_PATHS
+        or any(path.startswith(prefix) for prefix in _DASHBOARD_PREFIXES)
+        or any(path.startswith(prefix) for prefix in _WEBHOOK_PREFIXES)
+    )
+
+
+def _resolve_cf_user_key(email: str) -> str:
+    resolved_user_key = resolve_user_key(email, USERS_MAP)
+    if not resolved_user_key:
+        abort(403, "Access denied for this user.")
+    return resolved_user_key
+
+
+def _resolve_token_user_key(token: str) -> str:
+    if not PROXY_TOKEN or token != PROXY_TOKEN:
+        abort(403, "Invalid or missing proxy token.")
+    resolved_user_key = resolve_user_key(os.getenv("REX_ACTIVE_USER"), USERS_MAP)
+    if not resolved_user_key:
+        abort(403, "REX_ACTIVE_USER is not configured or invalid.")
+    return resolved_user_key
+
+
+def _resolve_local_user_key() -> str:
+    active_user = os.getenv("REX_ACTIVE_USER")
+    resolved_user_key = resolve_user_key(active_user, USERS_MAP)
+    if not resolved_user_key and _TESTING_MODE and active_user:
+        resolved_user_key = active_user.strip().lower()
+    if not resolved_user_key:
+        abort(403, "Local access not permitted: REX_ACTIVE_USER missing.")
+    return resolved_user_key
+
+
+def _resolve_request_user_key() -> str:
+    email = request.headers.get("Cf-Access-Authenticated-User-Email")
+    token = _extract_shared_secret()
+
+    if email:
+        return _resolve_cf_user_key(email)
+    if token:
+        return _resolve_token_user_key(token)
+    if ALLOW_LOCAL and _is_loopback_address(request.remote_addr):
+        return _resolve_local_user_key()
+
+    abort(403, "No authenticated identity provided.")
+
+
+def _load_request_memory_profile(user_key: str) -> dict[str, Any]:
+    try:
+        return load_memory_profile(user_key)
+    except FileNotFoundError:
+        if _TESTING_MODE:
+            return _testing_memory_profile(user_key)
+        abort(500, f"Memory file not found for user '{user_key}'.")
+    except json.JSONDecodeError:
+        abort(500, f"Memory file for user '{user_key}' is invalid JSON.")
+
+
 @app.before_request
 def load_user_memory() -> None:
-    if request.path in _PUBLIC_PATHS:
-        return
-
-    if any(request.path.startswith(prefix) for prefix in _DASHBOARD_PREFIXES):
-        return
-
-    if any(request.path.startswith(prefix) for prefix in _WEBHOOK_PREFIXES):
+    if _is_memory_exempt_path(request.path):
         return
 
     if _TESTING_MODE:
         g.__dict__.clear()
 
-    email = request.headers.get("Cf-Access-Authenticated-User-Email")
-    token = _extract_shared_secret()
-    remote_addr = request.remote_addr
-
-    resolved_user_key = None
-
-    if email:
-        resolved_user_key = resolve_user_key(email, USERS_MAP)
-        if not resolved_user_key:
-            abort(403, "Access denied for this user.")
-    elif token:
-        if not PROXY_TOKEN or token != PROXY_TOKEN:
-            abort(403, "Invalid or missing proxy token.")
-        resolved_user_key = resolve_user_key(os.getenv("REX_ACTIVE_USER"), USERS_MAP)
-        if not resolved_user_key:
-            abort(403, "REX_ACTIVE_USER is not configured or invalid.")
-    elif ALLOW_LOCAL and _is_loopback_address(remote_addr):
-        active_user = os.getenv("REX_ACTIVE_USER")
-        resolved_user_key = resolve_user_key(active_user, USERS_MAP)
-        if not resolved_user_key and _TESTING_MODE and active_user:
-            resolved_user_key = active_user.strip().lower()
-        if not resolved_user_key:
-            abort(403, "Local access not permitted: REX_ACTIVE_USER missing.")
-    else:
-        abort(403, "No authenticated identity provided.")
-
-    g.user_key = resolved_user_key
+    g.user_key = _resolve_request_user_key()
     g.user_folder = os.path.join("Memory", g.user_key)
-
-    try:
-        g.memory = load_memory_profile(g.user_key)
-    except FileNotFoundError:
-        if _TESTING_MODE:
-            g.memory = _testing_memory_profile(g.user_key)
-            return
-        abort(500, f"Memory file not found for user '{g.user_key}'.")
-    except json.JSONDecodeError:
-        abort(500, f"Memory file for user '{g.user_key}' is invalid JSON.")
+    g.memory = _load_request_memory_profile(g.user_key)
 
 
 @app.route("/")
@@ -282,4 +300,4 @@ def contracts():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+    app.run(host=os.getenv("REX_FLASK_PROXY_HOST", "127.0.0.1"), port=5000)

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -795,6 +795,8 @@ const defaultSettingsMap: Record<string, Settings> = {
 
 type TestableIntegration = 'email' | 'calendar' | 'sms' | 'homeassistant' | 'phone'
 
+type IntegrationTestResult = { ok: boolean; error?: string }
+
 interface StoredIntegrationStatus {
   status: IntegrationConnectionStatus
   testedAt?: string
@@ -1009,6 +1011,85 @@ function hasConfiguredEmail(integrations: Record<string, unknown>): boolean {
     }
     return hasText(account.clientId) && hasText(account.clientSecret) // pragma: allowlist secret
   })
+}
+
+function hasDirectEmailCredentials(integrations: Record<string, unknown>): boolean {
+  return hasText(integrations.emailClientId) && hasText(integrations.emailClientSecret) // pragma: allowlist secret
+}
+
+function hasDirectCalendarCredentials(integrations: Record<string, unknown>): boolean {
+  return hasText(integrations.calendarClientId) && hasText(integrations.calendarClientSecret) // pragma: allowlist secret
+}
+
+function hasGuiSmsCredentials(integrations: Record<string, unknown>): boolean {
+  return (
+    hasText(integrations.smsSid) &&
+    hasText(integrations.smsAuthToken) &&
+    hasText(integrations.smsFromNumber)
+  )
+}
+
+function hasEnvSmsCredentials(env: Record<string, string>): boolean {
+  return hasText(env.TWILIO_ACCOUNT_SID) && hasText(env.TWILIO_AUTH_TOKEN)
+}
+
+function hasGuiPhoneCredentials(integrations: Record<string, unknown>): boolean {
+  return (
+    hasText(integrations.phoneSid) &&
+    hasText(integrations.phoneAuthToken) &&
+    hasText(integrations.phoneNumber)
+  )
+}
+
+function hasEnvPhoneCredentials(env: Record<string, string>): boolean {
+  return (
+    hasText(env.TWILIO_ACCOUNT_SID) &&
+    hasText(env.TWILIO_AUTH_TOKEN) &&
+    hasText(env.TWILIO_PHONE_NUMBER)
+  )
+}
+
+function integrationConfiguredResult(configured: boolean): IntegrationTestResult {
+  return configured ? { ok: true } : { ok: false, error: 'No credentials configured' }
+}
+
+function testEmailIntegration(integrations: Record<string, unknown>): IntegrationTestResult {
+  if (hasConfiguredOutlookEmail(integrations)) {
+    return { ok: false, error: OUTLOOK_EMAIL_UNSUPPORTED }
+  }
+  return integrationConfiguredResult(hasDirectEmailCredentials(integrations) || hasConfiguredEmail(integrations))
+}
+
+function testCalendarIntegration(integrations: Record<string, unknown>): IntegrationTestResult {
+  if (hasConfiguredOutlookCalendar(integrations)) {
+    return { ok: false, error: OUTLOOK_CALENDAR_UNSUPPORTED }
+  }
+  return integrationConfiguredResult(hasDirectCalendarCredentials(integrations))
+}
+
+function testSmsIntegration(integrations: Record<string, unknown>): IntegrationTestResult {
+  const env = readEnvFile()
+  return integrationConfiguredResult(hasGuiSmsCredentials(integrations) || hasEnvSmsCredentials(env))
+}
+
+function testPhoneIntegration(integrations: Record<string, unknown>): IntegrationTestResult {
+  const env = readEnvFile()
+  return integrationConfiguredResult(hasGuiPhoneCredentials(integrations) || hasEnvPhoneCredentials(env))
+}
+
+async function testIntegrationByType(
+  type: string,
+  integrations: Record<string, unknown>
+): Promise<{ type?: TestableIntegration; result: IntegrationTestResult }> {
+  if (type === 'email') return { type, result: testEmailIntegration(integrations) }
+  if (type === 'calendar') return { type, result: testCalendarIntegration(integrations) }
+  if (type === 'sms') return { type, result: testSmsIntegration(integrations) }
+  if (type === 'phone') return { type, result: testPhoneIntegration(integrations) }
+  if (type === 'homeassistant') {
+    const { baseUrl, token } = readSavedHomeAssistantCredentials()
+    return { type, result: await testHomeAssistantConnection(baseUrl, token) }
+  }
+  return { result: { ok: false, error: 'Unknown integration type' } }
 }
 
 function buildIntegrationInventory(): IntegrationInventoryItem[] {
@@ -1264,74 +1345,13 @@ function registerIpcHandlers(mainWindow: BrowserWindow | null = null): void {
     // Check whether credentials for the requested integration are configured
     const stored = readGuiSettings()
     const integrations = (stored['integrations'] ?? {}) as Record<string, unknown>
-    let result: { ok: boolean; error?: string }
+    const testResult = await testIntegrationByType(type, integrations)
 
-    if (type === 'email') {
-      if (hasConfiguredOutlookEmail(integrations)) {
-        result = { ok: false, error: OUTLOOK_EMAIL_UNSUPPORTED }
-        writeIntegrationStatus('email', result)
-        return result
-      }
-      const hasCredentials =
-        typeof integrations.emailClientId === 'string' && integrations.emailClientId.trim() !== '' &&
-        typeof integrations.emailClientSecret === 'string' && integrations.emailClientSecret.trim() !== '' // pragma: allowlist secret
-      result = hasCredentials || hasConfiguredEmail(integrations)
-        ? { ok: true }
-        : { ok: false, error: 'No credentials configured' }
-      writeIntegrationStatus('email', result)
-      return result
+    if (testResult.type) {
+      writeIntegrationStatus(testResult.type, testResult.result)
     }
 
-    if (type === 'calendar') {
-      if (hasConfiguredOutlookCalendar(integrations)) {
-        result = { ok: false, error: OUTLOOK_CALENDAR_UNSUPPORTED }
-        writeIntegrationStatus('calendar', result)
-        return result
-      }
-      const hasCredentials =
-        typeof integrations.calendarClientId === 'string' && integrations.calendarClientId.trim() !== '' &&
-        typeof integrations.calendarClientSecret === 'string' && integrations.calendarClientSecret.trim() !== '' // pragma: allowlist secret
-      result = hasCredentials ? { ok: true } : { ok: false, error: 'No credentials configured' }
-      writeIntegrationStatus('calendar', result)
-      return result
-    }
-
-    if (type === 'sms') {
-      const env = readEnvFile()
-      const hasCredentials =
-        (
-          typeof integrations.smsSid === 'string' && integrations.smsSid.trim() !== '' &&
-          typeof integrations.smsAuthToken === 'string' && integrations.smsAuthToken.trim() !== '' &&
-          typeof integrations.smsFromNumber === 'string' && integrations.smsFromNumber.trim() !== ''
-        ) ||
-        (hasText(env.TWILIO_ACCOUNT_SID) && hasText(env.TWILIO_AUTH_TOKEN))
-      result = hasCredentials ? { ok: true } : { ok: false, error: 'No credentials configured' }
-      writeIntegrationStatus('sms', result)
-      return result
-    }
-
-    if (type === 'homeassistant') {
-      const { baseUrl, token } = readSavedHomeAssistantCredentials()
-      result = await testHomeAssistantConnection(baseUrl, token)
-      writeIntegrationStatus('homeassistant', result)
-      return result
-    }
-
-    if (type === 'phone') {
-      const env = readEnvFile()
-      const hasCredentials =
-        (
-          typeof integrations.phoneSid === 'string' && integrations.phoneSid.trim() !== '' &&
-          typeof integrations.phoneAuthToken === 'string' && integrations.phoneAuthToken.trim() !== '' &&
-          typeof integrations.phoneNumber === 'string' && integrations.phoneNumber.trim() !== ''
-        ) ||
-        (hasText(env.TWILIO_ACCOUNT_SID) && hasText(env.TWILIO_AUTH_TOKEN) && hasText(env.TWILIO_PHONE_NUMBER))
-      result = hasCredentials ? { ok: true } : { ok: false, error: 'No credentials configured' }
-      writeIntegrationStatus('phone', result)
-      return result
-    }
-
-    return { ok: false, error: 'Unknown integration type' }
+    return testResult.result
   })
 
   ipcMain.handle('rex:pickFolder', async (): Promise<{ ok: boolean; path?: string; error?: string }> => {


### PR DESCRIPTION
### Motivation
- Address CodeFactor quality findings by reducing method complexity and removing an unsafe default Flask bind while preserving behavior and IPC responses. 

### Description
- Refactored the Flask request memory loading path in `flask_proxy.py` into focused helpers (`_is_memory_exempt_path`, `_resolve_cf_user_key`, `_resolve_token_user_key`, `_resolve_local_user_key`, `_resolve_request_user_key`, `_load_request_memory_profile`) and reimplemented the `@app.before_request` hook to call them, preserving the original authentication, compatibility and error responses. 
- Made the Flask proxy bind default safe by changing `app.run(host="0.0.0.0", port=5000)` to `app.run(host=os.getenv("REX_FLASK_PROXY_HOST", "127.0.0.1"), port=5000)` so local loopback is the default while allowing explicit override via `REX_FLASK_PROXY_HOST`. 
- Split the large IPC integration test handler in `gui/src/main/index.ts` into small helpers (`hasDirectEmailCredentials`, `hasDirectCalendarCredentials`, `hasGuiSmsCredentials`, `hasEnvSmsCredentials`, `hasGuiPhoneCredentials`, `hasEnvPhoneCredentials`, `integrationConfiguredResult`, `testEmailIntegration`, `testCalendarIntegration`, `testSmsIntegration`, `testPhoneIntegration`, `testIntegrationByType`) and simplified the `rex:testIntegration` handler to delegate to `testIntegrationByType`, preserving returned payloads and `writeIntegrationStatus` side-effects. 
- Files changed: `flask_proxy.py`, `gui/src/main/index.ts`.
- Exact CodeFactor findings fixed: `gui/src/main/index.ts:1263-1335` (Complex Method), `flask_proxy.py:285` (Possible binding to all interfaces), and `flask_proxy.py:181-232` (Complex Method: `load_user_memory`).

### Testing
- Ran the focused test subset with `PYENV_VERSION=3.11.15 python -m pytest -q tests/test_flask_proxy.py tests/test_us115_migration_state_validation.py tests/test_outlook_integration_honesty.py tests/test_us312_surface_settings.py tests/test_us328_gui_launch_verification.py` and all tests passed (`62 passed`).
- Ran the full test suite with `PYENV_VERSION=3.11.15 python -m pytest -q` and the suite passed (`7135 passed, 102 skipped`).
- Ran coverage with `PYENV_VERSION=3.11.15 python -m pytest --cov=rex --cov-report=term-missing -q` and coverage completed (required threshold met) and produced `coverage.txt`.
- Static checks `PYENV_VERSION=3.11.15 python -m mypy rex --ignore-missing-imports`, `PYENV_VERSION=3.11.15 python -m ruff check .`, and `PYENV_VERSION=3.11.15 python -m black --check --diff rex/ tests/ bridge/ *.py` all succeeded.
- GUI checks `cd gui && npm run typecheck && npm run build` completed successfully (TypeScript typecheck and Electron build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2531383788832a814af13d341f8194)