### PR TITLE
test(pytest): register asyncio marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ addopts = [
     "--tb=short",
 ]
 markers = [
+    "asyncio_mode_not_required: mark tests that must run without pytest-asyncio strict-mode requirements",
     "unit: Unit tests that don't require external dependencies",
     "integration: Integration tests that may require external services",
     "slow: Tests that take significant time to run",


### PR DESCRIPTION
Registers the asyncio_mode_not_required pytest marker used by tests/test_us010_voice_pipeline_timeouts.py so pytest collection succeeds under strict marker checking.

Validation:
- py -3.11 -m pytest -q tests/test_us010_voice_pipeline_timeouts.py --collect-only
- git diff --check