### PR TITLE
feat(ci): add raw renderer /api/ fetch guard (US-003)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,23 @@ jobs:
       - name: 🔍 Run pre-commit on all files
         run: pre-commit run --all-files
 
+  gui-no-raw-api:
+    name: GUI Raw API Fetch Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 🧾 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: 🔍 Check for unapproved raw /api/ fetches in gui/src/
+        run: python scripts/check_no_renderer_api_fetch.py
+
   secret-scan:
     name: Hardcoded Secret Scan
     runs-on: ubuntu-latest

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -288,13 +288,13 @@ grep -rn "pytest.mark.skip\|pytest.skip\b" tests | wc -l
 **Implementation notes:** Write a script that greps `gui/src/**/*.{ts,tsx,js,jsx}` for raw `fetch('/api`, `fetch("/api`, and `fetch(\`/api` patterns. The script exits non-zero if any match is not listed in `gui/src/ALLOWED_API_FETCHES.txt` with `file:line` and a justification comment. The allowlist starts empty.
 
 **Acceptance Criteria:**
-- [ ] Script exists and exits 0 on a checkout that has zero raw `/api/` fetches (post-migration), and exits non-zero when a synthetic raw `/api/` fetch is introduced (covered by a unit test).
-- [ ] Allowlist file format is documented at the top of the file.
-- [ ] CI job `gui-no-raw-api` runs the script on every PR.
-- [ ] Story does NOT fix existing renderer call sites — those are owned by US-004 through US-010.
-- [ ] The script's allowlist permits all current renderer `/api/` call sites as a temporary baseline; each later migration story removes its line from the allowlist when complete.
-- [ ] `README.md` and `docs/UI_SURFACES.md` reference the guard and the allowlist policy.
-- [ ] `pytest tests/test_check_no_renderer_api_fetch.py -q` passes.
+- [x] Script exists and exits 0 on a checkout that has zero raw `/api/` fetches (post-migration), and exits non-zero when a synthetic raw `/api/` fetch is introduced (covered by a unit test).
+- [x] Allowlist file format is documented at the top of the file.
+- [x] CI job `gui-no-raw-api` runs the script on every PR.
+- [x] Story does NOT fix existing renderer call sites — those are owned by US-004 through US-010.
+- [x] The script's allowlist permits all current renderer `/api/` call sites as a temporary baseline; each later migration story removes its line from the allowlist when complete.
+- [x] `README.md` and `docs/UI_SURFACES.md` reference the guard and the allowlist policy.
+- [x] `pytest tests/test_check_no_renderer_api_fetch.py -q` passes.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/README.md
+++ b/README.md
@@ -419,6 +419,11 @@ npm run build
 
 The current coverage threshold in `pyproject.toml` is 75 percent. Test markers include `unit`, `integration`, `slow`, `audio`, `gpu`, `network`, `asyncio`, `anyio`, and `smoke`. The skipped-test inventory is maintained in [docs/testing/SKIPPED-TESTS-INVENTORY.md](docs/testing/SKIPPED-TESTS-INVENTORY.md).
 
+Renderer IPC policy — raw `fetch('/api/...')` calls in `gui/src/` are blocked by CI:
+
+- `scripts/check_no_renderer_api_fetch.py` — guard script (run via `python scripts/check_no_renderer_api_fetch.py`)
+- `gui/src/ALLOWED_API_FETCHES.txt` — temporary allowlist of unmigrated call sites; see [docs/UI_SURFACES.md](docs/UI_SURFACES.md) for the full policy
+
 ## Documentation
 
 Start with [docs/INDEX.md](docs/INDEX.md). High-value active docs:

--- a/docs/UI_SURFACES.md
+++ b/docs/UI_SURFACES.md
@@ -51,6 +51,14 @@ For Electron-only verification, run `npm.cmd run build` first, then use harnesse
 
 `rex-gui` starts `rex/gui_app.py`. It remains useful for local Flask API routes, smoke tests, and compatibility work. The browser UI at `/ui/` is incomplete in current testing and is not the primary user-facing GUI.
 
+## Renderer IPC Policy
+
+The Electron renderer communicates with the main process through typed IPC, not via raw `fetch('/api/...')` calls. Raw `/api/` fetches do not work in the packaged app (file:// protocol) and are guarded by CI.
+
+**Guard:** `scripts/check_no_renderer_api_fetch.py` scans `gui/src/**/*.{ts,tsx,js,jsx}` for `fetch('/api`, `fetch("/api`, and fetch(`` `/api `` patterns. The CI job `gui-no-raw-api` runs this check on every PR.
+
+**Allowlist:** `gui/src/ALLOWED_API_FETCHES.txt` lists the temporary baseline of call sites that have not yet been migrated (format: `rel/path:lineno  # justification`). Each migration story (US-004 through US-010) removes its entry when complete.
+
 ## Naming Notes
 
 - The canonical CLI remains `rex`; there is no `askrex` console script.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -178,3 +178,11 @@ Branch: `codex/production-us002-baseline-discovery`
 
 - `gh pr checks --watch` passed: 12 successful, 0 failing, 0 pending.
 - Marked the US-002 GitHub checks acceptance criterion complete.
+
+### US-003 rebase reconciliation
+
+- Rebased `ralph/production-us003-renderer-api-guard` onto current `origin/master` after US-001 and US-002 landed.
+- Preserved the current master progress history.
+- Retained US-003 implementation changes for the raw renderer `/api/` fetch guard.
+- Pre-rebase PR checks for #276 passed: 14 successful, 0 failing, 0 pending.
+

--- a/gui/src/ALLOWED_API_FETCHES.txt
+++ b/gui/src/ALLOWED_API_FETCHES.txt
@@ -1,0 +1,26 @@
+# Allowlist for raw fetch('/api/...') calls in gui/src/.
+#
+# Format (one entry per line):
+#   path/relative/to/repo/root:lineno  # justification
+#
+# Each entry exempts exactly one call site at the stated line number.
+# Remove the entry when that call is migrated to typed IPC.
+#
+# The CI job gui-no-raw-api runs scripts/check_no_renderer_api_fetch.py,
+# which exits non-zero if any fetch('/api/...') match in
+# gui/src/**/*.{ts,tsx,js,jsx} is not listed here.
+#
+# Policy: new renderer fetch('/api/...') calls must NEVER be added without
+# a corresponding allowlist entry AND an IPC migration story open on the
+# backlog. The allowlist is a temporary baseline — not a permanent escape.
+
+gui/src/pages/AboutPage.tsx:13  # fetch('/api/status') — pending US-004 migration to typed IPC
+gui/src/pages/CommandHistoryPage.tsx:26  # fetch('/api/history?limit=50') — pending US-005 migration
+gui/src/pages/DevicesPage.tsx:18  # fetch(`/api/devices/${entityId}/command`) — pending US-007 migration
+gui/src/pages/DevicesPage.tsx:231  # fetch('/api/devices') — pending US-006 migration
+gui/src/pages/QuickActionsPage.tsx:27  # fetch('/api/quick-actions') GET — pending US-008 migration
+gui/src/pages/QuickActionsPage.tsx:44  # fetch('/api/quick-actions') POST — pending US-008 migration
+gui/src/pages/QuickActionsPage.tsx:61  # fetch(`/api/quick-actions/${id}`) DELETE — pending US-009 migration
+gui/src/pages/QuickActionsPage.tsx:68  # fetch(`/api/quick-actions/${action.id}/run`) — pending US-009 migration
+gui/src/pages/SetupWizardPage.tsx:223  # fetch('/api/setup/complete') — pending US-010 migration
+gui/src/renderer/src/App.tsx:49  # fetch('/api/setup/status') — pending US-010 migration

--- a/scripts/check_no_renderer_api_fetch.py
+++ b/scripts/check_no_renderer_api_fetch.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Guard against raw renderer fetch('/api/...') calls in gui/src/.
+
+Scans gui/src/**/*.{ts,tsx,js,jsx} for patterns that match
+  fetch('/api...   fetch("/api...   fetch(`/api...
+
+Any match whose "relative/path:lineno" is NOT listed in
+gui/src/ALLOWED_API_FETCHES.txt causes the script to exit 1.
+
+Usage:
+    python scripts/check_no_renderer_api_fetch.py [--repo-root PATH]
+
+Exit codes:
+    0  no unapproved raw /api/ fetches found
+    1  one or more unapproved raw /api/ fetches found
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_PATTERN = re.compile(r"""fetch\(['"` ]/api""".replace(" ", ""))
+_GUI_SRC_GLOBS = ("*.ts", "*.tsx", "*.js", "*.jsx")
+_ALLOWLIST_RELPATH = Path("gui/src/ALLOWED_API_FETCHES.txt")
+
+
+def load_allowlist(repo_root: Path) -> set[str]:
+    """Return set of 'rel/path:lineno' keys from the allowlist file."""
+    path = repo_root / _ALLOWLIST_RELPATH
+    if not path.exists():
+        return set()
+    entries: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.split("#")[0].strip()
+        if stripped:
+            entries.add(stripped)
+    return entries
+
+
+def find_violations(repo_root: Path) -> list[tuple[str, int, str]]:
+    """Return (rel_path, lineno, line_content) for each unapproved match."""
+    allowlist = load_allowlist(repo_root)
+    gui_src = repo_root / "gui" / "src"
+    violations: list[tuple[str, int, str]] = []
+
+    if not gui_src.is_dir():
+        return violations
+
+    for glob in _GUI_SRC_GLOBS:
+        for fpath in sorted(gui_src.rglob(glob)):
+            rel = fpath.relative_to(repo_root).as_posix()
+            try:
+                lines = fpath.read_text(encoding="utf-8").splitlines()
+            except (OSError, UnicodeDecodeError):
+                continue
+            for i, line in enumerate(lines, start=1):
+                if _PATTERN.search(line):
+                    key = f"{rel}:{i}"
+                    if key not in allowlist:
+                        violations.append((rel, i, line.strip()))
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check for unapproved raw /api/ fetches in gui/src/."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root directory (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+
+    violations = find_violations(repo_root)
+    if violations:
+        print(f"ERROR: {len(violations)} unapproved raw /api/ fetch(s) in gui/src/:")
+        for rel, lineno, content in violations:
+            print(f"  {rel}:{lineno}  {content}")
+        print()
+        print(
+            "To allow an existing call site, add a line to "
+            "gui/src/ALLOWED_API_FETCHES.txt:\n"
+            "  rel/path/to/file.tsx:lineno  # justification\n"
+            "To fix permanently, migrate the call to typed IPC."
+        )
+        return 1
+
+    print("OK: no unapproved raw /api/ fetches in gui/src/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_no_renderer_api_fetch.py
+++ b/tests/test_check_no_renderer_api_fetch.py
@@ -1,0 +1,137 @@
+"""Tests for scripts/check_no_renderer_api_fetch.py (US-003)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import check_no_renderer_api_fetch as script  # noqa: E402
+
+
+def _gui_file(tmp_path: Path, rel: str, content: str) -> Path:
+    fpath = tmp_path / rel
+    fpath.parent.mkdir(parents=True, exist_ok=True)
+    fpath.write_text(content, encoding="utf-8")
+    return fpath
+
+
+def _allowlist(tmp_path: Path, text: str) -> None:
+    path = tmp_path / "gui" / "src" / "ALLOWED_API_FETCHES.txt"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# find_violations()
+# ---------------------------------------------------------------------------
+
+
+def test_no_api_fetches_returns_empty(tmp_path: Path) -> None:
+    _gui_file(
+        tmp_path, "gui/src/pages/Clean.tsx", "export default function Clean() { return null; }\n"
+    )
+    assert script.find_violations(tmp_path) == []
+
+
+def test_missing_gui_src_returns_empty(tmp_path: Path) -> None:
+    assert script.find_violations(tmp_path) == []
+
+
+def test_single_quote_fetch_detected(tmp_path: Path) -> None:
+    _gui_file(tmp_path, "gui/src/pages/Bad.tsx", "const r = await fetch('/api/status');\n")
+    violations = script.find_violations(tmp_path)
+    assert len(violations) == 1
+    assert violations[0][0] == "gui/src/pages/Bad.tsx"
+    assert violations[0][1] == 1
+
+
+def test_double_quote_fetch_detected(tmp_path: Path) -> None:
+    _gui_file(tmp_path, "gui/src/pages/Bad.tsx", 'const r = await fetch("/api/status");\n')
+    assert len(script.find_violations(tmp_path)) == 1
+
+
+def test_template_literal_fetch_detected(tmp_path: Path) -> None:
+    _gui_file(
+        tmp_path,
+        "gui/src/pages/Bad.tsx",
+        "const r = await fetch(`/api/devices/${id}/command`);\n",
+    )
+    assert len(script.find_violations(tmp_path)) == 1
+
+
+def test_non_api_fetch_not_flagged(tmp_path: Path) -> None:
+    _gui_file(
+        tmp_path, "gui/src/pages/Good.tsx", "const r = await fetch('https://example.com/data');\n"
+    )
+    assert script.find_violations(tmp_path) == []
+
+
+def test_allowlisted_entry_is_permitted(tmp_path: Path) -> None:
+    _gui_file(tmp_path, "gui/src/pages/AboutPage.tsx", "const r = await fetch('/api/status');\n")
+    _allowlist(tmp_path, "gui/src/pages/AboutPage.tsx:1  # pending US-004\n")
+    assert script.find_violations(tmp_path) == []
+
+
+def test_allowlist_wrong_line_still_flags(tmp_path: Path) -> None:
+    _gui_file(
+        tmp_path,
+        "gui/src/pages/AboutPage.tsx",
+        "// comment\nconst r = await fetch('/api/status');\n",
+    )
+    _allowlist(tmp_path, "gui/src/pages/AboutPage.tsx:1  # wrong line\n")
+    violations = script.find_violations(tmp_path)
+    assert len(violations) == 1
+    assert violations[0][1] == 2
+
+
+def test_allowlist_comment_stripping(tmp_path: Path) -> None:
+    _gui_file(tmp_path, "gui/src/pages/AboutPage.tsx", "const r = await fetch('/api/status');\n")
+    _allowlist(tmp_path, "  gui/src/pages/AboutPage.tsx:1   # inline comment stripped\n")
+    assert script.find_violations(tmp_path) == []
+
+
+def test_multiple_violations_reported(tmp_path: Path) -> None:
+    _gui_file(
+        tmp_path,
+        "gui/src/pages/Multi.tsx",
+        "fetch('/api/a');\nfetch('/api/b');\n",
+    )
+    violations = script.find_violations(tmp_path)
+    assert len(violations) == 2
+
+
+def test_js_file_also_scanned(tmp_path: Path) -> None:
+    _gui_file(tmp_path, "gui/src/utils/helper.js", "fetch('/api/data');\n")
+    assert len(script.find_violations(tmp_path)) == 1
+
+
+def test_blank_allowlist_file_flags_matches(tmp_path: Path) -> None:
+    _gui_file(tmp_path, "gui/src/pages/Bad.tsx", "fetch('/api/status');\n")
+    _allowlist(tmp_path, "# just comments\n\n# another comment\n")
+    assert len(script.find_violations(tmp_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_0_clean(tmp_path: Path) -> None:
+    _gui_file(tmp_path, "gui/src/pages/Clean.tsx", "export default null;\n")
+    assert script.main(["--repo-root", str(tmp_path)]) == 0
+
+
+def test_main_exits_1_violation(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    _gui_file(tmp_path, "gui/src/pages/Bad.tsx", "fetch('/api/status');\n")
+    result = script.main(["--repo-root", str(tmp_path)])
+    assert result == 1
+    out = capsys.readouterr().out
+    assert "Bad.tsx" in out
+    assert "ERROR" in out
+
+
+def test_main_exits_0_with_allowlist(tmp_path: Path) -> None:
+    _gui_file(tmp_path, "gui/src/pages/AboutPage.tsx", "fetch('/api/status');\n")
+    _allowlist(tmp_path, "gui/src/pages/AboutPage.tsx:1  # pending US-004\n")
+    assert script.main(["--repo-root", str(tmp_path)]) == 0


### PR DESCRIPTION
## Summary

- Adds `scripts/check_no_renderer_api_fetch.py` — scans `gui/src/**/*.{ts,tsx,js,jsx}` for raw `fetch('/api/...')` calls not in the allowlist; exits 0 (clean) or 1 (violations found).
- Adds `gui/src/ALLOWED_API_FETCHES.txt` — baseline allowlist of the 10 existing raw `/api/` call sites, each annotated with the migration story (US-004 through US-010) that will remove it.
- Adds `.github/workflows/ci.yml` job `gui-no-raw-api` — runs the guard on every PR.
- Adds `tests/test_check_no_renderer_api_fetch.py` — 15 pytest tests covering all guard code paths.
- Documents the policy in `docs/UI_SURFACES.md` ("Renderer IPC Policy" section) and `README.md`.

Closes US-003 from PRD-production-readiness.md.

## Test plan

- [ ] `pytest tests/test_check_no_renderer_api_fetch.py -q` → 15 passed
- [ ] `python scripts/check_no_renderer_api_fetch.py` → `OK: no unapproved raw /api/ fetches in gui/src/`
- [ ] CI job `gui-no-raw-api` passes
- [ ] All other CI checks pass