### PR TITLE
fix(skills): remove generated trainer placeholder

### DIFF
--- a/SURFACE-CLASSIFICATION.md
+++ b/SURFACE-CLASSIFICATION.md
@@ -101,6 +101,16 @@ any entry point, import, or startup path in the active codebase.
 
 ---
 
+## Internal Python APIs (User-Facing Capabilities)
+
+These modules implement user-facing capabilities invoked by the assistant pipeline. They are not entry points and are not user-invocable directly, but they affect user-visible behavior.
+
+| Module | Classification | Notes |
+|--------|----------------|-------|
+| `rex.skills.trainer` (`SkillTrainer`) | `shippable` | Invoked by the assistant when a user says "teach yourself to…" or similar. Generates a Python skill scaffold in `plugins/skills/` and registers it in the skill registry. The generated script includes an honest stub that tells the user the skill is not yet implemented. Users can edit the generated file to add real behavior. |
+
+---
+
 ## Package Distribution (pip / wheel)
 
 | Artifact | Classification | Notes |
@@ -133,3 +143,4 @@ any entry point, import, or startup path in the active codebase.
 | 2026-06-07 | US-REM-025 | Added root-level flask_proxy.py as deprecated (count: deprecated 4→5, total 32→33). Updated docs to use archived (not deprecated) for gui.py/run_gui.py. Added developer-only labels across INSTRUCTION_MANUAL.md, ARCHITECTURE.md, COMMANDS_AND_ENTRYPOINTS.md, and API/deployment docs. |
 | 2026-06-23 | US-013 | Added Package Distribution section classifying pip/wheel (askrex-assistant) as developer-only. |
 | 2026-06-23 | US-017 | Classified all 17 root-level bridge compatibility wrappers as developer-only (count: developer-only 10→27, total 33→50). Updated CLAUDE.md root-file count from 9 to 27. No files moved to archived/ — all bridge wrappers are actively used for test-import compatibility. |
+| 2026-06-24 | US-022 | Added Internal Python APIs section. Classified `rex.skills.trainer` (`SkillTrainer`) as shippable — invoked by assistant when user requests skill creation. |

--- a/rex/skills/trainer.py
+++ b/rex/skills/trainer.py
@@ -150,9 +150,7 @@ class SkillTrainer:
     """
 
     def __init__(self, skills_dir: Path | str | None = None) -> None:
-        self._skills_dir = (
-            Path(skills_dir) if skills_dir is not None else _DEFAULT_SKILLS_DIR
-        )
+        self._skills_dir = Path(skills_dir) if skills_dir is not None else _DEFAULT_SKILLS_DIR
 
     def handle_if_training_request(
         self,
@@ -198,17 +196,10 @@ class SkillTrainer:
                 trigger_patterns=triggers,
                 handler=str(script_path),
             )
-            logger.info(
-                "SkillTrainer: registered skill %r (id=%s)", skill.name, skill.id
-            )
+            logger.info("SkillTrainer: registered skill %r (id=%s)", skill.name, skill.id)
         except Exception as exc:
             logger.warning("SkillTrainer: failed to register skill: %s", exc)
-            return (
-                f"I created the skill file for '{name}' but couldn't register it: {exc}"
-            )
+            return f"I created the skill file for '{name}' but couldn't register it: {exc}"
 
         example_trigger = triggers[0] if triggers else name
-        return (
-            f"I've learned how to {name}. "
-            f'You can trigger it by saying "{example_trigger}".'
-        )
+        return f"I've learned how to {name}. " f'You can trigger it by saying "{example_trigger}".'

--- a/rex/skills/trainer.py
+++ b/rex/skills/trainer.py
@@ -124,7 +124,6 @@ def run(transcript: str) -> str:
     Returns:
         A human-readable response.
     """
-    # TODO: implement {name}
     return "The {name} skill was triggered but is not yet fully implemented."
 '''
 
@@ -151,7 +150,9 @@ class SkillTrainer:
     """
 
     def __init__(self, skills_dir: Path | str | None = None) -> None:
-        self._skills_dir = Path(skills_dir) if skills_dir is not None else _DEFAULT_SKILLS_DIR
+        self._skills_dir = (
+            Path(skills_dir) if skills_dir is not None else _DEFAULT_SKILLS_DIR
+        )
 
     def handle_if_training_request(
         self,
@@ -197,10 +198,17 @@ class SkillTrainer:
                 trigger_patterns=triggers,
                 handler=str(script_path),
             )
-            logger.info("SkillTrainer: registered skill %r (id=%s)", skill.name, skill.id)
+            logger.info(
+                "SkillTrainer: registered skill %r (id=%s)", skill.name, skill.id
+            )
         except Exception as exc:
             logger.warning("SkillTrainer: failed to register skill: %s", exc)
-            return f"I created the skill file for '{name}' but couldn't register it: {exc}"
+            return (
+                f"I created the skill file for '{name}' but couldn't register it: {exc}"
+            )
 
         example_trigger = triggers[0] if triggers else name
-        return f"I've learned how to {name}. " f'You can trigger it by saying "{example_trigger}".'
+        return (
+            f"I've learned how to {name}. "
+            f'You can trigger it by saying "{example_trigger}".'
+        )

--- a/tests/test_skills_trainer.py
+++ b/tests/test_skills_trainer.py
@@ -116,7 +116,7 @@ class TestSkillTrainerHandleIfTrainingRequest:
         assert "not yet fully implemented" in content
 
     def test_write_failure_returns_error_message(self, tmp_path):
-        trainer = SkillTrainer(skils_dir=tmp_path / "nonexistent" / "nested")
+        trainer = SkillTrainer(skills_dir=tmp_path / "nonexistent" / "nested")
         registry = MagicMock()
 
         with patch.object(Path, "mkdir", side_effect=PermissionError("no write")):
@@ -129,7 +129,7 @@ class TestSkillTrainerHandleIfTrainingRequest:
         registry.register.assert_not_called()
 
     def test_register_failure_returns_partial_error_message(self, tmp_path):
-        trainer = SkillTrainer(skils_dir=tmp_path)
+        trainer = SkillTrainer(skills_dir=tmp_path)
         registry = MagicMock()
         registry.register.side_effect = RuntimeError("registry full")
 

--- a/tests/test_skills_trainer.py
+++ b/tests/test_skills_trainer.py
@@ -1,0 +1,153 @@
+"""Tests for rex.skills.trainer — SkillTrainer and detect_skill_creation_intent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from rex.skills.trainer import SkillTrainer, detect_skill_creation_intent
+
+# ---------------------------------------------------------------------------
+# detect_skill_creation_intent
+# ---------------------------------------------------------------------------
+
+
+class TestDetectSkillCreationIntent:
+    def test_teach_yourself_matches(self):
+        result = detect_skill_creation_intent("teach yourself to check the battery")
+        assert result == "check the battery"
+
+    def test_learn_how_to_matches(self):
+        result = detect_skill_creation_intent("learn how to send reminders")
+        assert result == "send reminders"
+
+    def test_add_a_skill_that_matches(self):
+        result = detect_skill_creation_intent("add a skill that plays music")
+        assert result == "plays music"
+
+    def test_create_a_skill_for_matches(self):
+        result = detect_skill_creation_intent("create a skill for weather reports")
+        assert result == "weather reports"
+
+    def test_remember_how_to_matches(self):
+        result = detect_skill_creation_intent("remember how to greet users")
+        assert result == "greet users"
+
+    def test_make_a_skill_to_matches(self):
+        result = detect_skill_creation_intent("make a skill to control lights")
+        assert result == "control lights"
+
+    def test_trailing_punctuation_stripped(self):
+        result = detect_skill_creation_intent("teach yourself to check the battery.")
+        assert result == "check the battery"
+
+    def test_case_insensitive(self):
+        result = detect_skill_creation_intent("TEACH YOURSELF TO check the battery")
+        assert result == "check the battery"
+
+    def test_non_training_message_returns_none(self):
+        assert detect_skill_creation_intent("what is the weather today?") is None
+
+    def test_empty_message_returns_none(self):
+        assert detect_skill_creation_intent("") is None
+
+    def test_unrelated_message_returns_none(self):
+        assert detect_skill_creation_intent("turn on the living room lights") is None
+
+
+# ---------------------------------------------------------------------------
+# SkillTrainer.handle_if_training_request
+# ---------------------------------------------------------------------------
+
+
+class TestSkillTrainerHandleIfTrainingRequest:
+    def test_non_training_message_returns_none(self, tmp_path):
+        trainer = SkillTrainer(skills_dir=tmp_path)
+        registry = MagicMock()
+        result = trainer.handle_if_training_request("what time is it?", registry)
+        assert result is None
+        registry.register.assert_not_called()
+
+    def test_training_message_creates_skill_file(self, tmp_path):
+        trainer = SkillTrainer(skills_dir=tmp_path)
+        registry = MagicMock()
+        registry.register.return_value = MagicMock(
+            name="check the battery", id="abc123"
+        )
+
+        result = trainer.handle_if_training_request(
+            "teach yourself to check the battery", registry
+        )
+
+        assert result is not None
+        assert "check the battery" in result.lower() or "learned" in result.lower()
+        skill_files = list(tmp_path.glob("*.py"))
+        assert len(skill_files) == 1
+
+    def test_training_message_registers_skill(self, tmp_path):
+        trainer = SkillTrainer(skills_dir=tmp_path)
+        registry = MagicMock()
+        registry.register.return_value = MagicMock(name="send reminders", id="xyz789")
+
+        trainer.handle_if_training_request("learn how to send reminders", registry)
+
+        registry.register.assert_called_once()
+        call_kwargs = registry.register.call_args.kwargs
+        assert "send reminders" in call_kwargs["name"]
+
+    def test_generated_script_contains_no_todo_implement(self, tmp_path):
+        trainer = SkillTrainer(skills_dir=tmp_path)
+        registry = MagicMock()
+        registry.register.return_value = MagicMock(name="play music", id="m123")
+
+        trainer.handle_if_training_request("make a skill to play music", registry)
+
+        skill_files = list(tmp_path.glob("*.py"))
+        assert skill_files, "Expected a generated skill file"
+        content = skill_files[0].read_text(encoding="utf-8")
+        assert "TODO: implement" not in content
+
+    def test_generated_script_has_honest_return(self, tmp_path):
+        trainer = SkillTrainer(skills_dir=tmp_path)
+        registry = MagicMock()
+        registry.register.return_value = MagicMock(name="play music", id="m123")
+
+        trainer.handle_if_training_request("make a skill to play music", registry)
+
+        skill_files = list(tmp_path.glob("*.py"))
+        assert skill_files
+        content = skill_files[0].read_text(encoding="utf-8")
+        assert "not yet fully implemented" in content
+
+    def test_write_failure_returns_error_message(self, tmp_path):
+        trainer = SkillTrainer(skills_dir=tmp_path / "nonexistent" / "nested")
+        registry = MagicMock()
+
+        with patch.object(Path, "mkdir", side_effect=PermissionError("no write")):
+            result = trainer.handle_if_training_request(
+                "teach yourself to do something", registry
+            )
+
+        assert result is not None
+        assert (
+            "couldn't" in result.lower()
+            or "failed" in result.lower()
+            or "tried" in result.lower()
+        )
+        registry.register.assert_not_called()
+
+    def test_register_failure_returns_partial_error_message(self, tmp_path):
+        trainer = SkillTrainer(skills_dir=tmp_path)
+        registry = MagicMock()
+        registry.register.side_effect = RuntimeError("registry full")
+
+        result = trainer.handle_if_training_request(
+            "teach yourself to do something", registry
+        )
+
+        assert result is not None
+        assert (
+            "couldn't" in result.lower()
+            or "failed" in result.lower()
+            or "created" in result.lower()
+        )

--- a/tests/test_skills_trainer.py
+++ b/tests/test_skills_trainer.py
@@ -71,13 +71,9 @@ class TestSkillTrainerHandleIfTrainingRequest:
     def test_training_message_creates_skill_file(self, tmp_path):
         trainer = SkillTrainer(skills_dir=tmp_path)
         registry = MagicMock()
-        registry.register.return_value = MagicMock(
-            name="check the battery", id="abc123"
-        )
+        registry.register.return_value = MagicMock(name="check the battery", id="abc123")
 
-        result = trainer.handle_if_training_request(
-            "teach yourself to check the battery", registry
-        )
+        result = trainer.handle_if_training_request("teach yourself to check the battery", registry)
 
         assert result is not None
         assert "check the battery" in result.lower() or "learned" in result.lower()
@@ -120,30 +116,24 @@ class TestSkillTrainerHandleIfTrainingRequest:
         assert "not yet fully implemented" in content
 
     def test_write_failure_returns_error_message(self, tmp_path):
-        trainer = SkillTrainer(skills_dir=tmp_path / "nonexistent" / "nested")
+        trainer = SkillTrainer(skils_dir=tmp_path / "nonexistent" / "nested")
         registry = MagicMock()
 
         with patch.object(Path, "mkdir", side_effect=PermissionError("no write")):
-            result = trainer.handle_if_training_request(
-                "teach yourself to do something", registry
-            )
+            result = trainer.handle_if_training_request("teach yourself to do something", registry)
 
         assert result is not None
         assert (
-            "couldn't" in result.lower()
-            or "failed" in result.lower()
-            or "tried" in result.lower()
+            "couldn't" in result.lower() or "failed" in result.lower() or "tried" in result.lower()
         )
         registry.register.assert_not_called()
 
     def test_register_failure_returns_partial_error_message(self, tmp_path):
-        trainer = SkillTrainer(skills_dir=tmp_path)
+        trainer = SkillTrainer(skils_dir=tmp_path)
         registry = MagicMock()
         registry.register.side_effect = RuntimeError("registry full")
 
-        result = trainer.handle_if_training_request(
-            "teach yourself to do something", registry
-        )
+        result = trainer.handle_if_training_request("teach yourself to do something", registry)
 
         assert result is not None
         assert (


### PR DESCRIPTION
## Summary
- Remove the generated `TODO: implement` marker from skill scaffolds so generated skills report their incomplete state honestly.
- Add focused coverage for skill-creation intent detection, file generation, registration failures, and write failures.
- Classify `rex.skills.trainer` in `SURFACE-CLASSIFICATION.md`.
- Rebase the change on the CI-clean `master` from PR #297.

## Verification
- The focused skill-trainer suite passes locally: 18 tests passed.
- Ruff, Black, pre-commit, mypy, GUI typecheck/tests/build, wheel smoke, dependency audits, secret scan, raw renderer API guard, and Commitlint pass on GitHub.
- The previous full-suite failure was traced to two misspelled test fixture keywords (`skils_dir`); both are corrected.
- The full Python tests, integration tests, coverage threshold, and clean-working-tree gate are rerunning against the corrected commit.

## CLAUDE.md
No update is required for this PR. It changes no command, dependency, environment variable, integration contract, or repository structure.