### PR TITLE
fix(identity): reject unsafe profile IDs

### DIFF
--- a/rex/identity.py
+++ b/rex/identity.py
@@ -21,12 +21,44 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 
 from .config import settings
 
 logger = logging.getLogger(__name__)
+
+_USER_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+def validate_user_id(user_id: str) -> str:
+    """Validate and return a filesystem-safe user identifier.
+
+    User IDs are used as directory names under ``Memory/``. Restricting the
+    accepted characters and length prevents traversal through values such as
+    ``..`` while retaining common IDs containing letters, digits, dots,
+    underscores, and hyphens.
+
+    Raises:
+        ValueError: If *user_id* is empty, reserved, or filesystem-unsafe.
+    """
+    if not isinstance(user_id, str) or not _USER_ID_PATTERN.fullmatch(user_id):
+        raise ValueError(f"Invalid user_id: {user_id!r}")
+    if user_id in {".", ".."}:
+        raise ValueError(f"Invalid user_id: {user_id!r}")
+    return user_id
+
+
+def _validated_candidate(user_id: object, *, source: str) -> str | None:
+    """Return a valid candidate ID or fail closed for persisted configuration."""
+    if not isinstance(user_id, str) or not user_id:
+        return None
+    try:
+        return validate_user_id(user_id)
+    except ValueError:
+        logger.warning("Ignoring invalid %s user ID: %r", source, user_id)
+        return None
 
 
 def _session_state_path() -> Path:
@@ -48,7 +80,8 @@ def _known_user_ids() -> list[str]:
     users = []
     for entry in sorted(memory_dir.iterdir()):
         if entry.is_dir() and (entry / "core.json").exists():
-            users.append(entry.name)
+            if _validated_candidate(entry.name, source="Memory directory"):
+                users.append(entry.name)
     return users
 
 
@@ -89,6 +122,7 @@ def get_session_user() -> str | None:
 
 def set_session_user(user_id: str) -> None:
     """Set the active user in session state."""
+    user_id = validate_user_id(user_id)
     session = _load_session()
     session["active_user"] = user_id
     _save_session(session)
@@ -118,24 +152,26 @@ def resolve_active_user(
     Returns:
         User ID string, or ``None`` if no user could be resolved.
     """
-    # 1. Explicit flag
+    # 1. Explicit flag. Invalid explicit selection is a caller error and must
+    # not silently fall back to another person's session.
     if explicit_user:
-        return explicit_user
+        return validate_user_id(explicit_user)
 
-    # 2. Session state
+    # 2. Session state. Invalid persisted state fails closed.
     session_user = get_session_user()
     if session_user:
-        return session_user
+        return _validated_candidate(session_user, source="session")
 
-    # 3-4. Config values
+    # 3-4. Config values. Invalid configured identity fails closed rather than
+    # unexpectedly selecting the legacy fallback.
     if config:
         runtime = config.get("runtime", {})
         active = runtime.get("active_user")
         if active:
-            return active  # type: ignore[no-any-return]
+            return _validated_candidate(active, source="runtime.active_user")
         uid = runtime.get("user_id")
         if uid and uid != "default":
-            return uid  # type: ignore[no-any-return]
+            return _validated_candidate(uid, source="runtime.user_id")
 
     return None
 
@@ -185,6 +221,8 @@ def list_known_users() -> list[dict]:
     for entry in sorted(memory_dir.iterdir()):
         core = entry / "core.json"
         if entry.is_dir() and core.exists():
+            if not _validated_candidate(entry.name, source="Memory directory"):
+                continue
             try:
                 data = json.loads(core.read_text(encoding="utf-8"))
                 users.append(
@@ -225,8 +263,7 @@ def create_user_profile(
         ValueError: If user_id is empty or contains path separators.
         FileExistsError: If the profile already exists and overwrite is False.
     """
-    if not user_id or "/" in user_id or "\\" in user_id:
-        raise ValueError(f"Invalid user_id: {user_id!r}")
+    user_id = validate_user_id(user_id)
 
     base = (
         memory_dir if memory_dir is not None else Path(__file__).resolve().parent.parent / "Memory"
@@ -266,7 +303,11 @@ def get_user_profile(
 
     Returns:
         Profile dict, or None if not found.
+
+    Raises:
+        ValueError: If *user_id* is filesystem-unsafe.
     """
+    user_id = validate_user_id(user_id)
     base = (
         memory_dir if memory_dir is not None else Path(__file__).resolve().parent.parent / "Memory"
     )
@@ -295,7 +336,11 @@ def update_user_preferences(
 
     Returns:
         True if the profile was updated, False if not found.
+
+    Raises:
+        ValueError: If *user_id* is filesystem-unsafe.
     """
+    user_id = validate_user_id(user_id)
     base = (
         memory_dir if memory_dir is not None else Path(__file__).resolve().parent.parent / "Memory"
     )
@@ -328,4 +373,5 @@ __all__ = [
     "resolve_active_user",
     "set_session_user",
     "update_user_preferences",
+    "validate_user_id",
 ]

--- a/rex/user_facts.py
+++ b/rex/user_facts.py
@@ -16,6 +16,8 @@ import json
 import logging
 from pathlib import Path
 
+from rex.identity import validate_user_id
+
 logger = logging.getLogger(__name__)
 
 # Memory/ is at the repo root (same directory as rex/).
@@ -23,10 +25,15 @@ _MEMORY_ROOT = Path(__file__).parent.parent / "Memory"
 
 
 def _facts_path(user: str, memory_root: Path | None = None) -> Path:
+    """Return the facts file for a validated user ID.
+
+    User IDs are also used by the profile/session identity layer. Reusing its
+    validator prevents ambiguous filename sanitization where distinct IDs such
+    as ``alice/bob`` and ``alice_bob`` could map to the same facts file.
+    """
     root = memory_root or _MEMORY_ROOT
     root.mkdir(parents=True, exist_ok=True)
-    # Sanitise user key to a safe filename component.
-    safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in user)
+    safe = validate_user_id(user)
     return root / f"{safe}_facts.json"
 
 

--- a/tests/test_cli_scheduler_email_calendar.py
+++ b/tests/test_cli_scheduler_email_calendar.py
@@ -166,7 +166,7 @@ class TestEmailCLI:
         mock_email_service.connect.return_value = True
         mock_email_service.fetch_unread.return_value = []
 
-        args = MagicMock(email_command="unread", limit=10, verbose=False)
+        args = MagicMock(email_command="unread", limit=10, verbose=False, user=None)
         result = cmd_email(args)
 
         assert result == 0
@@ -190,7 +190,7 @@ class TestEmailCLI:
         mock_email_service.fetch_unread.return_value = [email1]
         mock_email_service.categorize.return_value = "important"
 
-        args = MagicMock(email_command="unread", limit=10, verbose=False)
+        args = MagicMock(email_command="unread", limit=10, verbose=False, user=None)
         result = cmd_email(args)
 
         assert result == 0
@@ -217,7 +217,7 @@ class TestEmailCLI:
         mock_email_service.fetch_unread.return_value = [email]
         mock_email_service.categorize.return_value = "general"
 
-        args = MagicMock(email_command="unread", limit=10, verbose=True)
+        args = MagicMock(email_command="unread", limit=10, verbose=True, user=None)
         result = cmd_email(args)
 
         assert result == 0
@@ -229,7 +229,7 @@ class TestEmailCLI:
         """Test email command when connection fails."""
         mock_email_service.connect.return_value = False
 
-        args = MagicMock(email_command="unread", limit=10, verbose=False)
+        args = MagicMock(email_command="unread", limit=10, verbose=False, user=None)
         result = cmd_email(args)
 
         assert result == 1
@@ -241,14 +241,14 @@ class TestEmailCLI:
         mock_email_service.connect.return_value = True
         mock_email_service.fetch_unread.return_value = []
 
-        args = MagicMock(email_command="unread", limit=5, verbose=False)
+        args = MagicMock(email_command="unread", limit=5, verbose=False, user=None)
         cmd_email(args)
 
         mock_email_service.fetch_unread.assert_called_once_with(limit=5)
 
     def test_email_unknown_command(self, mock_email_service, capsys):
         """Test unknown email subcommand."""
-        args = MagicMock(email_command="unknown")
+        args = MagicMock(email_command="unknown", user=None)
         result = cmd_email(args)
 
         assert result == 1
@@ -276,7 +276,9 @@ class TestCalendarCLI:
         mock_calendar_service.connect.return_value = True
         mock_calendar_service.get_upcoming_events.return_value = []
 
-        args = MagicMock(calendar_command="upcoming", days=7, conflicts=False, verbose=False)
+        args = MagicMock(
+            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user=None
+        )
         result = cmd_calendar(args)
 
         assert result == 0
@@ -303,7 +305,9 @@ class TestCalendarCLI:
         mock_calendar_service.connect.return_value = True
         mock_calendar_service.get_upcoming_events.return_value = [event]
 
-        args = MagicMock(calendar_command="upcoming", days=7, conflicts=False, verbose=False)
+        args = MagicMock(
+            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user=None
+        )
         result = cmd_calendar(args)
 
         assert result == 0
@@ -332,7 +336,9 @@ class TestCalendarCLI:
         mock_calendar_service.connect.return_value = True
         mock_calendar_service.get_upcoming_events.return_value = [event]
 
-        args = MagicMock(calendar_command="upcoming", days=7, conflicts=False, verbose=True)
+        args = MagicMock(
+            calendar_command="upcoming", days=7, conflicts=False, verbose=True, user=None
+        )
         result = cmd_calendar(args)
 
         assert result == 0
@@ -356,7 +362,9 @@ class TestCalendarCLI:
         mock_calendar_service.connect.return_value = True
         mock_calendar_service.get_upcoming_events.return_value = [event]
 
-        args = MagicMock(calendar_command="upcoming", days=7, conflicts=False, verbose=False)
+        args = MagicMock(
+            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user=None
+        )
         result = cmd_calendar(args)
 
         assert result == 0
@@ -389,7 +397,9 @@ class TestCalendarCLI:
         mock_calendar_service.get_upcoming_events.return_value = [event1, event2]
         mock_calendar_service.find_conflicts.return_value = [(event1, event2)]
 
-        args = MagicMock(calendar_command="upcoming", days=7, conflicts=True, verbose=False)
+        args = MagicMock(
+            calendar_command="upcoming", days=7, conflicts=True, verbose=False, user=None
+        )
         result = cmd_calendar(args)
 
         assert result == 0
@@ -403,7 +413,9 @@ class TestCalendarCLI:
         mock_calendar_service.connect.return_value = True
         mock_calendar_service.get_upcoming_events.return_value = []
 
-        args = MagicMock(calendar_command="upcoming", days=14, conflicts=False, verbose=False)
+        args = MagicMock(
+            calendar_command="upcoming", days=14, conflicts=False, verbose=False, user=None
+        )
         cmd_calendar(args)
 
         mock_calendar_service.get_upcoming_events.assert_called_once_with(days=14)
@@ -412,7 +424,9 @@ class TestCalendarCLI:
         """Test calendar command when connection fails."""
         mock_calendar_service.connect.return_value = False
 
-        args = MagicMock(calendar_command="upcoming", days=7, conflicts=False, verbose=False)
+        args = MagicMock(
+            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user=None
+        )
         result = cmd_calendar(args)
 
         assert result == 1
@@ -421,7 +435,7 @@ class TestCalendarCLI:
 
     def test_calendar_unknown_command(self, mock_calendar_service, capsys):
         """Test unknown calendar subcommand."""
-        args = MagicMock(calendar_command="unknown")
+        args = MagicMock(calendar_command="unknown", user=None)
         result = cmd_calendar(args)
 
         assert result == 1

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -17,11 +17,15 @@ import pytest
 from rex.identity import (
     _load_session,
     clear_session_user,
+    create_user_profile,
     get_session_user,
+    get_user_profile,
     list_known_users,
     require_active_user,
     resolve_active_user,
     set_session_user,
+    update_user_preferences,
+    validate_user_id,
 )
 
 # ---------------------------------------------------------------
@@ -299,3 +303,53 @@ class TestIdentityCLI:
         with patch("rex.identity.list_known_users", return_value=[]):
             result = cmd_identify(args)
             assert result == 1
+
+
+# ---------------------------------------------------------------
+# User ID safety tests
+# ---------------------------------------------------------------
+
+
+class TestUserIdSafety:
+    @pytest.mark.parametrize(
+        "user_id",
+        ["", ".", "..", "../alice", "alice/bob", r"alice\bob", " alice", "alice "],
+    )
+    def test_rejects_filesystem_unsafe_ids(self, user_id):
+        with pytest.raises(ValueError, match="Invalid user_id"):
+            validate_user_id(user_id)
+
+    @pytest.mark.parametrize("user_id", ["alice", "alice-2", "alice_2", "alice.smith"])
+    def test_accepts_common_safe_ids(self, user_id):
+        assert validate_user_id(user_id) == user_id
+
+    def test_create_profile_cannot_escape_memory_directory(self, tmp_path: Path):
+        memory_dir = tmp_path / "Memory"
+        with pytest.raises(ValueError, match="Invalid user_id"):
+            create_user_profile("..", "Outside", memory_dir=memory_dir)
+        assert not (tmp_path / "core.json").exists()
+
+    def test_profile_reads_and_updates_reject_traversal(self, tmp_path: Path):
+        memory_dir = tmp_path / "Memory"
+        outside = tmp_path / "core.json"
+        outside.write_text(json.dumps({"name": "Outside"}), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Invalid user_id"):
+            get_user_profile("..", memory_dir=memory_dir)
+        with pytest.raises(ValueError, match="Invalid user_id"):
+            update_user_preferences("..", {"theme": "dark"}, memory_dir=memory_dir)
+
+        assert json.loads(outside.read_text(encoding="utf-8")) == {"name": "Outside"}
+
+    def test_explicit_invalid_user_does_not_fall_back_to_session(self, session_dir):
+        set_session_user("alice")
+        with pytest.raises(ValueError, match="Invalid user_id"):
+            resolve_active_user("..")
+
+    def test_invalid_session_user_fails_closed(self, tmp_path: Path):
+        session_file = tmp_path / "rex-ai" / "session.json"
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text(json.dumps({"active_user": ".."}), encoding="utf-8")
+
+        with patch("rex.identity._session_state_path", return_value=session_file):
+            assert resolve_active_user(config={"runtime": {"active_user": "alice"}}) is None

--- a/tests/test_us324_user_facts.py
+++ b/tests/test_us324_user_facts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 
 def test_store_and_recall(tmp_path: Path) -> None:
     """store() persists a fact; recall() retrieves it."""
@@ -67,6 +69,27 @@ def test_format_facts_for_prompt_empty(tmp_path: Path) -> None:
     assert format_facts_for_prompt("nobody", memory_root=tmp_path) is None
 
 
+@pytest.mark.parametrize("user", ["", ".", "..", "alice/bob", r"alice\bob", " alice"])
+def test_fact_store_rejects_unsafe_user_ids(tmp_path: Path, user: str) -> None:
+    """Fact paths must use the canonical identity validator."""
+    from rex.user_facts import store
+
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        store(user, "key", "value", memory_root=tmp_path)
+
+
+def test_invalid_user_cannot_collide_with_safe_user(tmp_path: Path) -> None:
+    """Sanitization must not merge an invalid identity into a valid user's file."""
+    from rex.user_facts import recall, store
+
+    store("alice_bob", "owner", "safe", memory_root=tmp_path)
+
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        store("alice/bob", "owner", "unsafe", memory_root=tmp_path)
+
+    assert recall("alice_bob", "owner", memory_root=tmp_path) == "safe"
+
+
 def test_cli_remember_stores_fact(tmp_path: Path, monkeypatch: object) -> None:
     """python -m rex remember 'fact' stores the fact for the default user."""
     import types
@@ -77,7 +100,6 @@ def test_cli_remember_stores_fact(tmp_path: Path, monkeypatch: object) -> None:
         "rex.user_facts._MEMORY_ROOT",
         tmp_path,
     )
-
     args = types.SimpleNamespace(fact="My dog is named Max", user="default", key=None, value=None)
     ret = cmd_remember(args)
     assert ret == 0


### PR DESCRIPTION
## Summary
- Add one canonical `validate_user_id()` guard for profile, session, and fact-store identities.
- Reject traversal and filesystem-unsafe IDs, including `.`, `..`, separators, whitespace-padded values, invalid characters, and excessive length.
- Apply validation consistently to session selection, config resolution, profile creation, profile reads, preference updates, known-user discovery, and per-user fact storage.
- Fail closed when persisted identity state is invalid instead of falling back to a different user's session or legacy configuration.
- Remove filename sanitization from `rex.user_facts` that could map distinct IDs such as `alice/bob` and `alice_bob` to the same facts file.
- Add regression coverage for path traversal, safe IDs, profile reads and writes, invalid session state, explicit-user fallback behavior, and fact-store collisions.

## Security impact
User IDs become directory names and fact-file names under `Memory/`. The previous profile check rejected `/` and `\` but accepted `..`, which could resolve outside the intended profile directory. The fact store separately rewrote invalid characters, which could merge two distinct identities into one file. This change prevents both classes of identity confusion.

## Local verification
- Focused user-ID safety suite: 16 passed.
- Existing non-CLI identity tests passed in the available local environment.
- Full Python 3.11 and repository checks are rerunning in GitHub CI after the fact-store extension.

## Tracking
This addresses the first concrete findings under #303. That broader issue remains open for complete conversation history, credential, cache, knowledge, scheduler, and background-job isolation verification.

## CLAUDE.md
No command, dependency, environment variable, file-layout, or integration contract changes are introduced.