### PR TITLE
fix(assistant): isolate response cache and conversation history per user

### DIFF
--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -91,13 +91,19 @@ class Assistant:
     ) -> None:
         self._settings = settings_obj or settings
         self._llm = LanguageModel(config=self._settings)
-        self._history: list[ConversationTurn] = []
-        self._history_limit = history_limit or self._settings.max_memory_items
-        self._plugins = list(plugins or [])
-        self._transcripts_dir = Path(transcripts_dir or self._settings.transcripts_dir)
 
         # Prefer explicit user_id, then settings.user_id, then "default"
         self._user_id = user_id or getattr(self._settings, "user_id", None) or "default"
+
+        # Per-user in-memory history windows keyed by user id (issue #303).
+        # ``self._history`` is a property that resolves to the current
+        # ``self._user_id``'s list, so identified-speaker requests never see
+        # another user's turns.
+        self._histories: dict[str, list[ConversationTurn]] = {}
+        self._history = []
+        self._history_limit = history_limit or self._settings.max_memory_items
+        self._plugins = list(plugins or [])
+        self._transcripts_dir = Path(transcripts_dir or self._settings.transcripts_dir)
 
         # Conversation history persistence
         self._history_store: HistoryStore | None = None
@@ -222,6 +228,9 @@ class Assistant:
             history=self._history,
             user_id=self._user_id,
             followup_engine=self._followup_engine,
+            # Live per-user view: resolves to the active user's history at
+            # build time instead of a construction-time snapshot (#303).
+            history_provider=lambda: self._history,
         )
 
         # Intent router: handles direct-reply shortcuts without LLM (US-015)
@@ -304,6 +313,41 @@ class Assistant:
     def user_id(self) -> str:
         """Get the user ID for this assistant session."""
         return self._user_id
+
+    # ------------------------------------------------------------------
+    # Per-user in-memory history (issue #303)
+    # ------------------------------------------------------------------
+
+    def _load_persisted_history(self, user_id: str) -> list[ConversationTurn]:
+        """Load the most recent persisted turns for *user_id* (empty when no store)."""
+        store = getattr(self, "_history_store", None)
+        if store is None:
+            return []
+        try:
+            stored = store.load_history(user_id, limit=50)
+            return [ConversationTurn(speaker=row["role"], text=row["content"]) for row in stored]
+        except Exception as exc:
+            logger.warning("Failed to load history for user %s: %s", user_id, exc)
+            return []
+
+    def _history_for(self, user_id: str) -> list[ConversationTurn]:
+        """Return the in-memory history window for *user_id*, loading it lazily."""
+        histories: dict[str, list[ConversationTurn]] = self.__dict__.setdefault("_histories", {})
+        hist = histories.get(user_id)
+        if hist is None:
+            hist = self._load_persisted_history(user_id)
+            histories[user_id] = hist
+        return hist
+
+    @property
+    def _history(self) -> list[ConversationTurn]:
+        """History window for the currently active ``self._user_id``."""
+        return self._history_for(getattr(self, "_user_id", "default"))
+
+    @_history.setter
+    def _history(self, value: list[ConversationTurn]) -> None:
+        uid = getattr(self, "_user_id", "default")
+        self.__dict__.setdefault("_histories", {})[uid] = list(value)
 
     @property
     def has_pending_followup(self) -> bool:
@@ -400,24 +444,35 @@ class Assistant:
             plugin_enrichments=plugin_enrichments,
         )
 
-    def _record_completion(self, transcript: str, completion: str) -> None:
+    def _record_completion(
+        self, transcript: str, completion: str, *, user_id: str | None = None
+    ) -> None:
+        """Persist and remember a completed turn under its owning user.
+
+        *user_id* overrides ``self._user_id`` so early-return paths (intent
+        shortcuts, cache hits) and post-``_end_request`` recording attribute
+        the turn to the identified speaker rather than the session default
+        (issue #303).
+        """
+        uid = user_id if user_id is not None else self._user_id
         now = datetime.utcnow()
         history_store = getattr(self, "_history_store", None)
         if history_store is not None:
             try:
-                history_store.save_turn(self._user_id, "user", transcript, now)
-                history_store.save_turn(self._user_id, "assistant", completion, now)
+                history_store.save_turn(uid, "user", transcript, now)
+                history_store.save_turn(uid, "assistant", completion, now)
             except Exception as exc:
                 logger.warning("Failed to persist conversation turn: %s", exc)
 
-        self._history.append(ConversationTurn("user", transcript))
-        self._history.append(ConversationTurn("assistant", completion))
-        self._history = [
+        hist = self._history_for(uid)
+        hist.append(ConversationTurn("user", transcript))
+        hist.append(ConversationTurn("assistant", completion))
+        self._histories[uid] = [
             ConversationTurn(**item) if isinstance(item, dict) else item
-            for item in trim_history(self._history, limit=self._history_limit)  # type: ignore[arg-type]
+            for item in trim_history(hist, limit=self._history_limit)  # type: ignore[arg-type]
         ]
 
-        self._log_turn(transcript, completion)
+        self._log_turn(transcript, completion, user_id=uid)
 
     def _looks_like_unverified_action_claim(self, completion: str) -> bool:
         return any(pattern.search(completion) for pattern in _UNVERIFIED_ACTION_CLAIM_PATTERNS)
@@ -536,6 +591,13 @@ class Assistant:
         """Orchestrate a full reply: intent → cache → context → dispatch → response."""
         loop = asyncio.get_running_loop()
 
+        # The user this turn belongs to: the identified speaker when known,
+        # otherwise the session default.  Used for cache partitioning and
+        # turn attribution on every path, including early returns (#303).
+        effective_user_id = (
+            active_user_id if active_user_id is not None else getattr(self, "_user_id", "default")
+        )
+
         # Route intent: capability queries, pending suggestions, time/date, greetings, recipes
         _intent = self._get_or_create_intent_router().route(
             transcript,
@@ -545,13 +607,16 @@ class Assistant:
         if _intent.handled:
             # Greeting shortcuts are suppressed in multi-user voice sessions
             if not (_intent.intent_type == "greeting" and active_user_id is not None):
-                self._record_completion(transcript, _intent.response)
+                self._record_completion(transcript, _intent.response, user_id=effective_user_id)
                 return _intent.response  # type: ignore[no-any-return]
 
-        # Fast path: return cached response without hitting the LLM
-        _cached = self._get_or_create_response_builder().check_cache(transcript)
+        # Fast path: return cached response without hitting the LLM.
+        # Lookup is confined to the effective user's cache partition.
+        _cached = self._get_or_create_response_builder().check_cache(
+            transcript, user_id=effective_user_id
+        )
         if _cached is not None:
-            self._record_completion(transcript, _cached)
+            self._record_completion(transcript, _cached, user_id=effective_user_id)
             return _cached  # type: ignore[no-any-return]
 
         # Apply per-request model routing and user ID scoping; restore in finally
@@ -570,13 +635,13 @@ class Assistant:
                 loop=loop,
             )
             final = self._get_or_create_response_builder().build(
-                result, _ctx, transcript=transcript
+                result, _ctx, transcript=transcript, user_id=effective_user_id
             )
             completion = final.text
         finally:
             self._end_request(prev_model, prev_user_id)
 
-        self._record_completion(transcript, completion)
+        self._record_completion(transcript, completion, user_id=effective_user_id)
         return completion  # type: ignore[no-any-return]
 
     def _begin_request(self, transcript: str, active_user_id: str | None) -> tuple[str | None, str]:
@@ -703,6 +768,7 @@ class Assistant:
                 history=getattr(self, "_history", []),
                 user_id=getattr(self, "_user_id", "default"),
                 followup_engine=getattr(self, "_followup_engine", None),
+                history_provider=lambda: getattr(self, "_history", []),
             )
             self._context_builder = cb
         return cb
@@ -832,10 +898,11 @@ class Assistant:
     def history(self) -> list[ConversationTurn]:
         return list(self._history)
 
-    def _log_turn(self, transcript: str, reply: str) -> None:
+    def _log_turn(self, transcript: str, reply: str, *, user_id: str | None = None) -> None:
         try:
+            uid = user_id if user_id is not None else self._user_id
             self._transcripts_dir.mkdir(parents=True, exist_ok=True)
-            user_dir = self._transcripts_dir / self._user_id
+            user_dir = self._transcripts_dir / uid
             user_dir.mkdir(parents=True, exist_ok=True)
             timestamp = datetime.utcnow()
             file_path = user_dir / f"{timestamp:%Y-%m-%d}.txt"

--- a/rex/context/builder.py
+++ b/rex/context/builder.py
@@ -8,6 +8,7 @@ Extracted from ``rex.assistant.Assistant._build_prompt``,
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -71,10 +72,15 @@ class ContextBuilder:
     """Assembles LLM context from history, user profile, and personality.
 
     Args:
-        settings:        App config/settings object (``AppConfig`` or ``Settings``).
-        history:         Mutable reference to the in-memory conversation history list.
-        user_id:         Default user/session identifier.
-        followup_engine: Optional follow-up engine for ``format_followups()``.
+        settings:         App config/settings object (``AppConfig`` or ``Settings``).
+        history:          Mutable reference to the in-memory conversation history list.
+        user_id:          Default user/session identifier.
+        followup_engine:  Optional follow-up engine for ``format_followups()``.
+        history_provider: Optional zero-arg callable returning the current
+                          history list.  When given it takes precedence over
+                          *history*, so the builder always reads the caller's
+                          live (per-user) history instead of a snapshot taken
+                          at construction time (issue #303).
     """
 
     def __init__(
@@ -84,11 +90,19 @@ class ContextBuilder:
         user_id: str,
         *,
         followup_engine: Any = None,
+        history_provider: Callable[[], list] | None = None,
     ) -> None:
         self._settings = settings
         self._history = history
         self._user_id = user_id
         self._followup_engine = followup_engine
+        self._history_provider = history_provider
+
+    def _current_history(self) -> list:
+        """Return the live history list (provider-backed when configured)."""
+        if self._history_provider is not None:
+            return self._history_provider()
+        return self._history
 
     # ------------------------------------------------------------------
     # Primary entry point
@@ -297,7 +311,7 @@ class ContextBuilder:
         if voice_mode:
             messages.append({"role": "system", "content": _VOICE_CONCISE_INSTRUCTION})
 
-        for turn in self._history[-4:]:
+        for turn in self._current_history()[-4:]:
             speaker = str(turn.speaker).strip().lower()
             role = "assistant" if speaker in {"assistant", "rex"} else "user"
             messages.append({"role": role, "content": turn.text})
@@ -338,7 +352,7 @@ class ContextBuilder:
         if tool_context:
             history_lines.append(tool_context)
 
-        history_lines += [f"{turn.speaker}: {turn.text}" for turn in self._history[-4:]]
+        history_lines += [f"{turn.speaker}: {turn.text}" for turn in self._current_history()[-4:]]
         history_lines.append(f"user: {user_message}")
 
         if voice_mode:

--- a/rex/response/builder.py
+++ b/rex/response/builder.py
@@ -89,15 +89,19 @@ class ResponseBuilder:
     # Cache lookup (pre-dispatch fast path)
     # ------------------------------------------------------------------
 
-    def check_cache(self, transcript: str) -> str | None:
+    def check_cache(self, transcript: str, *, user_id: str | None = None) -> str | None:
         """Return a cached response for *transcript*, or ``None`` on miss/bypass.
 
-        Delegates to :meth:`~rex.response_cache.ResponseCache.get`.
+        Delegates to :meth:`~rex.response_cache.ResponseCache.get`.  When
+        *user_id* is given the lookup is confined to that user's cache
+        partition so one user never receives another user's cached answer.
         Returns ``None`` when no cache is configured.
         """
         if self._cache is None:
             return None
-        return self._cache.get(transcript)  # type: ignore[no-any-return]
+        if user_id is None:
+            return self._cache.get(transcript)  # type: ignore[no-any-return]
+        return self._cache.get(transcript, user_id=user_id)  # type: ignore[no-any-return]
 
     # ------------------------------------------------------------------
     # Primary entry point
@@ -109,6 +113,7 @@ class ResponseBuilder:
         context: Any,
         *,
         transcript: str = "",
+        user_id: str | None = None,
     ) -> FinalResponse:
         """Build a :class:`FinalResponse` from an :class:`~rex.actions.dispatcher.ActionResult`.
 
@@ -116,6 +121,8 @@ class ResponseBuilder:
             action_result: Result from :class:`~rex.actions.dispatcher.ActionDispatcher`.
             context:       :class:`~rex.context.builder.ContextPackage` from the context builder.
             transcript:    The original user transcript; used as the cache key for the PUT.
+            user_id:       Owner of the cache entry; confines the PUT to that
+                           user's partition (issue #303).
 
         Returns:
             A fully populated :class:`FinalResponse`.
@@ -127,7 +134,10 @@ class ResponseBuilder:
 
         # Cache PUT: store result so identical future queries skip the LLM.
         if self._cache is not None and transcript:
-            self._cache.put(transcript, text)
+            if user_id is None:
+                self._cache.put(transcript, text)
+            else:
+                self._cache.put(transcript, text, user_id=user_id)
 
         return FinalResponse(
             text=text,

--- a/rex/response_cache.py
+++ b/rex/response_cache.py
@@ -1,8 +1,13 @@
 """Response cache for repeated factual queries (US-LAT-004).
 
-Caches LLM responses keyed on normalized message text.  Cache entries expire
-after a configurable TTL (default 5 minutes).  Cache lookup is bypassed for
-messages that reference time-sensitive intents or invoke tools.
+Caches LLM responses keyed on normalized message text and the requesting
+user.  Cache entries expire after a configurable TTL (default 5 minutes).
+Cache lookup is bypassed for messages that reference time-sensitive intents
+or invoke tools.
+
+Entries stored for one ``user_id`` are never returned for another, so a
+personalized answer cached for user A cannot leak to user B asking the same
+question (issue #303).
 """
 
 from __future__ import annotations
@@ -111,7 +116,7 @@ class ResponseCache:
     def __init__(self, ttl: float = 300.0, max_size: int = 256) -> None:
         self._ttl = ttl
         self._max_size = max_size
-        self._store: dict[str, _CacheEntry] = {}
+        self._store: dict[tuple[str | None, str], _CacheEntry] = {}
         self._lock = Lock()
         self._hits = 0
         self._misses = 0
@@ -120,13 +125,17 @@ class ResponseCache:
     # Public API
     # ------------------------------------------------------------------
 
-    def get(self, message: str) -> str | None:
-        """Return a cached response for *message*, or None on miss/bypass/expiry."""
+    def get(self, message: str, *, user_id: str | None = None) -> str | None:
+        """Return a cached response for *message*, or None on miss/bypass/expiry.
+
+        Entries are partitioned by *user_id*: a response stored for one user
+        is never returned for another.  ``None`` is its own partition.
+        """
         if _should_bypass(message):
             logger.debug("[cache] bypass: %r", message[:60])
             return None
 
-        key = _normalize(message)
+        key = (user_id, _normalize(message))
         now = time.monotonic()
 
         with self._lock:
@@ -136,27 +145,32 @@ class ResponseCache:
                     del self._store[key]
                 self._misses += 1
                 logger.debug(
-                    "[cache] miss (total hits=%d misses=%d): %r",
+                    "[cache] miss (total hits=%d misses=%d): user=%r %r",
                     self._hits,
                     self._misses,
-                    key[:60],
+                    user_id,
+                    key[1][:60],
                 )
                 return None
             self._hits += 1
             logger.debug(
-                "[cache] hit (total hits=%d misses=%d): %r",
+                "[cache] hit (total hits=%d misses=%d): user=%r %r",
                 self._hits,
                 self._misses,
-                key[:60],
+                user_id,
+                key[1][:60],
             )
             return entry.response
 
-    def put(self, message: str, response: str) -> None:
-        """Store *response* for *message* unless the query should be bypassed."""
+    def put(self, message: str, response: str, *, user_id: str | None = None) -> None:
+        """Store *response* for *message* in *user_id*'s partition.
+
+        Skipped entirely when the query should be bypassed.
+        """
         if _should_bypass(message):
             return
 
-        key = _normalize(message)
+        key = (user_id, _normalize(message))
         expires_at = time.monotonic() + self._ttl
 
         with self._lock:

--- a/tests/test_us017_response_builder.py
+++ b/tests/test_us017_response_builder.py
@@ -322,7 +322,8 @@ class TestAssistantUsesResponseBuilder:
             reply = asyncio.run(a.generate_reply("hello"))
 
         assert reply == "LLM reply"
-        rb.check_cache.assert_called_once_with("hello")
+        # Cache lookups are confined to the active user's partition (#303)
+        rb.check_cache.assert_called_once_with("hello", user_id="default")
         rb.build.assert_called_once()
 
     def test_generate_reply_returns_cached_without_dispatch(self):

--- a/tests/test_us022_music_handler.py
+++ b/tests/test_us022_music_handler.py
@@ -274,7 +274,7 @@ class TestAssistantMusicRouting:
         assistant._history_store = None
         assistant._transcripts_dir = pathlib.Path("/tmp")
         assistant._user_id = "test"
-        assistant._record_completion = lambda t, c: None  # type: ignore[method-assign]
+        assistant._record_completion = lambda t, c, **kw: None  # type: ignore[method-assign]
         assistant._router = MagicMock()
         assistant._router.classify.return_value = "general"
         assistant._router.resolve_model.return_value = ""

--- a/tests/test_us303_user_isolation.py
+++ b/tests/test_us303_user_isolation.py
@@ -1,0 +1,273 @@
+"""Negative tests for per-user isolation of the response cache and the
+in-memory conversation history (issue #303, gaps A and B).
+
+Proves:
+
+- A response cached for user A is never returned for user B (same text).
+- The in-memory history window is partitioned per user: user B's LLM
+  prompt never contains user A's turns.
+- Turn recording (in-memory and persisted) is attributed to the identified
+  speaker on every ``generate_reply`` path, including the cache-hit and
+  post-``_end_request`` paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from rex.response_cache import ResponseCache
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_assistant(user_id: str = "default", history_store=None):
+    """Build a minimal Assistant without running the heavy __init__."""
+    from rex.assistant import Assistant
+
+    a = Assistant.__new__(Assistant)
+    a._settings = MagicMock()
+    a._settings.max_memory_items = 50
+    a._settings.persist_history = False
+    a._settings.followups_enabled = False
+    a._settings.model_routing = None
+    a._settings.transcripts_enabled = False
+    a._user_id = user_id
+    a._histories = {}
+    a._history = []
+    a._history_limit = 50
+    a._plugins = []
+    a._history_store = history_store
+    a._followup_engine = None
+    a._pending_followup = None
+    a._followup_lock = asyncio.Lock()
+    a._router = None
+    a._response_cache = None
+    a._ha_bridge = None
+    a._suggestion_engine = None
+    a._pattern_entries = []
+    return a
+
+
+# ---------------------------------------------------------------------------
+# ResponseCache — per-user partitioning (gap A)
+# ---------------------------------------------------------------------------
+
+
+class TestResponseCacheUserPartition:
+    def test_user_b_cannot_read_user_a_entry(self):
+        cache = ResponseCache(ttl=60.0)
+        cache.put("what is my favorite color?", "Your favorite color is blue.", user_id="alice")
+        assert cache.get("what is my favorite color?", user_id="bob") is None
+
+    def test_same_user_still_hits(self):
+        cache = ResponseCache(ttl=60.0)
+        cache.put("what is my favorite color?", "Your favorite color is blue.", user_id="alice")
+        assert cache.get("what is my favorite color?", user_id="alice") == (
+            "Your favorite color is blue."
+        )
+
+    def test_anonymous_partition_isolated_from_named_users(self):
+        cache = ResponseCache(ttl=60.0)
+        cache.put("what is the capital of France?", "Paris.")
+        assert cache.get("what is the capital of France?", user_id="alice") is None
+        assert cache.get("what is the capital of France?") == "Paris."
+
+    def test_named_partition_isolated_from_anonymous(self):
+        cache = ResponseCache(ttl=60.0)
+        cache.put("what is the capital of France?", "Paris.", user_id="alice")
+        assert cache.get("what is the capital of France?") is None
+
+    def test_two_users_can_hold_different_answers(self):
+        cache = ResponseCache(ttl=60.0)
+        cache.put("what is my dog's name?", "Rex.", user_id="alice")
+        cache.put("what is my dog's name?", "Fido.", user_id="bob")
+        assert cache.get("what is my dog's name?", user_id="alice") == "Rex."
+        assert cache.get("what is my dog's name?", user_id="bob") == "Fido."
+
+
+# ---------------------------------------------------------------------------
+# ResponseBuilder — user id threads through to the cache
+# ---------------------------------------------------------------------------
+
+
+class TestResponseBuilderCacheUserThreading:
+    def test_check_cache_passes_user_id(self):
+        from rex.response.builder import ResponseBuilder
+
+        cache = MagicMock()
+        cache.get.return_value = None
+        rb = ResponseBuilder(response_cache=cache)
+        rb.check_cache("hello", user_id="alice")
+        cache.get.assert_called_once_with("hello", user_id="alice")
+
+    def test_check_cache_without_user_keeps_legacy_call(self):
+        from rex.response.builder import ResponseBuilder
+
+        cache = MagicMock()
+        cache.get.return_value = None
+        rb = ResponseBuilder(response_cache=cache)
+        rb.check_cache("hello")
+        cache.get.assert_called_once_with("hello")
+
+    def test_build_puts_under_user_partition(self):
+        from rex.actions.dispatcher import ActionResult
+        from rex.context.builder import ContextPackage
+        from rex.response.builder import ResponseBuilder
+
+        cache = MagicMock()
+        rb = ResponseBuilder(response_cache=cache)
+        ctx = ContextPackage(
+            messages=[], system_prompt="s", session_id="alice", user_facts={}, prompt=""
+        )
+        rb.build(
+            ActionResult(success=True, response="answer"),
+            ctx,
+            transcript="question",
+            user_id="alice",
+        )
+        cache.put.assert_called_once_with("question", "answer", user_id="alice")
+
+
+# ---------------------------------------------------------------------------
+# Assistant — per-user in-memory history (gap B)
+# ---------------------------------------------------------------------------
+
+
+class TestAssistantHistoryPartition:
+    def test_record_completion_isolates_users(self):
+        a = _make_assistant(user_id="alice")
+        a._record_completion("my pin is 1234", "Noted.", user_id="alice")
+        a._record_completion("what's the weather like", "Rainy.", user_id="bob")
+
+        alice_history = a._history_for("alice")
+        bob_history = a._history_for("bob")
+        assert any("1234" in turn.text for turn in alice_history)
+        assert not any("1234" in turn.text for turn in bob_history)
+
+    def test_history_property_follows_active_user(self):
+        a = _make_assistant(user_id="alice")
+        a._record_completion("alice secret", "ok", user_id="alice")
+
+        a._user_id = "bob"
+        assert not any("alice secret" in turn.text for turn in a._history)
+
+        a._user_id = "alice"
+        assert any("alice secret" in turn.text for turn in a._history)
+
+    def test_context_builder_prompt_excludes_other_users_turns(self):
+        a = _make_assistant(user_id="alice")
+        a._record_completion("my ssn is 000-00-0000", "Stored.", user_id="alice")
+
+        cb = a._get_or_create_context_builder()
+
+        # Simulate the _begin_request user swap for an identified speaker.
+        a._user_id = "bob"
+        messages = cb._build_messages("hello", system_prompt="sys")
+        joined = " ".join(str(m.get("content", "")) for m in messages)
+        assert "000-00-0000" not in joined
+
+        # Alice's own context still contains her turns.
+        a._user_id = "alice"
+        messages = cb._build_messages("hello again", system_prompt="sys")
+        joined = " ".join(str(m.get("content", "")) for m in messages)
+        assert "000-00-0000" in joined
+
+    def test_context_builder_sees_new_turns_after_trim_reassignment(self):
+        """The cached builder must read live history, not an init-time snapshot."""
+        a = _make_assistant(user_id="alice")
+        cb = a._get_or_create_context_builder()
+
+        # _record_completion reassigns self._history after trimming; the
+        # builder previously kept a stale reference to the original list.
+        a._record_completion("remember the cake", "Will do.", user_id="alice")
+        messages = cb._build_messages("hello", system_prompt="sys")
+        joined = " ".join(str(m.get("content", "")) for m in messages)
+        assert "remember the cake" in joined
+
+
+# ---------------------------------------------------------------------------
+# Assistant.generate_reply — attribution and cache partition end to end
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReplyAttribution:
+    def _wire_llm_path(self, a, reply_text: str):
+        """Attach fake intent router / dispatcher so generate_reply reaches
+        the response-builder path and returns *reply_text*."""
+        from rex.actions.dispatcher import ActionResult
+        from rex.intent.router import IntentResult
+
+        ir = MagicMock()
+        ir.route.return_value = IntentResult(handled=False, response=None, intent_type=None)
+        a._intent_router = ir
+
+        async def _fake_dispatch(*args, **kwargs):
+            return ActionResult(success=True, response=reply_text)
+
+        ad = MagicMock()
+        ad.dispatch = _fake_dispatch
+        a._action_dispatcher = ad
+        a._llm = MagicMock()
+        a._llm.model_name = "m"
+
+    def test_cached_answer_not_shared_across_active_users(self):
+        a = _make_assistant(user_id="default")
+        a._response_cache = ResponseCache(ttl=60.0)
+        self._wire_llm_path(a, "Blue, your favorite.")
+
+        first = asyncio.run(a.generate_reply("what is my favorite color", active_user_id="alice"))
+        assert first == "Blue, your favorite."
+
+        # Same question from bob must not hit alice's cached entry: the
+        # dispatcher runs again and can produce a bob-specific answer.
+        self._wire_llm_path(a, "Green, your favorite.")
+        second = asyncio.run(a.generate_reply("what is my favorite color", active_user_id="bob"))
+        assert second == "Green, your favorite."
+
+        # And alice still gets her own cached answer without dispatch.
+        a._action_dispatcher = MagicMock()  # would explode if dispatched
+        third = asyncio.run(a.generate_reply("what is my favorite color", active_user_id="alice"))
+        assert third == "Blue, your favorite."
+
+    def test_persisted_turns_attributed_to_active_user(self):
+        store = MagicMock()
+        store.load_history.return_value = []
+        a = _make_assistant(user_id="default", history_store=store)
+        self._wire_llm_path(a, "Done.")
+
+        asyncio.run(a.generate_reply("turn it up", active_user_id="bob"))
+
+        saved_users = [call.args[0] for call in store.save_turn.call_args_list]
+        assert saved_users, "expected save_turn to be called"
+        assert set(saved_users) == {"bob"}
+
+    def test_generate_reply_prompt_excludes_other_users_history(self):
+        from rex.actions.dispatcher import ActionResult
+        from rex.intent.router import IntentResult
+
+        a = _make_assistant(user_id="default")
+        a._record_completion("my password is hunter2", "Stored.", user_id="alice")
+
+        ir = MagicMock()
+        ir.route.return_value = IntentResult(handled=False, response=None, intent_type=None)
+        a._intent_router = ir
+        a._llm = MagicMock()
+        a._llm.model_name = "m"
+
+        captured: dict = {}
+
+        async def _capture_dispatch(intent, ctx, transcript, **kwargs):
+            captured["messages"] = ctx.messages
+            return ActionResult(success=True, response="ok")
+
+        ad = MagicMock()
+        ad.dispatch = _capture_dispatch
+        a._action_dispatcher = ad
+
+        asyncio.run(a.generate_reply("hello", active_user_id="bob"))
+
+        joined = " ".join(str(m.get("content", "")) for m in captured["messages"])
+        assert "hunter2" not in joined


### PR DESCRIPTION
## Summary

Fixes the two highest-severity cross-user data leaks from the #303 store inventory (gaps A and B): the response cache and the in-memory conversation history were shared across identified speakers on a single long-lived `Assistant`.

### Gap A — response cache was user-blind

`ResponseCache` keyed entries by normalized message text only, so user B asking the same question received user A's cached (potentially personalized) answer.

- `rex/response_cache.py`: cache key is now `(user_id, normalized_text)`; `get`/`put` accept keyword-only `user_id` (default `None`, its own partition — fully backward compatible).
- `rex/response/builder.py`: `check_cache`/`build` thread `user_id` through to the cache, passing the kwarg only when set so existing caller/stub signatures keep working.
- `rex/assistant.py`: `generate_reply` computes `effective_user_id` (the identified speaker, else the session user) and confines cache lookup and write to that partition.

### Gap B — in-memory history window leaked across users

`_begin_request` swapped `self._user_id` but not `self._history`, so user A's last turns were injected into user B's LLM prompt. Two adjacent defects were found and fixed in the same mechanism:

- The cached `ContextBuilder` held a construction-time reference to the history list, which `_record_completion`'s trim-reassignment detached after the first turn (prompt history amnesia on the dispatcher path).
- The final `_record_completion` in `generate_reply` ran **after** `_end_request`, persisting identified-speaker turns under the session-default user (mis-attribution in `data/history.db`, in-memory history, and transcript files).

Fixes:

- `rex/assistant.py`: `self._history` is now a property over `self._histories: dict[user_id -> list[ConversationTurn]]`, keyed by the current `self._user_id` and lazily loaded from `HistoryStore`. The existing `_begin_request`/`_end_request` user swap now automatically swaps the history window too.
- `rex/context/builder.py`: `ContextBuilder` gained an optional `history_provider` callable (used by both construction sites) so prompts always read the live, per-user history instead of a stale snapshot.
- `rex/assistant.py`: `_record_completion` and `_log_turn` gained keyword-only `user_id`; `generate_reply` attributes every path (intent shortcut, cache hit, post-dispatch) to `effective_user_id`.

### Behavior notes

- Single-user flows are unchanged except cache keys now include the session user id (one partition).
- `stream_reply` (no `active_user_id` concept) behaves exactly as before.
- No changes to `rex/identity.py`; this work does not depend on PR #306.

## Tests

New `tests/test_us303_user_isolation.py` (15 tests), including the negative tests required by #303:

- user B cannot read user A's cached response (cache, builder, and `generate_reply` level);
- user B's LLM prompt never contains user A's turns;
- persisted turns are attributed to the identified speaker (`save_turn` called with the active user);
- the cached context builder sees live history after trim-reassignment;
- anonymous and named cache partitions are mutually isolated.

Two existing tests updated to the new internal signatures (`test_us017_response_builder.py` asserts the user-scoped cache call; `test_us022_music_handler.py` stub lambda accepts the new kwarg). No assertions were weakened.

## Verification (local, Python 3.11.9)

```
pytest -q tests/test_us303_user_isolation.py tests/test_lat004_response_cache.py \
  tests/test_us017_response_builder.py tests/test_us014_context_builder.py \
  tests/test_assistant.py tests/test_voice_id_profile_switch.py tests/test_us050_personality.py \
  tests/test_us038_capability_response.py tests/test_us022_music_handler.py \
  tests/test_us015_intent_router.py tests/test_voice_loop_fixes.py
# 249 passed

pytest -q   # full suite
# 7346 passed, 94 skipped, 1 failed: test_us098_test_coverage.py::test_coverage_txt_exists
#   (pre-existing environmental failure — asserts the locally generated coverage.txt exists;
#    absent in a fresh worktree, generated by the CI job itself; identical on unmodified master)

ruff check / black --check  # clean on all changed files
mypy rex/response_cache.py rex/response/builder.py rex/context/builder.py rex/assistant.py
# Success: no issues found in 4 source files
```

**Baseline proof**: the new test file was also run against unmodified `origin/master` (fde0c76) in a temporary worktree — 14 of 15 tests fail there (the one pass is the legacy-call compatibility test, which must pass on both sides). The tests pin the fixed behavior, they don't pass vacuously.

A fresh-context review of the final diff reported no changes requested, and confirmed: no other `ResponseCache` call sites bypass partitioning; no `bridge/` or production code reads `assistant._history` externally; `stream_reply` and all single-user bridge callers are behaviorally unchanged.

## Residual known gaps (out of scope here, tracked in #303)

- `SuggestionEngine._pending` is a single un-partitioned attribute, so a pending suggestion surfaced to user A could be picked up in user B's next turn (pre-existing).
- `Assistant._histories` has no eviction for long-lived instances serving many transient speakers (each entry is bounded by the trim limit; only distinct-user count grows).

Part of #303. Independent of PR #306 (no `validate_user_id` dependency); the remaining #303 gaps (reminders bridge, memory singletons, per-user email accounts) need #306's `validate_user_id` and will follow as separate PRs.
