### PR TITLE
feat(wakeword): add runtime unreliable-model self-test with fallback

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -77,6 +77,41 @@ The current Rex install paths are validated on Python 3.11. Fresh installs on Py
 3. Test wake word detection: `python wakeword_listener.py`
 4. Record custom wake word: `python scripts/record_wakeword.py`
 
+## Custom Wake Model — False Triggers on Silence
+
+**Issue:** Rex wakes up constantly on background noise with a custom-trained wake
+model, or logs show `custom_wake_model_unreliable` / `wakeword_backend_fallback_activated`.
+
+**What happened:** During the first 10 seconds of each wake-listening cycle the
+listener runs a noise self-test on the `custom_embedding` backend. If it sees 5
+high-confidence detections (≥ 0.85) on effectively silent audio (RMS ≤ 0.006 and
+peak ≤ 0.025), it concludes the model is unreliable in this environment:
+
+- **With a fallback available** (`wakeword.fallback_to_builtin: true`, the default) —
+  Rex automatically swaps to the built-in `openwakeword` keyword
+  (`wakeword.fallback_keyword`, default "hey jarvis") and keeps listening. The log
+  contains `wakeword_backend_fallback_activated`, and the detection that triggered
+  the swap is suppressed so no false capture fires.
+
+- **Without a fallback** (`fallback_to_builtin: false`) — the model is marked
+  unreliable in the logs (`custom_wake_model_unreliable`) but keeps running;
+  expect continued false triggers until you fix the model.
+
+**Solutions:**
+1. **Retrain in your environment.** Run `python scripts/record_wakeword.py` in the
+   same room and mic setup Rex will use. More varied samples improve robustness.
+2. **Keep the built-in fallback enabled** in `config/rex_config.json`:
+   ```json
+   "wakeword": {
+     "backend": "custom_embedding",
+     "fallback_to_builtin": true,
+     "fallback_keyword": "hey jarvis"
+   }
+   ```
+3. **Switch backend** to `openwakeword` if retraining is not practical.
+4. **Check microphone gain.** Very high ambient gain (OS AGC) can make room
+   noise look like speech. Reduce the OS microphone boost level.
+
 ## Rate Limit Errors (TTS API)
 
 **Error:** `429 Too Many Requests`

--- a/rex/wakeword/listener.py
+++ b/rex/wakeword/listener.py
@@ -23,6 +23,17 @@ from .utils import (
 logger = logging.getLogger(__name__)
 _DEFAULT_LOAD_WAKEWORD_MODEL = load_wakeword_model
 
+# Thresholds for detecting unreliable custom-embedding models: a model that
+# repeatedly reports high confidence on quiet/background audio is broken and
+# would fire constantly. Frames are only counted inside the self-test window
+# at the start of a listening cycle to avoid false fallbacks from marginal
+# models during long quiet periods.
+_UNRELIABLE_CONFIDENCE_THRESHOLD: float = 0.85
+_UNRELIABLE_RMS_MAX: float = 0.006
+_UNRELIABLE_PEAK_MAX: float = 0.025
+_UNRELIABLE_MIN_FRAMES: int = 5
+_UNRELIABLE_WINDOW_S: float = 10.0
+
 DetectorResult: TypeAlias = bool | WakeWordDetectionResult
 DetectorCallable: TypeAlias = Callable[[np.ndarray], DetectorResult]
 DetectorFactoryResult: TypeAlias = tuple[DetectorCallable, Callable[[], None] | None, str | None]
@@ -44,6 +55,10 @@ class WakeWordListener:
         keyword: str | None = None,
         backend: str | None = None,
         event_callback: WakeEventCallback | None = None,
+        fallback_detector_factory: DetectorFactory | None = None,
+        fallback_keyword: str | None = None,
+        fallback_backend: str | None = None,
+        unreliable_silence_enabled: bool = False,
     ) -> None:
         self._detector = detector
         self._poll_interval = poll_interval
@@ -59,12 +74,22 @@ class WakeWordListener:
         self._event_callback = event_callback
         self._listening_started_at: float | None = None
         self._listening_cycle = 0
+        self._fallback_detector_factory = fallback_detector_factory
+        self._fallback_keyword = fallback_keyword
+        self._fallback_backend = fallback_backend
+        self._unreliable_silence_enabled = unreliable_silence_enabled
+        self._high_confidence_quiet_frames = 0
+        self._model_marked_unreliable = False
+        self._suppress_next_trigger = False
 
     def mark_listening_started(self, *, reason: str = "manual") -> None:
         """Mark a user-visible wake-listening cycle as active."""
         self._attempt_count = 0
         self._listening_cycle += 1
         self._listening_started_at = time.monotonic()
+        # Restart the unreliable-model self-test window for the new cycle.
+        # A model already marked unreliable stays on the fallback detector.
+        self._high_confidence_quiet_frames = 0
         extra: dict[str, object] = {
             "event": "wakeword_listening_cycle_started",
             "reason": reason,
@@ -194,7 +219,66 @@ class WakeWordListener:
                     attempt_extra,
                 )
 
-                if triggered:
+                # Unreliable custom-model self-test: count frames where the
+                # model reports high confidence on quiet/background audio
+                # inside the self-test window at the start of the cycle.
+                # After _UNRELIABLE_MIN_FRAMES such frames the model is
+                # declared unreliable and the fallback detector is activated.
+                if (
+                    self._unreliable_silence_enabled
+                    and not self._model_marked_unreliable
+                    and time_since_listening_start_s <= _UNRELIABLE_WINDOW_S
+                ):
+                    _rms_raw = result_extra.get("audio_rms")
+                    _peak_raw = result_extra.get("audio_peak")
+                    _rms = float(_rms_raw) if isinstance(_rms_raw, (int, float)) else 0.0
+                    _peak = float(_peak_raw) if isinstance(_peak_raw, (int, float)) else 0.0
+                    _is_quiet = _rms <= _UNRELIABLE_RMS_MAX and _peak <= _UNRELIABLE_PEAK_MAX
+                    _is_high_conf = confidence >= _UNRELIABLE_CONFIDENCE_THRESHOLD
+                    if _is_quiet and _is_high_conf:
+                        self._high_confidence_quiet_frames += 1
+                        _sample_extra: dict[str, object] = {
+                            "event": "wakeword_custom_embedding_score_sample",
+                            "self_test_state": "accumulating",
+                            "confidence": confidence,
+                            "threshold": threshold,
+                            "audio_rms": _rms,
+                            "audio_peak": _peak,
+                            "high_confidence_quiet_frames": self._high_confidence_quiet_frames,
+                            "unreliable_min_frames": _UNRELIABLE_MIN_FRAMES,
+                            "active_wake_phrase": self._keyword,
+                            "active_backend": self._backend,
+                        }
+                        logger.debug(
+                            "Custom embedding high-confidence silence frame %d/%d",
+                            self._high_confidence_quiet_frames,
+                            _UNRELIABLE_MIN_FRAMES,
+                            extra=_sample_extra,
+                        )
+                        self._emit_event(
+                            "DEBUG",
+                            "Custom embedding high-confidence silence frame",
+                            _sample_extra,
+                        )
+                        if self._high_confidence_quiet_frames >= _UNRELIABLE_MIN_FRAMES:
+                            await self._activate_fallback(
+                                audio_rms=_rms,
+                                audio_peak=_peak,
+                                confidence=confidence,
+                            )
+
+                if triggered and self._suppress_next_trigger:
+                    self._suppress_next_trigger = False
+                    logger.debug(
+                        "Wake-word trigger suppressed after fallback activation",
+                        extra={
+                            "event": "wakeword_trigger_suppressed_fallback",
+                            "confidence": confidence,
+                            "keyword": keyword,
+                            "backend": self._backend,
+                        },
+                    )
+                elif triggered:
                     detected_at = time.monotonic()
                     self._mark_listening_ended(
                         reason="accepted_wake",
@@ -242,6 +326,119 @@ class WakeWordListener:
             self._event_callback({"level": level, "message": message, "extra": dict(extra)})
         except Exception:
             logger.debug("Wake event callback failed", exc_info=True)
+
+    async def _activate_fallback(
+        self, *, audio_rms: float, audio_peak: float, confidence: float
+    ) -> None:
+        """Mark the custom model unreliable and switch to the fallback detector.
+
+        Emits ``high_confidence_silence`` and ``custom_wake_model_unreliable``
+        events, then loads the fallback detector (openWakeWord) and emits
+        ``wakeword_backend_fallback_activated``.  Suppresses the frame that
+        triggered activation so no false STT capture fires.
+        """
+        self._model_marked_unreliable = True
+        self._high_confidence_quiet_frames = 0
+        self._suppress_next_trigger = True
+
+        original_backend = self._backend
+        original_keyword = self._keyword
+
+        base_extra: dict[str, object] = {
+            "confidence": confidence,
+            "audio_rms": audio_rms,
+            "audio_peak": audio_peak,
+            "unreliable_confidence_threshold": _UNRELIABLE_CONFIDENCE_THRESHOLD,
+            "unreliable_rms_max": _UNRELIABLE_RMS_MAX,
+            "unreliable_peak_max": _UNRELIABLE_PEAK_MAX,
+            "original_backend": original_backend,
+            "original_keyword": original_keyword,
+            "fallback_keyword": self._fallback_keyword,
+            "fallback_backend": self._fallback_backend,
+            "detector_generation": self._detector_generation,
+        }
+
+        silence_extra: dict[str, object] = {**base_extra, "event": "high_confidence_silence"}
+        logger.warning(
+            "Wake-word custom model unreliable: high-confidence on quiet audio "
+            "(backend=%s keyword=%r rms=%.4f peak=%.4f confidence=%.4f)",
+            original_backend,
+            original_keyword,
+            audio_rms,
+            audio_peak,
+            confidence,
+            extra=silence_extra,
+        )
+        self._emit_event(
+            "WARNING",
+            "Wake-word custom model unreliable: high-confidence on quiet audio",
+            silence_extra,
+        )
+
+        unreliable_extra: dict[str, object] = {
+            **base_extra,
+            "event": "custom_wake_model_unreliable",
+        }
+        self._emit_event("WARNING", "Custom wake model marked unreliable", unreliable_extra)
+
+        if self._fallback_detector_factory is None:
+            return
+
+        loading_extra: dict[str, object] = {
+            "event": "wakeword_fallback_loading",
+            "original_backend": original_backend,
+            "original_keyword": original_keyword,
+            "fallback_keyword": self._fallback_keyword,
+            "fallback_backend": self._fallback_backend,
+        }
+        self._emit_event("INFO", "Wake-word fallback detector loading", loading_extra)
+
+        factory = self._fallback_detector_factory
+        try:
+            fallback_detector, fallback_reset, fallback_label = (
+                await asyncio.get_running_loop().run_in_executor(None, factory)
+            )
+        except Exception as exc:
+            disabled_extra: dict[str, object] = {
+                "event": "wakeword_backend_fallback_disabled",
+                "error": str(exc),
+                "original_backend": original_backend,
+                "original_keyword": original_keyword,
+            }
+            logger.error(
+                "Wake-word fallback detector failed to load: %s",
+                exc,
+                extra=disabled_extra,
+            )
+            self._emit_event(
+                "ERROR",
+                "Wake-word fallback detector failed to load",
+                disabled_extra,
+            )
+            return
+
+        self._detector = fallback_detector
+        self._reset_detector = fallback_reset
+        self._rebuild_detector = factory
+        if fallback_label:
+            self._keyword = fallback_label
+        if self._fallback_backend:
+            self._backend = self._fallback_backend
+        self._detector_generation += 1
+
+        activated_extra: dict[str, object] = {
+            "event": "wakeword_backend_fallback_activated",
+            "fallback_keyword": self._keyword,
+            "fallback_backend": self._backend,
+            "detector_generation": self._detector_generation,
+            "original_backend": original_backend,
+            "original_keyword": original_keyword,
+            "confidence_at_activation": confidence,
+            "audio_rms_at_activation": audio_rms,
+            "audio_peak_at_activation": audio_peak,
+        }
+        logger.info("Wake-word backend fallback activated", extra=activated_extra)
+        self._emit_event("INFO", "Wake-word backend fallback activated", activated_extra)
 
     @staticmethod
     def _coerce_result(
@@ -454,6 +651,37 @@ def build_default_detector(
     if poll_interval is None:
         poll_interval = min(0.05, max(0.0, chunk_duration / 2))
 
+    # Build a fallback factory for runtime unreliable-model detection when
+    # using a custom embedding backend.  The factory loads the builtin
+    # openWakeWord model with the configured fallback keyword so the listener
+    # can swap it in if the custom model proves unreliable at runtime.
+    _fallback_factory: DetectorFactory | None = None
+    _fallback_kw: str | None = None
+    _fallback_be: str | None = None
+    if active_backend == "custom_embedding" and fallback_to_builtin is not False:
+        _fb_kw = (fallback_keyword or "hey jarvis").strip()
+        _fb_threshold = threshold
+
+        def _build_fallback_instance() -> DetectorFactoryResult:
+            fb_model, fb_selection = load_wakeword_model_with_metadata(
+                keyword=_fb_kw,
+                backend="openwakeword",
+                fallback_to_builtin=True,
+                fallback_keyword=_fb_kw,
+            )
+            fb_label = fb_selection.active_label
+
+            def _fb_detector(frame: np.ndarray) -> WakeWordDetectionResult:
+                return evaluate_wakeword(fb_model, frame, threshold=_fb_threshold)
+
+            fb_reset = getattr(fb_model, "reset", None)
+            fb_reset_fn = fb_reset if callable(fb_reset) else None
+            return _fb_detector, fb_reset_fn, fb_label
+
+        _fallback_factory = _build_fallback_instance
+        _fallback_kw = _fb_kw
+        _fallback_be = "openwakeword"
+
     logger.info(
         "Wake-word listener configured",
         extra={
@@ -475,6 +703,9 @@ def build_default_detector(
             "fallback_keyword": selection.fallback_keyword if selection else fallback_keyword,
             "validation_error": selection.validation_error if selection else None,
             "reset_supported": reset_detector is not None,
+            "unreliable_silence_enabled": _fallback_factory is not None
+            or active_backend == "custom_embedding",
+            "fallback_factory_available": _fallback_factory is not None,
         },
     )
     logger.info(
@@ -509,6 +740,10 @@ def build_default_detector(
         keyword=active_label,
         backend=active_backend,
         event_callback=event_callback,
+        fallback_detector_factory=_fallback_factory,
+        fallback_keyword=_fallback_kw,
+        fallback_backend=_fallback_be,
+        unreliable_silence_enabled=(active_backend == "custom_embedding"),
     )
 
 

--- a/tests/test_wakeword_listener_runtime.py
+++ b/tests/test_wakeword_listener_runtime.py
@@ -292,3 +292,498 @@ def test_build_default_detector_uses_configured_threshold(monkeypatch, caplog):
     assert instance_records[-1].threshold == 0.03
     assert attempt_records[-1].threshold == 0.03
     assert attempt_records[-1].accepted is True
+
+
+# ---------------------------------------------------------------------------
+# Unreliable-model detection tests
+# ---------------------------------------------------------------------------
+
+
+def _quiet_result(
+    triggered: bool = False,
+    confidence: float = 0.90,
+    rms: float = 0.003,
+    peak: float = 0.012,
+    threshold: float = 0.5,
+) -> WakeWordDetectionResult:
+    return WakeWordDetectionResult(
+        triggered=triggered,
+        threshold=threshold,
+        predictions={"hey_rex": confidence},
+        confidence=confidence,
+        keyword="hey_rex",
+        reason="confidence_met_threshold" if triggered else "below_threshold",
+        audio_rms=rms,
+        audio_peak=peak,
+    )
+
+
+@pytest.mark.unit
+def test_wakeword_listener_unreliable_detected_after_min_frames():
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_PEAK_MAX,
+        _UNRELIABLE_RMS_MAX,
+    )
+
+    def detector(_frame):
+        return _quiet_result(
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 0.5,
+            peak=_UNRELIABLE_PEAK_MAX * 0.5,
+        )
+
+    state: dict = {}
+
+    async def run():
+        call_count = 0
+        listener = WakeWordListener(detector, poll_interval=0, unreliable_silence_enabled=True)
+        state["listener"] = listener
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            if call_count > _UNRELIABLE_MIN_FRAMES:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _ in listener.listen(source):
+            break
+
+    asyncio.run(run())
+    assert state["listener"]._model_marked_unreliable is True
+
+
+@pytest.mark.unit
+def test_wakeword_listener_unreliable_not_triggered_below_min_frames():
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_PEAK_MAX,
+        _UNRELIABLE_RMS_MAX,
+    )
+
+    def detector(_frame):
+        return _quiet_result(
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 0.5,
+            peak=_UNRELIABLE_PEAK_MAX * 0.5,
+        )
+
+    state: dict = {}
+
+    async def run():
+        call_count = 0
+        # Stop on the (MIN_FRAMES - 1)th source call so the loop exits after processing
+        # exactly MIN_FRAMES - 1 quiet frames (one short of activation).
+        listener = WakeWordListener(detector, poll_interval=0, unreliable_silence_enabled=True)
+        state["listener"] = listener
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= _UNRELIABLE_MIN_FRAMES - 1:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _ in listener.listen(source):
+            break
+
+    asyncio.run(run())
+    assert state["listener"]._model_marked_unreliable is False
+    assert state["listener"]._high_confidence_quiet_frames == _UNRELIABLE_MIN_FRAMES - 1
+
+
+@pytest.mark.unit
+def test_wakeword_listener_loud_audio_does_not_increment_unreliable_counter():
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_RMS_MAX,
+    )
+
+    def detector(_frame):
+        # High confidence but loud audio — RMS well above the quiet threshold.
+        return _quiet_result(
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 10,  # loud
+            peak=0.15,
+        )
+
+    state: dict = {}
+
+    async def run():
+        call_count = 0
+        listener = WakeWordListener(detector, poll_interval=0, unreliable_silence_enabled=True)
+        state["listener"] = listener
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            if call_count > _UNRELIABLE_MIN_FRAMES + 2:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _ in listener.listen(source):
+            break
+
+    asyncio.run(run())
+    assert state["listener"]._model_marked_unreliable is False
+    assert state["listener"]._high_confidence_quiet_frames == 0
+
+
+@pytest.mark.unit
+def test_wakeword_listener_fallback_factory_called_on_activation():
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_PEAK_MAX,
+        _UNRELIABLE_RMS_MAX,
+    )
+
+    factory_calls: list[int] = []
+
+    def fallback_detector(_frame):
+        return _quiet_result(triggered=False, confidence=0.1)
+
+    def fallback_factory():
+        factory_calls.append(1)
+        return fallback_detector, None, "hey jarvis"
+
+    def detector(_frame):
+        return _quiet_result(
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 0.5,
+            peak=_UNRELIABLE_PEAK_MAX * 0.5,
+        )
+
+    state: dict = {}
+
+    async def run():
+        call_count = 0
+        listener = WakeWordListener(
+            detector,
+            poll_interval=0,
+            unreliable_silence_enabled=True,
+            fallback_detector_factory=fallback_factory,
+            fallback_keyword="hey jarvis",
+            fallback_backend="openwakeword",
+        )
+        state["listener"] = listener
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            if call_count > _UNRELIABLE_MIN_FRAMES + 1:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _ in listener.listen(source):
+            break
+
+    asyncio.run(run())
+    assert factory_calls == [1]
+    assert state["listener"]._model_marked_unreliable is True
+    assert state["listener"]._keyword == "hey jarvis"
+    assert state["listener"]._backend == "openwakeword"
+
+
+@pytest.mark.unit
+def test_wakeword_listener_fallback_activation_events_emitted():
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_PEAK_MAX,
+        _UNRELIABLE_RMS_MAX,
+    )
+
+    events_emitted: list[str] = []
+
+    def event_callback(payload: dict) -> None:
+        extra = payload.get("extra", {})
+        if isinstance(extra, dict):
+            event_name = str(extra.get("event", ""))
+            if event_name:
+                events_emitted.append(event_name)
+
+    def fallback_detector(_frame):
+        return _quiet_result(triggered=False, confidence=0.1)
+
+    def fallback_factory():
+        return fallback_detector, None, "hey jarvis"
+
+    def detector(_frame):
+        return _quiet_result(
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 0.5,
+            peak=_UNRELIABLE_PEAK_MAX * 0.5,
+        )
+
+    async def run():
+        call_count = 0
+        listener = WakeWordListener(
+            detector,
+            poll_interval=0,
+            unreliable_silence_enabled=True,
+            fallback_detector_factory=fallback_factory,
+            fallback_keyword="hey jarvis",
+            fallback_backend="openwakeword",
+            event_callback=event_callback,
+        )
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            if call_count > _UNRELIABLE_MIN_FRAMES + 1:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _ in listener.listen(source):
+            break
+
+    asyncio.run(run())
+    assert "high_confidence_silence" in events_emitted
+    assert "wakeword_backend_fallback_activated" in events_emitted
+
+
+@pytest.mark.unit
+def test_wakeword_listener_no_second_activation_after_unreliable():
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_PEAK_MAX,
+        _UNRELIABLE_RMS_MAX,
+    )
+
+    factory_calls: list[int] = []
+
+    def fallback_detector(_frame):
+        return _quiet_result(triggered=False, confidence=0.1)
+
+    def fallback_factory():
+        factory_calls.append(1)
+        return fallback_detector, None, "hey jarvis"
+
+    def detector(_frame):
+        return _quiet_result(
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 0.5,
+            peak=_UNRELIABLE_PEAK_MAX * 0.5,
+        )
+
+    state: dict = {}
+
+    async def run():
+        call_count = 0
+        # Run 3× MIN_FRAMES to ensure we'd see a second activation if the guard failed.
+        listener = WakeWordListener(
+            detector,
+            poll_interval=0,
+            unreliable_silence_enabled=True,
+            fallback_detector_factory=fallback_factory,
+            fallback_keyword="hey jarvis",
+            fallback_backend="openwakeword",
+        )
+        state["listener"] = listener
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            if call_count > _UNRELIABLE_MIN_FRAMES * 3:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _ in listener.listen(source):
+            break
+
+    asyncio.run(run())
+    assert factory_calls == [1], "fallback factory must be called exactly once"
+
+
+@pytest.mark.unit
+def test_wakeword_listener_trigger_suppressed_on_activation_frame():
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_PEAK_MAX,
+        _UNRELIABLE_RMS_MAX,
+    )
+
+    # Detector: not triggered on frames 1 to N-1, triggered on frame N (activation frame).
+    # The activation frame should be suppressed — no yield.
+    frames_yielded: list[int] = []
+    call_count_holder = [0]
+
+    def detector(_frame):
+        n = call_count_holder[0]
+        is_activation_frame = n >= _UNRELIABLE_MIN_FRAMES
+        return _quiet_result(
+            triggered=is_activation_frame,
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 0.5,
+            peak=_UNRELIABLE_PEAK_MAX * 0.5,
+        )
+
+    def fallback_detector(_frame):
+        return _quiet_result(triggered=False, confidence=0.1)
+
+    def fallback_factory():
+        return fallback_detector, None, "hey jarvis"
+
+    async def run():
+        call_count = 0
+        listener = WakeWordListener(
+            detector,
+            poll_interval=0,
+            unreliable_silence_enabled=True,
+            fallback_detector_factory=fallback_factory,
+            fallback_keyword="hey jarvis",
+            fallback_backend="openwakeword",
+        )
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            call_count_holder[0] = call_count
+            if call_count > _UNRELIABLE_MIN_FRAMES + 2:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _frame in listener.listen(source):
+            frames_yielded.append(1)
+            break  # stop after first yield if any
+
+    asyncio.run(run())
+    assert frames_yielded == [], "activation frame must be suppressed — no yield expected"
+
+
+@pytest.mark.unit
+def test_wakeword_listener_self_test_inactive_after_window_elapsed():
+    """Quiet high-confidence frames outside the self-test window are ignored."""
+    import time as _time
+
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_PEAK_MAX,
+        _UNRELIABLE_RMS_MAX,
+        _UNRELIABLE_WINDOW_S,
+    )
+
+    factory_calls: list[int] = []
+
+    def fallback_factory():
+        factory_calls.append(1)
+        return (lambda _frame: _quiet_result(confidence=0.1)), None, "hey jarvis"
+
+    def detector(_frame):
+        return _quiet_result(
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 0.5,
+            peak=_UNRELIABLE_PEAK_MAX * 0.5,
+        )
+
+    state: dict = {}
+
+    async def run():
+        call_count = 0
+        listener = WakeWordListener(
+            detector,
+            poll_interval=0,
+            unreliable_silence_enabled=True,
+            fallback_detector_factory=fallback_factory,
+            fallback_keyword="hey jarvis",
+            fallback_backend="openwakeword",
+        )
+        state["listener"] = listener
+        listener.mark_listening_started(reason="test")
+        # Simulate a listening cycle that started well past the self-test window.
+        listener._listening_started_at = _time.monotonic() - (_UNRELIABLE_WINDOW_S + 5.0)
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            if call_count > _UNRELIABLE_MIN_FRAMES * 2:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _ in listener.listen(source):
+            break
+
+    asyncio.run(run())
+    assert state["listener"]._model_marked_unreliable is False
+    assert state["listener"]._high_confidence_quiet_frames == 0
+    assert factory_calls == []
+
+
+@pytest.mark.unit
+def test_wakeword_listener_stays_on_fallback_across_cycles():
+    """A model marked unreliable stays on the fallback in later cycles."""
+    from rex.wakeword.listener import (
+        _UNRELIABLE_CONFIDENCE_THRESHOLD,
+        _UNRELIABLE_MIN_FRAMES,
+        _UNRELIABLE_PEAK_MAX,
+        _UNRELIABLE_RMS_MAX,
+    )
+
+    factory_calls: list[int] = []
+
+    def fallback_detector(_frame):
+        return _quiet_result(triggered=False, confidence=0.1)
+
+    def fallback_factory():
+        factory_calls.append(1)
+        return fallback_detector, None, "hey jarvis"
+
+    def detector(_frame):
+        return _quiet_result(
+            confidence=_UNRELIABLE_CONFIDENCE_THRESHOLD + 0.01,
+            rms=_UNRELIABLE_RMS_MAX * 0.5,
+            peak=_UNRELIABLE_PEAK_MAX * 0.5,
+        )
+
+    state: dict = {}
+
+    async def run_cycle(listener, frames):
+        call_count = 0
+
+        async def source():
+            nonlocal call_count
+            call_count += 1
+            if call_count > frames:
+                listener.stop()
+            return np.zeros(16000, dtype=np.float32)
+
+        async for _ in listener.listen(source):
+            break
+
+    async def run():
+        listener = WakeWordListener(
+            detector,
+            poll_interval=0,
+            unreliable_silence_enabled=True,
+            fallback_detector_factory=fallback_factory,
+            fallback_keyword="hey jarvis",
+            fallback_backend="openwakeword",
+        )
+        state["listener"] = listener
+        # First cycle: enough quiet high-confidence frames to activate fallback.
+        await run_cycle(listener, _UNRELIABLE_MIN_FRAMES + 1)
+        assert listener._model_marked_unreliable is True
+        assert factory_calls == [1]
+
+        # New listening cycle: counter resets but the fallback stays active.
+        listener.mark_listening_started(reason="post_interaction_reset")
+        assert listener._model_marked_unreliable is True
+        assert listener._high_confidence_quiet_frames == 0
+        assert listener._backend == "openwakeword"
+        assert listener._keyword == "hey jarvis"
+
+        # Second cycle sees more quiet frames; no second activation may fire.
+        await run_cycle(listener, _UNRELIABLE_MIN_FRAMES * 2)
+
+    asyncio.run(run())
+    assert state["listener"]._model_marked_unreliable is True
+    assert factory_calls == [1]
+    assert state["listener"]._backend == "openwakeword"


### PR DESCRIPTION
## Summary

Adds a runtime "unreliable custom wake model" self-test with automatic fallback to the builtin openWakeWord detector — the highest-value hardware-independent item for issue #304, salvaged from the wake-word stashes and ported onto the current listener.

**Problem:** a custom-embedding wake model that fires high-confidence on silence (a common failed-training outcome) produces constant false wakes for the entire session. Master only has *load-time* fallback; nothing detects a model that loads fine but is broken at runtime.

**Behavior:** during the first 10 seconds of each listening cycle (`_UNRELIABLE_WINDOW_S`), frames where the detector reports confidence ≥ 0.85 on effectively silent audio (RMS ≤ 0.006, peak ≤ 0.025) are counted. At 5 such frames (`_UNRELIABLE_MIN_FRAMES`) the model is marked unreliable: `high_confidence_silence` / `custom_wake_model_unreliable` warning events are emitted, and if a fallback factory is configured the builtin openWakeWord detector (with `wakeword.fallback_keyword`, default "hey jarvis") is loaded in an executor and swapped in (`wakeword_backend_fallback_activated`). The activation frame is suppressed so no false STT capture fires. A model once marked unreliable stays on the fallback across listening cycles. Without a fallback factory (`fallback_to_builtin: false`), the model is marked in logs but keeps running (no silent behavior change).

`build_default_detector` wires the factory automatically for `custom_embedding` backends and logs `unreliable_silence_enabled` / `fallback_factory_available` in the `wakeword_listener_configured` record.

## Salvage provenance

- Core implementation + 7 tests: stash `salvage: frosty-johnson-aed812` (the only stash variant whose fallback actually swaps the detector; the others relabel without swapping or lack tests).
- Time-boxed self-test window: design refinement from stash `salvage: busy-ardinghelli-5b1a81`.
- Troubleshooting docs: adapted from `busy-ardinghelli` and corrected to match the shipped thresholds and current `rex_config.json` keys.
- Rejected: stash `infallible-shtern-5debb4` listener (relabel-only fallback, factory never wired — non-functional draft); frosty's `rex_voice_bridge.py` rewrite (predates the bridge/ split; root file is now a thin exec wrapper); frosty's GUI diffs (stale; UI plumbing deferred until events are consumed). No stashes were applied, popped, or dropped.

## Tests

`tests/test_wakeword_listener_runtime.py` grows from 7 to 16 tests: the 7 salvaged fallback tests (activation at threshold, no activation below threshold, loud audio not counted, factory invoked, events emitted, single activation, activation-frame suppression) plus 2 added after fresh-context review flagged coverage gaps — the 10-second window boundary (frames outside the window are ignored) and cross-cycle fallback persistence (`mark_listening_started` resets the counter but never un-marks the model; factory fires exactly once).

## Verification (local, Python 3.11.9)

```
pytest -q tests/test_wakeword_listener_runtime.py            # 16 passed
pytest -q tests/*wakeword* tests/*wake_*                     # 140 passed
pytest -q                                                    # full suite: 7338 passed, 94 skipped,
    # 1 failed: test_us098_test_coverage.py::test_coverage_txt_exists (pre-existing environmental —
    # asserts the locally generated coverage.txt exists; generated by CI itself; identical on master)
ruff check / black --check                                   # clean
mypy rex --ignore-missing-imports                            # Success: no issues found in 335 source files
```

Fresh-context review confirmed: suppression hits exactly the activation frame; post-interaction rebuild cannot reinstate the unreliable custom model (the rebuild factory is replaced atomically); the window/counter reset paths are exercised by all six real `mark_listening_started` call sites in `rex/voice/loop.py`; docs constants match code exactly. Its two substantive findings (untested window boundary, untested cross-cycle persistence) were fixed by the 2 added tests.

Part of #304 — remaining #304 items (live measurement matrix, false-positive rates in real rooms, mic-hardware variants) require physical hardware and stay open.
