### PR TITLE
docs(readme): document logs endpoint auth requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Files under `docs/archive/` are historical development records and may intention
 - Keep secrets in `.env` or `config/credentials.json`; do not put them in `config/rex_config.json`.
 - `rex-speak-api` requires `REX_SPEAK_API_KEY`.
 - `rex-tool-server` requires `REX_TOOL_API_KEY` for tool invocation.
+- The GUI backend's log endpoints (`/api/logs/stream`, `/api/logs/download`) require a `REX_PROXY_TOKEN` Bearer token and redact home-directory paths from served log content. See [docs/configuration.md](docs/configuration.md).
 - Approval-gated high-risk actions, such as WooCommerce writes and remote PC commands, require explicit confirmation flows.
 
 ### Security baseline


### PR DESCRIPTION
## Summary

Adds the one missing documentation line for **US-023** (authenticate the logs download endpoint): README's Security section now states that `/api/logs/stream` and `/api/logs/download` require a `REX_PROXY_TOKEN` Bearer token and redact home-directory paths, linking to [docs/configuration.md](https://github.com/Blueibear/AskRex-Assistant/blob/master/docs/configuration.md).

Per the 2026-07-08 reconciliation (PR #308), US-023's implementation and tests were already complete on master (`rex/routes/logs.py` `_require_auth()` + redaction; `tests/test_rr008_log_auth.py` asserts 401 for both routes) — the README mention was the only remaining gap.

## Sequencing note

The US-023 acceptance checkbox lives in `PRD-production-readiness.md`, which PR #308 rewrites in the same region; flipping it here would guarantee a merge conflict. Once #308 and this PR both merge, the docs box (and the story's final checks-pass box) can be checked in a one-line follow-up.

## Verification

Single-line README change; no code paths affected. `grep -n 'REX_PROXY_TOKEN' README.md` now returns the new Security bullet.