### PR TITLE
fix(suggestions): isolate SuggestionEngine pending state per user

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,6 +406,7 @@ Add a short rule here that would have prevented the mistake.
 - Direct Ruff and Black installations in CI must use the same revisions as `.pre-commit-config.yaml`; never install unpinned formatters in a required check.
 - The repository dependency security gate must audit the local project explicitly with `pip-audit --strict .`; a bare `pip-audit` audits the runner environment and is not an acceptable project gate.
 - Python releases use `release-please-config.json` plus `.release-please-manifest.json` with the `python` release strategy. Keep the manifest and `pyproject.toml` package version synchronized.
+- Session/user state on long-lived components wired into `Assistant` (engines, caches, in-memory logs) must be keyed by `user_id` in a dict, never held as plain instance attributes — one `Assistant` serves multiple identified users per request via `_begin_request`. Mirror the `FollowupEngine`/`SuggestionEngine` pattern: every stateful public method takes an explicit `user_id`, validates it via `rex.identity.validate_user_id`, and fails closed (no-op, never a default-user fallback) on missing or invalid identity.
 
 ## OpenClaw Migration Status
 

--- a/rex/actions/dispatcher.py
+++ b/rex/actions/dispatcher.py
@@ -70,7 +70,8 @@ class ActionDispatcher:
         music_handler:        Optional :class:`~rex.music_handler.MusicHandler`.
         device_state_handler: Optional :class:`~rex.ha.state_handler.DeviceStateHandler`.
         suggestion_engine:    Optional proactive suggestion engine.
-        pattern_entries:      Shared mutable list of PatternEntry objects for suggestion detection.
+        pattern_entries:      Mutable dict mapping user_id to that user's list of
+                              PatternEntry objects for suggestion detection (issue #303).
         build_tool_context_fn: Callable returning ``{"location": ..., "timezone": ...}`` dict.
         model_call_fn_builder: Callable ``(transcript) -> model_call_fn`` used for tool re-prompts.
         run_plugins_fn:       Async callable ``(transcript) -> list[str]`` for plugin enrichments.
@@ -91,7 +92,7 @@ class ActionDispatcher:
         music_handler: Any = None,
         device_state_handler: Any = None,
         suggestion_engine: Any = None,
-        pattern_entries: list | None = None,
+        pattern_entries: dict | None = None,
         build_tool_context_fn: Callable[[], dict] | None = None,
         model_call_fn_builder: Callable[[str], Any] | None = None,
         run_plugins_fn: Callable[..., Awaitable[list[str]]] | None = None,
@@ -108,7 +109,8 @@ class ActionDispatcher:
         self._music_handler = music_handler
         self._device_state_handler = device_state_handler
         self._suggestion_engine = suggestion_engine
-        self._pattern_entries: list = pattern_entries if pattern_entries is not None else []
+        # Per-user command log for pattern detection, keyed by user_id (#303)
+        self._pattern_entries: dict = pattern_entries if pattern_entries is not None else {}
         self._build_tool_context_fn = build_tool_context_fn
         self._model_call_fn_builder = model_call_fn_builder
         self._run_plugins_fn = run_plugins_fn
@@ -242,7 +244,7 @@ class ActionDispatcher:
                             _last = _cmd_hist._entries[-1]
                             from rex.suggestions.pattern_detector import PatternEntry
 
-                            self._pattern_entries.append(
+                            self._pattern_entries.setdefault(effective_user, []).append(
                                 PatternEntry(
                                     entity_id=_last.entity_id,
                                     service=_last.service,
@@ -255,8 +257,12 @@ class ActionDispatcher:
                         try:
                             from rex.suggestions.pattern_detector import detect_patterns
 
-                            _patterns = detect_patterns(self._pattern_entries)
-                            _sug = self._suggestion_engine.get_suggestion(_patterns)
+                            _patterns = detect_patterns(
+                                self._pattern_entries.get(effective_user, [])
+                            )
+                            _sug = self._suggestion_engine.get_suggestion(
+                                _patterns, user_id=effective_user
+                            )
                             if _sug is not None:
                                 _, _spoken = _sug
                                 completion = f"{completion} {_spoken}"

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -248,8 +248,10 @@ class Assistant:
             dismissed_path=_dismissed_path,
             automations_path=_automations_path,
         )
-        # In-memory command log for pattern detection (wall-clock timestamps)
-        self._pattern_entries: list[PatternEntry] = []
+        # In-memory command log for pattern detection (wall-clock timestamps),
+        # keyed by user_id so one user's commands never seed another user's
+        # suggestions (issue #303).
+        self._pattern_entries: dict[str, list[PatternEntry]] = {}
 
         # Response builder: cache, TTS cleaning, suggestions, followups (US-017)
         from .response.builder import ResponseBuilder
@@ -603,6 +605,7 @@ class Assistant:
             transcript,
             settings=self._settings,
             suggestion_engine=getattr(self, "_suggestion_engine", None),
+            user_id=effective_user_id,
         )
         if _intent.handled:
             # Greeting shortcuts are suppressed in multi-user voice sessions

--- a/rex/intent/router.py
+++ b/rex/intent/router.py
@@ -118,6 +118,7 @@ class IntentRouter:
         *,
         settings: Any = None,
         suggestion_engine: Any = None,
+        user_id: str | None = None,
     ) -> IntentResult:
         """Check *user_message* for recognized shortcut intents.
 
@@ -134,6 +135,10 @@ class IntentRouter:
             suggestion_engine: Optional proactive suggestion engine; intercepts
                                yes/no responses while a suggestion is pending
                                (US-018).
+            user_id:           The user this turn belongs to.  The pending
+                               suggestion intercept is scoped to this user only
+                               (issue #303); without it the intercept is skipped
+                               entirely (fail closed).
         """
         text = user_message.strip()
         if not text:
@@ -158,13 +163,21 @@ class IntentRouter:
             except Exception as exc:
                 logger.debug("Capability query check failed: %s", exc)
 
-        # Pending suggestion yes/no intercept
-        if suggestion_engine is not None and getattr(suggestion_engine, "has_pending", False):
+        # Pending suggestion yes/no intercept, scoped to the requesting user
+        # (issue #303).  Without an identified user the intercept is skipped
+        # so nobody can accept or dismiss someone else's suggestion.
+        _has_pending = False
+        if suggestion_engine is not None and user_id:
+            try:
+                _has_pending = bool(suggestion_engine.has_pending(user_id))
+            except Exception as exc:
+                logger.debug("suggestion has_pending check failed: %s", exc)
+        if _has_pending:
             if getattr(suggestion_engine, "is_accept", None) and suggestion_engine.is_accept(text):
                 try:
                     return IntentResult(
                         handled=True,
-                        response=str(suggestion_engine.handle_yes()),
+                        response=str(suggestion_engine.handle_yes(user_id)),
                         intent_type="suggestion_accept",
                     )
                 except Exception as exc:
@@ -175,7 +188,7 @@ class IntentRouter:
                 try:
                     return IntentResult(
                         handled=True,
-                        response=str(suggestion_engine.handle_dismiss()),
+                        response=str(suggestion_engine.handle_dismiss(user_id)),
                         intent_type="suggestion_dismiss",
                     )
                 except Exception as exc:

--- a/rex/response/builder.py
+++ b/rex/response/builder.py
@@ -129,7 +129,7 @@ class ResponseBuilder:
         """
         text = action_result.response
         tts_text = _clean_for_tts(text)
-        suggestions = self._get_suggestions()
+        suggestions = self._get_suggestions(user_id)
         followups = self._get_followups()
 
         # Cache PUT: store result so identical future queries skip the LLM.
@@ -151,17 +151,19 @@ class ResponseBuilder:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _get_suggestions(self) -> list[str]:
-        """Return any pending suggestion text from the suggestion engine."""
+    def _get_suggestions(self, user_id: str | None = None) -> list[str]:
+        """Return *user_id*'s pending suggestion text from the suggestion engine.
+
+        Pending suggestions are per-user (issue #303); without a *user_id* no
+        suggestion is surfaced (fail closed).
+        """
         engine = self._suggestion_engine
-        if engine is None:
+        if engine is None or not user_id:
             return []
         try:
-            pending = getattr(engine, "_pending", None)
-            if pending and isinstance(pending, dict):
-                spoken = pending.get("spoken_text")
-                if spoken:
-                    return [str(spoken)]
+            spoken = engine.pending_spoken_text(user_id)
+            if spoken:
+                return [str(spoken)]
         except Exception as exc:
             logger.debug("Failed to get suggestions from engine: %s", exc)
         return []

--- a/rex/suggestions/engine.py
+++ b/rex/suggestions/engine.py
@@ -1,13 +1,30 @@
 """Proactive suggestion engine — surfaces one automation suggestion per session.
 
 Workflow:
-1. Caller passes a list of detected patterns (from :func:`detect_patterns`).
+1. Caller passes a list of detected patterns (from :func:`detect_patterns`)
+   together with the ``user_id`` whose command history produced them.
 2. :meth:`SuggestionEngine.get_suggestion` returns ``(key, spoken_text)`` for
    the first eligible pattern, or ``None`` if nothing is due.
 3. The assistant speaks *spoken_text* and waits for the user to reply.
 4. On "yes" → :meth:`handle_yes` saves the automation entry.
    On "no thanks" → :meth:`handle_dismiss` records the dismissal so the same
    pattern is skipped for the next 30 days.
+
+Per-user isolation (issue #303): all session state (pending suggestion,
+one-per-session flag) and persisted dismissals are keyed by ``user_id`` so one
+user can never see, accept, or dismiss another user's suggestion.  A missing
+or invalid ``user_id`` fails closed: no suggestion is surfaced and no pending
+state is consumed.
+
+Persisted file formats:
+
+- ``dismissed_suggestions.json`` — ``{"users": {"<user_id>": {"<key>": ts}}}``.
+  The legacy flat format ``{"<key>": ts}`` predates per-user scoping and is
+  read as belonging to the ``"default"`` user (never silently shared with
+  other users).
+- ``automations.json`` — list of entries; entries now carry a ``"user_id"``
+  field recording who accepted the suggestion.  Legacy entries without the
+  field are left untouched and treated as unattributed.
 """
 
 from __future__ import annotations
@@ -24,6 +41,14 @@ _DISMISS_WINDOW_DAYS: int = 30
 _DEFAULT_DISMISSED_PATH = Path("data/dismissed_suggestions.json")
 _DEFAULT_AUTOMATIONS_PATH = Path("data/automations.json")
 
+# Top-level key of the per-user dismissed-suggestions file format.  Pattern
+# keys always contain a ":" (``"<entity_id>:<service>"``) so a bare "users"
+# key can never collide with a legacy flat entry.
+_DISMISSED_USERS_KEY = "users"
+
+# User that legacy (pre-per-user) dismissal entries are attributed to.
+_LEGACY_DISMISSED_USER = "default"
+
 # Lowercased words/phrases that count as acceptance
 _ACCEPT_WORDS: frozenset[str] = frozenset(
     {"yes", "yeah", "yep", "sure", "ok", "okay", "do it", "automate it", "please do"}
@@ -35,11 +60,14 @@ _DISMISS_WORDS: frozenset[str] = frozenset(
 
 
 class SuggestionEngine:
-    """Surfaces proactive automation suggestions, one per session.
+    """Surfaces proactive automation suggestions, one per user per session.
+
+    All stateful methods take an explicit ``user_id`` and operate only on that
+    user's slice of state, mirroring :class:`rex.followup_engine.FollowupEngine`.
 
     Args:
         dismissed_path: Path to JSON file that persists dismissed pattern keys
-            with their dismissal timestamps.  Created on first write.
+            per user with their dismissal timestamps.  Created on first write.
         automations_path: Path to JSON file that persists accepted automations.
             Created on first write.
     """
@@ -51,23 +79,69 @@ class SuggestionEngine:
     ) -> None:
         self._dismissed_path = Path(dismissed_path or _DEFAULT_DISMISSED_PATH)
         self._automations_path = Path(automations_path or _DEFAULT_AUTOMATIONS_PATH)
-        # At most one suggestion per session
-        self._suggested_this_session: bool = False
-        # Stores the active pending suggestion while waiting for user response
-        self._pending: dict[str, Any] | None = None
+        # At most one suggestion per user per session, keyed by user_id
+        self._suggested_this_session: dict[str, bool] = {}
+        # Active pending suggestion awaiting a response, keyed by user_id
+        self._pending: dict[str, dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Identity guard
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _valid_user(user_id: str | None) -> str | None:
+        """Return a validated user ID, or ``None`` to fail closed.
+
+        Missing, empty, or malformed identities must never fall through to a
+        default or another user's state (issue #303).
+        """
+        if not isinstance(user_id, str) or not user_id:
+            return None
+        # Lazy import: rex.identity loads rex.config.settings at module import
+        # time; deferring keeps this module free of config side effects.
+        from rex.identity import validate_user_id
+
+        try:
+            return validate_user_id(user_id)
+        except ValueError:
+            logger.warning("suggestions: ignoring invalid user_id %r", user_id)
+            return None
 
     # ------------------------------------------------------------------
     # Public query API
     # ------------------------------------------------------------------
 
-    @property
-    def has_pending(self) -> bool:
-        """True when a suggestion has been spoken and awaits a user response."""
-        return self._pending is not None
+    def has_pending(self, user_id: str | None) -> bool:
+        """True when a suggestion was spoken to *user_id* and awaits their response."""
+        uid = self._valid_user(user_id)
+        return uid is not None and uid in self._pending
 
-    def is_dismissed(self, key: str, window_days: int = _DISMISS_WINDOW_DAYS) -> bool:
-        """Return ``True`` if *key* was dismissed within *window_days* days."""
-        dismissed = self._load_dismissed()
+    def pending_spoken_text(self, user_id: str | None) -> str | None:
+        """Return the spoken text of *user_id*'s pending suggestion, if any."""
+        uid = self._valid_user(user_id)
+        if uid is None:
+            return None
+        pending = self._pending.get(uid)
+        if pending is None:
+            return None
+        spoken = pending.get("spoken_text")
+        return str(spoken) if spoken else None
+
+    def is_dismissed(
+        self,
+        key: str,
+        user_id: str | None,
+        window_days: int = _DISMISS_WINDOW_DAYS,
+    ) -> bool:
+        """Return ``True`` if *user_id* dismissed *key* within *window_days* days.
+
+        An invalid *user_id* fails closed by reporting the key as dismissed,
+        so nothing is surfaced to an unidentified caller.
+        """
+        uid = self._valid_user(user_id)
+        if uid is None:
+            return True
+        dismissed = self._load_dismissed(uid)
         ts = dismissed.get(key)
         if ts is None:
             return False
@@ -90,28 +164,34 @@ class SuggestionEngine:
     def get_suggestion(
         self,
         patterns: list[dict[str, Any]],
+        user_id: str | None,
     ) -> tuple[str, str] | None:
         """Return ``(key, spoken_text)`` for the first eligible pattern.
 
         Returns ``None`` when:
-        - A suggestion was already made this session.
-        - All patterns have been dismissed within the last 30 days.
+        - *user_id* is missing or invalid (fail closed).
+        - A suggestion was already made to *user_id* this session.
+        - All patterns were dismissed by *user_id* within the last 30 days.
         - *patterns* is empty.
 
-        Side effect: marks *_suggested_this_session* and sets *_pending* so that
-        a subsequent call to :meth:`handle_yes` or :meth:`handle_dismiss` knows
-        which pattern is being answered.
+        Side effect: marks *user_id* in *_suggested_this_session* and stores
+        their *_pending* entry so a subsequent :meth:`handle_yes` or
+        :meth:`handle_dismiss` for the same user knows which pattern is being
+        answered.
         """
-        if self._suggested_this_session or not patterns:
+        uid = self._valid_user(user_id)
+        if uid is None:
+            return None
+        if self._suggested_this_session.get(uid) or not patterns:
             return None
 
         for pattern in patterns:
             key = _pattern_key(pattern)
-            if self.is_dismissed(key):
+            if self.is_dismissed(key, uid):
                 continue
             spoken = _build_spoken_text(pattern)
-            self._suggested_this_session = True
-            self._pending = {
+            self._suggested_this_session[uid] = True
+            self._pending[uid] = {
                 "key": key,
                 "spoken_text": spoken,
                 "automation": pattern.get("suggested_automation", ""),
@@ -120,19 +200,22 @@ class SuggestionEngine:
 
         return None
 
-    def handle_yes(self) -> str:
-        """Accept the pending suggestion and persist the automation entry.
+    def handle_yes(self, user_id: str | None) -> str:
+        """Accept *user_id*'s pending suggestion and persist the automation entry.
 
-        Returns a confirmation string suitable for TTS.  No-op when there is no
-        pending suggestion.
+        Returns a confirmation string suitable for TTS.  No-op when *user_id*
+        is invalid or has no pending suggestion — another user's pending state
+        is never consumed.
         """
-        pending = self._pending
+        uid = self._valid_user(user_id)
+        if uid is None:
+            return "No pending suggestion to accept."
+        pending = self._pending.pop(uid, None)
         if pending is None:
             return "No pending suggestion to accept."
 
         key = pending["key"]
         automation = pending["automation"]
-        self._pending = None
 
         try:
             automations: list[dict[str, Any]] = []
@@ -144,55 +227,87 @@ class SuggestionEngine:
                 {
                     "key": key,
                     "automation": automation,
+                    "user_id": uid,
                     "created_at": time.time(),
                 }
             )
             self._automations_path.parent.mkdir(parents=True, exist_ok=True)
             self._automations_path.write_text(json.dumps(automations, indent=2), encoding="utf-8")
-            logger.info("Automation saved: %s", automation)
+            logger.info("Automation saved for user %s: %s", uid, automation)
         except Exception as exc:  # pragma: no cover - defensive I/O guard
             logger.warning("Could not save automation: %s", exc)
 
         return "Great, I've set that up for you!"
 
-    def handle_dismiss(self) -> str:
-        """Dismiss the pending suggestion for 30 days.
+    def handle_dismiss(self, user_id: str | None) -> str:
+        """Dismiss *user_id*'s pending suggestion for 30 days.
 
-        Returns a confirmation string suitable for TTS.  No-op when there is no
-        pending suggestion.
+        Returns a confirmation string suitable for TTS.  No-op when *user_id*
+        is invalid or has no pending suggestion — another user's pending state
+        is never consumed, and the dismissal only applies to *user_id*.
         """
-        pending = self._pending
+        uid = self._valid_user(user_id)
+        if uid is None:
+            return "No pending suggestion."
+        pending = self._pending.pop(uid, None)
         if pending is None:
             return "No pending suggestion."
 
         key = pending["key"]
-        self._pending = None
 
-        dismissed = self._load_dismissed()
+        dismissed = self._load_dismissed(uid)
         dismissed[key] = time.time()
-        self._save_dismissed(dismissed)
-        logger.info("Suggestion dismissed: %s", key)
+        self._save_dismissed(uid, dismissed)
+        logger.info("Suggestion dismissed by user %s: %s", uid, key)
 
         return "Got it, I won't suggest that again for a while."
+
+    def reset_session(self, user_id: str | None) -> None:
+        """Clear the one-per-session flag for *user_id* (e.g. on a new session)."""
+        uid = self._valid_user(user_id)
+        if uid is not None:
+            self._suggested_this_session.pop(uid, None)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _load_dismissed(self) -> dict[str, float]:
+    def _load_dismissed_all(self) -> dict[str, dict[str, float]]:
+        """Load the full per-user dismissal map, migrating the legacy format.
+
+        Legacy flat files (``{"<key>": ts}``) predate per-user scoping and are
+        attributed to the ``"default"`` user rather than shared across users.
+        """
         try:
             if self._dismissed_path.exists():
                 data = json.loads(self._dismissed_path.read_text(encoding="utf-8"))
                 if isinstance(data, dict):
-                    return {str(k): float(v) for k, v in data.items()}
+                    users = data.get(_DISMISSED_USERS_KEY)
+                    if isinstance(users, dict):
+                        return {
+                            str(user): {str(k): float(v) for k, v in entries.items()}
+                            for user, entries in users.items()
+                            if isinstance(entries, dict)
+                        }
+                    if data:
+                        legacy = {str(k): float(v) for k, v in data.items()}
+                        return {_LEGACY_DISMISSED_USER: legacy}
         except Exception as exc:
             logger.warning("Could not load dismissed suggestions: %s", exc)
         return {}
 
-    def _save_dismissed(self, dismissed: dict[str, float]) -> None:
+    def _load_dismissed(self, user_id: str) -> dict[str, float]:
+        return self._load_dismissed_all().get(user_id, {})
+
+    def _save_dismissed(self, user_id: str, dismissed: dict[str, float]) -> None:
         try:
+            all_users = self._load_dismissed_all()
+            all_users[user_id] = dismissed
             self._dismissed_path.parent.mkdir(parents=True, exist_ok=True)
-            self._dismissed_path.write_text(json.dumps(dismissed, indent=2), encoding="utf-8")
+            self._dismissed_path.write_text(
+                json.dumps({_DISMISSED_USERS_KEY: all_users}, indent=2),
+                encoding="utf-8",
+            )
         except Exception as exc:
             logger.warning("Could not save dismissed suggestions: %s", exc)
 

--- a/tests/test_suggestion_isolation.py
+++ b/tests/test_suggestion_isolation.py
@@ -1,0 +1,415 @@
+"""Per-user isolation tests for the proactive suggestion pipeline (issue #303).
+
+Proves that one user can never see, accept, or dismiss another user's
+suggestion, that pattern entries feeding suggestion content are scoped per
+user, and that missing or invalid identity fails closed.
+
+Covers:
+- SuggestionEngine: pending state, session flag, and dismissals per user
+- Persistence: dismissals and accepted automations survive an engine restart
+  with per-user attribution intact
+- IntentRouter: the yes/no intercept only fires for the pending suggestion's
+  owner
+- ResponseBuilder: pending suggestion text is surfaced only to its owner
+- ActionDispatcher: pattern entries are recorded under the requesting user
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from rex.actions.dispatcher import ActionDispatcher
+from rex.intent.router import IntentRouter
+from rex.response.builder import ResponseBuilder
+from rex.suggestions.engine import SuggestionEngine
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pattern(
+    entity_id: str = "light.kitchen_ceiling",
+    service: str = "turn_on",
+    start_hour: int = 7,
+    frequency: int = 5,
+) -> dict[str, Any]:
+    return {
+        "pattern": f"{service} {entity_id} around {start_hour:02d}:00",
+        "frequency": frequency,
+        "suggested_automation": f"Automate: {service} {entity_id} daily at {start_hour:02d}:00",
+        "entity_id": entity_id,
+        "service": service,
+        "start_hour": start_hour,
+    }
+
+
+def _make_engine(tmp_path: Path) -> SuggestionEngine:
+    return SuggestionEngine(
+        dismissed_path=tmp_path / "dismissed.json",
+        automations_path=tmp_path / "automations.json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# SuggestionEngine — per-user pending state
+# ---------------------------------------------------------------------------
+
+
+class TestPendingIsolation:
+    def test_pending_suggestion_isolated_per_user(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        assert engine.get_suggestion([_make_pattern()], "alice") is not None
+        assert engine.has_pending("alice")
+        assert not engine.has_pending("bob")
+
+    def test_user_b_yes_does_not_consume_user_a_pending(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+
+        reply = engine.handle_yes("bob")
+
+        assert "no pending" in reply.lower()
+        # Alice's pending suggestion is untouched and still accepted by her
+        assert engine.has_pending("alice")
+        assert not (tmp_path / "automations.json").exists()
+        assert "set that up" in engine.handle_yes("alice").lower()
+
+    def test_user_b_dismiss_does_not_consume_user_a_pending(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+
+        reply = engine.handle_dismiss("bob")
+
+        assert "no pending" in reply.lower()
+        assert engine.has_pending("alice")
+        assert not (tmp_path / "dismissed.json").exists()
+
+    def test_session_flag_is_per_user(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        patterns = [_make_pattern()]
+        assert engine.get_suggestion(patterns, "alice") is not None
+        # Alice already got her one suggestion this session; Bob still gets his
+        assert engine.get_suggestion(patterns, "alice") is None
+        assert engine.get_suggestion(patterns, "bob") is not None
+
+    def test_pending_spoken_text_scoped_to_owner(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        assert engine.pending_spoken_text("alice")
+        assert engine.pending_spoken_text("bob") is None
+
+
+# ---------------------------------------------------------------------------
+# SuggestionEngine — per-user dismissals
+# ---------------------------------------------------------------------------
+
+
+class TestDismissalIsolation:
+    def test_dismissal_scoped_to_dismissing_user(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        patterns = [_make_pattern()]
+        engine.get_suggestion(patterns, "alice")
+        engine.handle_dismiss("alice")
+
+        # Alice's dismissal must not suppress Bob's identical pattern
+        assert engine.get_suggestion(patterns, "bob") is not None
+        # ... while Alice stays suppressed in a fresh session
+        engine.reset_session("alice")
+        assert engine.get_suggestion(patterns, "alice") is None
+
+    def test_is_dismissed_per_user(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        engine.handle_dismiss("alice")
+
+        key = "light.kitchen_ceiling:turn_on"
+        assert engine.is_dismissed(key, "alice")
+        assert not engine.is_dismissed(key, "bob")
+
+
+# ---------------------------------------------------------------------------
+# Fail closed on missing / invalid identity
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosed:
+    def test_no_suggestion_without_user(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        assert engine.get_suggestion([_make_pattern()], None) is None
+        assert engine.get_suggestion([_make_pattern()], "") is None
+
+    def test_no_suggestion_for_invalid_user(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        assert engine.get_suggestion([_make_pattern()], "../evil") is None
+        assert engine.get_suggestion([_make_pattern()], "..") is None
+
+    def test_invalid_user_cannot_consume_pending(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+
+        assert "no pending" in engine.handle_yes(None).lower()
+        assert "no pending" in engine.handle_yes("../evil").lower()
+        assert "no pending" in engine.handle_dismiss(None).lower()
+        assert engine.has_pending("alice")
+
+    def test_has_pending_false_for_invalid_user(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        assert not engine.has_pending(None)
+        assert not engine.has_pending("../evil")
+
+
+# ---------------------------------------------------------------------------
+# Persistence across engine restart
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_dismissal_persists_per_user_across_restart(self, tmp_path: Path) -> None:
+        patterns = [_make_pattern()]
+        engine1 = _make_engine(tmp_path)
+        engine1.get_suggestion(patterns, "alice")
+        engine1.handle_dismiss("alice")
+
+        # Fresh engine over the same files (process restart)
+        engine2 = _make_engine(tmp_path)
+        assert engine2.get_suggestion(patterns, "alice") is None
+        assert engine2.get_suggestion(patterns, "bob") is not None
+
+    def test_automations_persist_with_owner_across_restart(self, tmp_path: Path) -> None:
+        engine1 = _make_engine(tmp_path)
+        engine1.get_suggestion([_make_pattern()], "alice")
+        engine1.handle_yes("alice")
+
+        engine2 = _make_engine(tmp_path)
+        engine2.get_suggestion([_make_pattern(entity_id="light.bedroom")], "bob")
+        engine2.handle_yes("bob")
+
+        saved = json.loads((tmp_path / "automations.json").read_text(encoding="utf-8"))
+        assert len(saved) == 2
+        owners = {entry["key"]: entry["user_id"] for entry in saved}
+        assert owners["light.kitchen_ceiling:turn_on"] == "alice"
+        assert owners["light.bedroom:turn_on"] == "bob"
+
+    def test_legacy_flat_dismissed_file_not_shared(self, tmp_path: Path) -> None:
+        """A pre-per-user flat dismissed file belongs to "default", not everyone."""
+        pattern = _make_pattern()
+        dismissed_path = tmp_path / "dismissed.json"
+        dismissed_path.write_text(
+            json.dumps({"light.kitchen_ceiling:turn_on": time.time()}),
+            encoding="utf-8",
+        )
+
+        engine = _make_engine(tmp_path)
+        assert engine.get_suggestion([pattern], "default") is None
+        assert engine.get_suggestion([pattern], "alice") is not None
+
+    def test_new_dismissal_upgrades_legacy_file_without_losing_entries(
+        self, tmp_path: Path
+    ) -> None:
+        legacy_key = "light.hallway:turn_off"
+        dismissed_path = tmp_path / "dismissed.json"
+        dismissed_path.write_text(json.dumps({legacy_key: time.time()}), encoding="utf-8")
+
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        engine.handle_dismiss("alice")
+
+        data = json.loads(dismissed_path.read_text(encoding="utf-8"))
+        assert legacy_key in data["users"]["default"]
+        assert "light.kitchen_ceiling:turn_on" in data["users"]["alice"]
+
+
+# ---------------------------------------------------------------------------
+# IntentRouter — yes/no intercept scoped to the owner
+# ---------------------------------------------------------------------------
+
+
+class TestRouterIntercept:
+    def test_owner_yes_accepts(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        router = IntentRouter()
+
+        result = router.route("yes", suggestion_engine=engine, user_id="alice")
+
+        assert result.handled
+        assert result.intent_type == "suggestion_accept"
+        assert not engine.has_pending("alice")
+
+    def test_other_user_yes_not_intercepted(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        router = IntentRouter()
+
+        result = router.route("yes", suggestion_engine=engine, user_id="bob")
+
+        # Bob's "yes" must not be treated as an answer to Alice's suggestion
+        assert result.intent_type != "suggestion_accept"
+        assert engine.has_pending("alice")
+
+    def test_other_user_no_not_intercepted(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        router = IntentRouter()
+
+        result = router.route("no thanks", suggestion_engine=engine, user_id="bob")
+
+        assert result.intent_type != "suggestion_dismiss"
+        assert engine.has_pending("alice")
+        assert not (tmp_path / "dismissed.json").exists()
+
+    def test_missing_user_id_skips_intercept(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        router = IntentRouter()
+
+        result = router.route("yes", suggestion_engine=engine)
+
+        assert result.intent_type != "suggestion_accept"
+        assert engine.has_pending("alice")
+
+
+# ---------------------------------------------------------------------------
+# ResponseBuilder — pending suggestion surfaced only to its owner
+# ---------------------------------------------------------------------------
+
+
+class TestResponseBuilderScoping:
+    def _build(self, engine: SuggestionEngine, user_id: str | None):
+        rb = ResponseBuilder(suggestion_engine=engine)
+        action_result = MagicMock()
+        action_result.response = "Done."
+        return rb.build(action_result, None, transcript="hi", user_id=user_id)
+
+    def test_owner_sees_pending_suggestion(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        result = self._build(engine, "alice")
+        assert result.suggestions
+        assert "Want me to automate that?" in result.suggestions[0]
+
+    def test_other_user_sees_no_suggestion(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        assert self._build(engine, "bob").suggestions == []
+
+    def test_no_user_sees_no_suggestion(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        assert self._build(engine, None).suggestions == []
+
+
+# ---------------------------------------------------------------------------
+# ActionDispatcher — pattern entries recorded per user
+# ---------------------------------------------------------------------------
+
+
+class _FakeCommandHistory:
+    """Minimal stand-in for HABridge._command_history."""
+
+    def __init__(self) -> None:
+        self._entries: list[Any] = []
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+def _make_ha_bridge(history: _FakeCommandHistory) -> MagicMock:
+    ha = MagicMock()
+    ha.enabled = True
+    ha._command_history = history
+
+    def _process(_transcript: str) -> str:
+        entry = MagicMock()
+        entry.entity_id = "light.kitchen_ceiling"
+        entry.service = "turn_on"
+        history._entries.append(entry)
+        return "Done."
+
+    ha.process_transcript.side_effect = _process
+    return ha
+
+
+class TestDispatcherPatternEntries:
+    def test_pattern_entries_recorded_under_requesting_user(self) -> None:
+        history = _FakeCommandHistory()
+        engine = MagicMock()
+        engine.get_suggestion.return_value = None
+        pattern_entries: dict[str, list] = {}
+        dispatcher = ActionDispatcher(
+            context_builder=MagicMock(),
+            llm=MagicMock(),
+            result_handler=MagicMock(),
+            ha_bridge=_make_ha_bridge(history),
+            suggestion_engine=engine,
+            pattern_entries=pattern_entries,
+        )
+
+        asyncio.run(
+            dispatcher.dispatch(None, None, "turn on the kitchen light", active_user_id="alice")
+        )
+        asyncio.run(
+            dispatcher.dispatch(None, None, "turn on the kitchen light", active_user_id="bob")
+        )
+        asyncio.run(
+            dispatcher.dispatch(None, None, "turn on the kitchen light", active_user_id="alice")
+        )
+
+        assert len(pattern_entries["alice"]) == 2
+        assert len(pattern_entries["bob"]) == 1
+
+    def test_get_suggestion_called_with_requesting_user(self) -> None:
+        history = _FakeCommandHistory()
+        engine = MagicMock()
+        engine.get_suggestion.return_value = None
+        dispatcher = ActionDispatcher(
+            context_builder=MagicMock(),
+            llm=MagicMock(),
+            result_handler=MagicMock(),
+            ha_bridge=_make_ha_bridge(history),
+            suggestion_engine=engine,
+            pattern_entries={},
+        )
+
+        asyncio.run(
+            dispatcher.dispatch(None, None, "turn on the kitchen light", active_user_id="alice")
+        )
+
+        assert engine.get_suggestion.call_count == 1
+        _, kwargs = engine.get_suggestion.call_args
+        assert kwargs["user_id"] == "alice"
+
+    def test_suggestion_derived_only_from_own_entries(self, tmp_path: Path) -> None:
+        """Three of Alice's commands never produce a suggestion for Bob."""
+        history = _FakeCommandHistory()
+        engine = _make_engine(tmp_path)
+        dispatcher = ActionDispatcher(
+            context_builder=MagicMock(),
+            llm=MagicMock(),
+            result_handler=MagicMock(),
+            ha_bridge=_make_ha_bridge(history),
+            suggestion_engine=engine,
+            pattern_entries={},
+        )
+
+        # Alice repeats the same command three times (min_occurrences)
+        for _ in range(3):
+            asyncio.run(
+                dispatcher.dispatch(None, None, "turn on the kitchen light", active_user_id="alice")
+            )
+        # Alice's own repetition triggered a pending suggestion for Alice
+        assert engine.has_pending("alice")
+
+        # Bob issues one command; his single entry can't reach the threshold,
+        # so no suggestion may leak to him from Alice's history
+        asyncio.run(
+            dispatcher.dispatch(None, None, "turn on the kitchen light", active_user_id="bob")
+        )
+        assert not engine.has_pending("bob")

--- a/tests/test_us015_intent_router.py
+++ b/tests/test_us015_intent_router.py
@@ -234,4 +234,5 @@ async def test_generate_reply_uses_intent_router_for_greeting():
         "hello",
         settings=a._settings,
         suggestion_engine=None,
+        user_id="default",
     )

--- a/tests/test_us017_response_builder.py
+++ b/tests/test_us017_response_builder.py
@@ -191,17 +191,27 @@ class TestBuild:
 
     def test_suggestions_from_pending_engine(self):
         engine = MagicMock()
-        engine._pending = {"spoken_text": "Want me to automate that?"}
+        engine.pending_spoken_text.return_value = "Want me to automate that?"
         rb = _make_builder(suggestion_engine=engine)
-        result = rb.build(_make_action_result("ok"), _make_context())
+        result = rb.build(_make_action_result("ok"), _make_context(), user_id="alice")
         assert result.suggestions == ["Want me to automate that?"]
+        engine.pending_spoken_text.assert_called_once_with("alice")
 
     def test_suggestions_empty_when_no_pending(self):
         engine = MagicMock()
-        engine._pending = None
+        engine.pending_spoken_text.return_value = None
+        rb = _make_builder(suggestion_engine=engine)
+        result = rb.build(_make_action_result("ok"), _make_context(), user_id="alice")
+        assert result.suggestions == []
+
+    def test_suggestions_empty_without_user_id(self):
+        # Fail closed: no user identity means no suggestion is surfaced (#303)
+        engine = MagicMock()
+        engine.pending_spoken_text.return_value = "Want me to automate that?"
         rb = _make_builder(suggestion_engine=engine)
         result = rb.build(_make_action_result("ok"), _make_context())
         assert result.suggestions == []
+        engine.pending_spoken_text.assert_not_called()
 
     def test_followups_empty_no_engine(self):
         rb = _make_builder()
@@ -256,7 +266,7 @@ class TestAssistantUsesResponseBuilder:
         a._response_cache = None
         a._ha_bridge = None
         a._suggestion_engine = None
-        a._pattern_entries = []
+        a._pattern_entries = {}
         return a
 
     def test_get_or_create_response_builder_returns_instance(self):

--- a/tests/test_us036_suggestions.py
+++ b/tests/test_us036_suggestions.py
@@ -1,11 +1,12 @@
 """Tests for US-036: Surface proactive suggestions to the user.
 
 Covers:
-- At most one suggestion per session
+- At most one suggestion per user per session
 - Spoken text format
-- Accept flow (yes → automation saved)
-- Dismiss flow (no thanks → dismissal recorded, not re-suggested for 30 days)
+- Accept flow (yes → automation saved, tagged with the accepting user)
+- Dismiss flow (no thanks → dismissal recorded per user, not re-suggested for 30 days)
 - Already-dismissed pattern is skipped
+- Legacy flat dismissed-file format is attributed to the "default" user
 """
 
 from __future__ import annotations
@@ -38,6 +39,13 @@ def _make_pattern(
         "service": service,
         "start_hour": start_hour,
     }
+
+
+def _make_engine(tmp_path: Path) -> SuggestionEngine:
+    return SuggestionEngine(
+        dismissed_path=tmp_path / "dismissed.json",
+        automations_path=tmp_path / "automations.json",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -104,12 +112,9 @@ class TestPatternKey:
 
 class TestGetSuggestion:
     def test_returns_key_and_spoken_text(self, tmp_path: Path) -> None:
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
+        engine = _make_engine(tmp_path)
         patterns = [_make_pattern()]
-        result = engine.get_suggestion(patterns)
+        result = engine.get_suggestion(patterns, "alice")
         assert result is not None
         key, spoken = result
         assert "light.kitchen_ceiling" in key
@@ -117,31 +122,32 @@ class TestGetSuggestion:
         assert "Want me to automate that?" in spoken
 
     def test_at_most_one_suggestion_per_session(self, tmp_path: Path) -> None:
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
+        engine = _make_engine(tmp_path)
         patterns = [_make_pattern(), _make_pattern(entity_id="light.bedroom")]
-        engine.get_suggestion(patterns)
-        # Second call in the same session must return None
-        result2 = engine.get_suggestion(patterns)
+        engine.get_suggestion(patterns, "alice")
+        # Second call in the same session must return None for the same user
+        result2 = engine.get_suggestion(patterns, "alice")
         assert result2 is None
 
     def test_empty_patterns_returns_none(self, tmp_path: Path) -> None:
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
-        assert engine.get_suggestion([]) is None
+        engine = _make_engine(tmp_path)
+        assert engine.get_suggestion([], "alice") is None
 
     def test_sets_has_pending(self, tmp_path: Path) -> None:
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
-        assert not engine.has_pending
-        engine.get_suggestion([_make_pattern()])
-        assert engine.has_pending
+        engine = _make_engine(tmp_path)
+        assert not engine.has_pending("alice")
+        engine.get_suggestion([_make_pattern()], "alice")
+        assert engine.has_pending("alice")
+
+    def test_missing_user_returns_none(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        assert engine.get_suggestion([_make_pattern()], None) is None
+        assert engine.get_suggestion([_make_pattern()], "") is None
+
+    def test_invalid_user_returns_none(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        assert engine.get_suggestion([_make_pattern()], "../evil") is None
+        assert not engine.has_pending("../evil")
 
 
 # ---------------------------------------------------------------------------
@@ -152,35 +158,27 @@ class TestGetSuggestion:
 class TestAcceptFlow:
     def test_yes_saves_automation(self, tmp_path: Path) -> None:
         automations_path = tmp_path / "automations.json"
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=automations_path,
-        )
+        engine = _make_engine(tmp_path)
         patterns = [_make_pattern()]
-        engine.get_suggestion(patterns)
+        engine.get_suggestion(patterns, "alice")
 
-        reply = engine.handle_yes()
+        reply = engine.handle_yes("alice")
 
         assert "set that up" in reply.lower() or "great" in reply.lower()
         assert automations_path.exists()
         saved = json.loads(automations_path.read_text())
         assert len(saved) == 1
         assert "light.kitchen_ceiling" in saved[0]["key"]
+        assert saved[0]["user_id"] == "alice"
 
     def test_yes_clears_pending(self, tmp_path: Path) -> None:
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
-        engine.get_suggestion([_make_pattern()])
-        engine.handle_yes()
-        assert not engine.has_pending
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        engine.handle_yes("alice")
+        assert not engine.has_pending("alice")
 
     def test_is_accept_recognises_yes(self, tmp_path: Path) -> None:
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
+        engine = _make_engine(tmp_path)
         assert engine.is_accept("yes")
         assert engine.is_accept("Yeah")
         assert engine.is_accept("Sure")
@@ -195,57 +193,59 @@ class TestAcceptFlow:
 class TestDismissFlow:
     def test_dismiss_records_to_disk(self, tmp_path: Path) -> None:
         dismissed_path = tmp_path / "dismissed.json"
-        engine = SuggestionEngine(
-            dismissed_path=dismissed_path,
-            automations_path=tmp_path / "automations.json",
-        )
+        engine = _make_engine(tmp_path)
         patterns = [_make_pattern()]
-        engine.get_suggestion(patterns)
+        engine.get_suggestion(patterns, "alice")
 
-        reply = engine.handle_dismiss()
+        reply = engine.handle_dismiss("alice")
 
         assert "won't suggest" in reply.lower() or "got it" in reply.lower()
         assert dismissed_path.exists()
         data = json.loads(dismissed_path.read_text())
-        assert any("light.kitchen_ceiling" in k for k in data)
+        assert any("light.kitchen_ceiling" in k for k in data["users"]["alice"])
 
     def test_dismissed_pattern_not_re_suggested(self, tmp_path: Path) -> None:
-        dismissed_path = tmp_path / "dismissed.json"
-        engine = SuggestionEngine(
-            dismissed_path=dismissed_path,
-            automations_path=tmp_path / "automations.json",
-        )
+        engine = _make_engine(tmp_path)
         patterns = [_make_pattern()]
-        engine.get_suggestion(patterns)
-        engine.handle_dismiss()
+        engine.get_suggestion(patterns, "alice")
+        engine.handle_dismiss("alice")
 
-        # New session (reset the session flag)
-        engine._suggested_this_session = False
-        result = engine.get_suggestion(patterns)
+        # New session (reset the per-user session flag)
+        engine.reset_session("alice")
+        result = engine.get_suggestion(patterns, "alice")
         assert result is None
 
     def test_dismissed_pattern_re_suggested_after_window(self, tmp_path: Path) -> None:
         dismissed_path = tmp_path / "dismissed.json"
-        engine = SuggestionEngine(
-            dismissed_path=dismissed_path,
-            automations_path=tmp_path / "automations.json",
-        )
+        engine = _make_engine(tmp_path)
         pattern = _make_pattern()
         key = _pattern_key(pattern)
 
         # Write a dismissal timestamp 31 days in the past
         old_ts = time.time() - (31 * 86400)
         dismissed_path.parent.mkdir(parents=True, exist_ok=True)
-        dismissed_path.write_text(json.dumps({key: old_ts}))
+        dismissed_path.write_text(json.dumps({"users": {"alice": {key: old_ts}}}))
 
-        result = engine.get_suggestion([pattern])
+        result = engine.get_suggestion([pattern], "alice")
         assert result is not None
 
+    def test_legacy_flat_dismissed_file_maps_to_default_user(self, tmp_path: Path) -> None:
+        """Pre-per-user flat files belong to "default", not to everyone."""
+        dismissed_path = tmp_path / "dismissed.json"
+        engine = _make_engine(tmp_path)
+        pattern = _make_pattern()
+        key = _pattern_key(pattern)
+
+        dismissed_path.parent.mkdir(parents=True, exist_ok=True)
+        dismissed_path.write_text(json.dumps({key: time.time()}))
+
+        # The legacy dismissal suppresses the suggestion for "default" ...
+        assert engine.get_suggestion([pattern], "default") is None
+        # ... but not for other users
+        assert engine.get_suggestion([pattern], "alice") is not None
+
     def test_is_dismiss_recognises_no_thanks(self, tmp_path: Path) -> None:
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
+        engine = _make_engine(tmp_path)
         assert engine.is_dismiss("no thanks")
         assert engine.is_dismiss("No Thanks")
         assert engine.is_dismiss("nope")
@@ -253,13 +253,10 @@ class TestDismissFlow:
         assert not engine.is_dismiss("yes")
 
     def test_dismiss_clears_pending(self, tmp_path: Path) -> None:
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
-        engine.get_suggestion([_make_pattern()])
-        engine.handle_dismiss()
-        assert not engine.has_pending
+        engine = _make_engine(tmp_path)
+        engine.get_suggestion([_make_pattern()], "alice")
+        engine.handle_dismiss("alice")
+        assert not engine.has_pending("alice")
 
 
 # ---------------------------------------------------------------------------
@@ -303,11 +300,8 @@ class TestPatternDetectorIntegration:
             for i in range(3)
         ]
         patterns = detect_patterns(entries, min_occurrences=3, time_window_hours=1.0)
-        engine = SuggestionEngine(
-            dismissed_path=tmp_path / "dismissed.json",
-            automations_path=tmp_path / "automations.json",
-        )
-        result = engine.get_suggestion(patterns)
+        engine = _make_engine(tmp_path)
+        result = engine.get_suggestion(patterns, "alice")
         assert result is not None
         _, spoken = result
         assert "kitchen ceiling" in spoken

--- a/tests/test_us038_capability_response.py
+++ b/tests/test_us038_capability_response.py
@@ -267,7 +267,7 @@ class TestAssistantCapabilityIntegration:
         assistant._ha_bridge = None
         assistant._response_cache = None
         assistant._suggestion_engine = None
-        assistant._pattern_entries = []
+        assistant._pattern_entries = {}
         assistant._user_id = "default"
         assistant._plugins = []
         assistant._transcripts_dir = __import__("pathlib").Path("/tmp/rex_test_transcripts")

--- a/tests/test_us303_user_isolation.py
+++ b/tests/test_us303_user_isolation.py
@@ -47,7 +47,7 @@ def _make_assistant(user_id: str = "default", history_store=None):
     a._response_cache = None
     a._ha_bridge = None
     a._suggestion_engine = None
-    a._pattern_entries = []
+    a._pattern_entries = {}
     return a
 
 
@@ -271,3 +271,81 @@ class TestGenerateReplyAttribution:
 
         joined = " ".join(str(m.get("content", "")) for m in captured["messages"])
         assert "hunter2" not in joined
+
+
+# ---------------------------------------------------------------------------
+# Assistant.generate_reply — pending suggestion isolation end to end
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReplySuggestionIsolation:
+    """Suggestion accept/dismiss through the full generate_reply pipeline is
+    scoped to the pending suggestion's owner (issue #303)."""
+
+    @staticmethod
+    def _pattern() -> dict:
+        return {
+            "pattern": "turn_on light.kitchen_ceiling around 07:00",
+            "frequency": 5,
+            "suggested_automation": "Automate: turn_on light.kitchen_ceiling daily at 07:00",
+            "entity_id": "light.kitchen_ceiling",
+            "service": "turn_on",
+            "start_hour": 7,
+        }
+
+    def _make_assistant_with_pending(self, tmp_path, owner: str):
+        """Assistant with a real IntentRouter and a real SuggestionEngine
+        holding a pending suggestion for *owner*."""
+        from rex.actions.dispatcher import ActionResult
+        from rex.intent.router import IntentRouter
+        from rex.suggestions.engine import SuggestionEngine
+
+        a = _make_assistant(user_id="default")
+        engine = SuggestionEngine(
+            dismissed_path=tmp_path / "dismissed.json",
+            automations_path=tmp_path / "automations.json",
+        )
+        assert engine.get_suggestion([self._pattern()], owner) is not None
+        a._suggestion_engine = engine
+        a._intent_router = IntentRouter()
+
+        async def _fake_dispatch(*args, **kwargs):
+            return ActionResult(success=True, response="LLM answer")
+
+        ad = MagicMock()
+        ad.dispatch = _fake_dispatch
+        a._action_dispatcher = ad
+        a._llm = MagicMock()
+        a._llm.model_name = "m"
+        return a, engine
+
+    def test_other_users_yes_does_not_accept_pending(self, tmp_path):
+        a, engine = self._make_assistant_with_pending(tmp_path, owner="alice")
+
+        reply = asyncio.run(a.generate_reply("yes", active_user_id="bob"))
+
+        # Bob's "yes" falls through to normal dispatch instead of accepting
+        # Alice's suggestion, which remains pending and unsaved.
+        assert "set that up" not in reply.lower()
+        assert engine.has_pending("alice")
+        assert not (tmp_path / "automations.json").exists()
+
+    def test_other_users_no_does_not_dismiss_pending(self, tmp_path):
+        a, engine = self._make_assistant_with_pending(tmp_path, owner="alice")
+
+        asyncio.run(a.generate_reply("no thanks", active_user_id="bob"))
+
+        assert engine.has_pending("alice")
+        assert not (tmp_path / "dismissed.json").exists()
+
+    def test_owner_yes_accepts_pending(self, tmp_path):
+        import json
+
+        a, engine = self._make_assistant_with_pending(tmp_path, owner="alice")
+
+        reply = asyncio.run(a.generate_reply("yes", active_user_id="alice"))
+
+        assert "set that up" in reply.lower()
+        assert not engine.has_pending("alice")
+        saved = json.loads((tmp_path / "automations.json").read_text(encoding="utf-8"))
+        assert saved[0]["user_id"] == "alice"


### PR DESCRIPTION
Closes the first remaining per-user isolation gap tracked by #303: `SuggestionEngine` pending state was process-global, so in a multi-user household user B's "yes" could silently accept (or "no" dismiss) user A's pending automation suggestion, suggestion content could be derived from another user's command patterns, and accepted automations were persisted with no owner.

## Defect (demonstrated on the previous implementation)

Reproduced against `HEAD~1`'s engine before fixing:

```
[alice] suggestion surfaced: 'I noticed you turn on the kitchen ceiling at 7am most days. Want me to automate that?'
[bob says 'yes'] engine reply: "Great, I've set that up for you!"
automation persisted: [{'key': 'light.kitchen_ceiling:turn_on', 'automation': 'Automate: turn_on light.kitchen_ceiling daily at 07:00', 'created_at': ...}]
alice's pending consumed by bob: True
```

## Fix

All suggestion state is keyed by `user_id`, mirroring the proven `FollowupEngine` dict-per-user pattern:

- **`rex/suggestions/engine.py`** — `_pending` and `_suggested_this_session` become per-user dicts; `get_suggestion`/`handle_yes`/`handle_dismiss`/`has_pending` take an explicit `user_id`, validated via `rex.identity.validate_user_id`, failing closed (no-op, never a default-user fallback) on missing/invalid identity. New `pending_spoken_text(user_id)` public accessor.
- **Persisted dismissals** — `dismissed_suggestions.json` becomes per-user (`{"users": {"<uid>": {"<key>": ts}}}`); the legacy flat format is read as belonging to the `"default"` user, never silently shared with other users. Saving upgrades the file without losing legacy entries.
- **Persisted automations** — `automations.json` entries are tagged with the accepting `user_id` (advisory metadata pending the ownership decision in #303 open questions; legacy entries untouched).
- **`rex/assistant.py` / `rex/actions/dispatcher.py`** — `_pattern_entries` becomes `dict[user_id, list[PatternEntry]]`; pattern detection and `get_suggestion` operate only on the requesting user's entries.
- **`rex/intent/router.py`** — `route()` gains `user_id`; the pending yes/no intercept fires only for the pending suggestion's owner and is skipped entirely when the caller is unidentified.
- **`rex/response/builder.py`** — pending suggestion text is surfaced only to its owner.
- **`CLAUDE.md`** — recorded the per-user state rule (dict keyed by `user_id`, fail closed) under Learned rules for the remaining #303 workstreams.

Single-user behavior is preserved: the session default user is `"default"`, which passes validation, so one-suggestion-per-session, the 30-day dismissal window, and accept/dismiss flows behave exactly as before.

## Tests

- **New `tests/test_suggestion_isolation.py` (25 tests)** — negative tests that fail on the previous implementation: pending state isolation, "B's yes/no does not consume A's pending", per-user session flag, per-user dismissals, fail-closed on `None`/empty/path-traversal user IDs, restart-persistence for dismissals and owner-tagged automations, legacy flat-file attribution, router intercept scoping, response-builder scoping, dispatcher pattern-entry scoping.
- **`tests/test_us303_user_isolation.py`** — new `TestGenerateReplySuggestionIsolation` (3 tests) proving isolation end-to-end through `Assistant.generate_reply()` with a real `IntentRouter` and real `SuggestionEngine` (added after a fresh-context review flagged the wiring-level gap).
- **`tests/test_us036_suggestions.py`** — updated to the per-user API, plus new fail-closed and legacy-format cases.
- Small harness updates in `test_us015_intent_router.py`, `test_us017_response_builder.py`, `test_us038_capability_response.py` (no weakened assertions).

## Validation

```
$ .venv pytest -q tests/test_suggestion_isolation.py tests/test_us036_suggestions.py
48 passed in 0.64s

$ pytest -q tests/test_suggestion_isolation.py tests/test_us036_suggestions.py tests/test_us303_user_isolation.py \
    tests/test_us015_intent_router.py tests/test_us017_response_builder.py tests/test_us038_capability_response.py \
    tests/test_us016_action_dispatcher.py tests/test_voice_loop_fixes.py
176 passed, 2 warnings  (before the 3 end-to-end tests were added; final: tests/test_us303_user_isolation.py + tests/test_suggestion_isolation.py = 43 passed)

$ ruff check <changed files>        -> All checks passed!
$ black --check <changed files>     -> 11 files would be left unchanged (after 1 reformat)
$ mypy rex --ignore-missing-imports -> Success: no issues found in 335 source files

$ pytest -q   (full suite)
1 failed, 7407 passed, 94 skipped in 418.28s
```

The single full-suite failure is `tests/test_us098_test_coverage.py::test_coverage_txt_exists`, the known environmental failure in fresh worktrees (asserts a CI-generated `coverage.txt` exists locally); it fails identically on unmodified `master` and is unrelated to this change.

## Remaining #303 gaps (not in this PR, by design)

1. Reminder/scheduled-job ownership (`rex/reminder_service.py`, `bridge/rex_reminders_bridge.py`, `rex/commands/reminders.py`) — recommended next PR.
2. `rex/memory.py` Working/LongTerm memory global singletons.
3. `rex/knowledge_base.py` — needs owner decision: shared household knowledge vs. per-user.
4. Email account/credential resolution ignores `user_email_accounts` config.
5. `Assistant._histories` stale-key eviction (low severity).
6. `rex/openclaw/identity_adapter.py` `"rex"` fallback inconsistency.
