### PR TITLE
fix(reminders): enforce per-user ownership for reminders and scheduled firing

### DIFF
--- a/bridge/rex_reminders_bridge.py
+++ b/bridge/rex_reminders_bridge.py
@@ -2,18 +2,30 @@
 
 Reads a JSON command from stdin and writes a JSON response to stdout.
 
+Every command operates on behalf of a resolved user identity (US-303
+per-user isolation):
+
+- An explicit ``"user"`` field in the payload takes precedence (it is
+  validated; malformed IDs fail closed).
+- Otherwise the active user is resolved through the standard identity
+  chain (``rex identify`` session state, then ``runtime.active_user`` /
+  ``runtime.user_id`` in ``config/rex_config.json``).
+- If no user can be resolved, the command fails closed with an error.
+  Single-user setups keep working by explicitly selecting the ``default``
+  profile (``rex identify --user default`` or ``"user": "default"``).
+
 Commands:
-  {"command": "list"}
-    -> {"ok": true, "reminders": [...]}
+  {"command": "list", "user"?: "<user_id>"}
+    -> {"ok": true, "reminders": [...]}   (only the resolved user's reminders)
 
-  {"command": "save", "reminder": {id?, title, notes?, dueAt, priority, repeat}}
-    -> {"ok": true, "reminder": {...}}
+  {"command": "save", "user"?: "<user_id>", "reminder": {id?, title, notes?, dueAt, priority, repeat}}
+    -> {"ok": true, "reminder": {...}}    (owned by the resolved user)
 
-  {"command": "delete", "id": "<reminder_id>"}
-    -> {"ok": true}
+  {"command": "delete", "user"?: "<user_id>", "id": "<reminder_id>"}
+    -> {"ok": true}                       (ownership enforced)
 
-  {"command": "complete", "id": "<reminder_id>"}
-    -> {"ok": true}
+  {"command": "complete", "user"?: "<user_id>", "id": "<reminder_id>"}
+    -> {"ok": true}                       (ownership enforced)
 
 Reminder format (GUI):
   {id, title, notes?, dueAt (ISO), priority: "low"|"medium"|"high", done, repeat?: "none"|"daily"|"weekly"|"custom"}
@@ -31,9 +43,36 @@ from rex.bridge_utils import bridge_error_response, repo_root, resolve_python
 _PYTHON_EXE = resolve_python()  # venv-aware interpreter path for subprocess calls
 _REPO_ROOT = repo_root()  # absolute repo root for resolving scripts and config
 
+_NO_USER_ERROR = (
+    "No active user for reminders. Set one with 'rex identify --user <id>' "
+    "or include a 'user' field in the request."
+)
+
 
 def _utc_now() -> datetime:
     return datetime.now(tz=UTC)
+
+
+def _resolve_user(payload: dict[str, Any]) -> str | None:
+    """Resolve the requesting user, failing closed on missing/invalid identity.
+
+    Never falls back to ``"default"`` or any other profile implicitly.
+    """
+    from rex.identity import resolve_active_user
+
+    explicit = str(payload.get("user") or "").strip() or None
+    try:
+        config: dict[str, Any] | None
+        try:
+            from rex.config_manager import load_config
+
+            config = load_config()
+        except Exception:
+            config = None
+        return resolve_active_user(explicit, config=config)
+    except ValueError:
+        # Malformed explicit user ID: fail closed, no fallback.
+        return None
 
 
 def _reminder_to_gui(reminder: Any) -> dict[str, Any]:
@@ -52,15 +91,15 @@ def _reminder_to_gui(reminder: Any) -> dict[str, Any]:
     }
 
 
-def _handle_list() -> dict[str, Any]:
+def _handle_list(user_id: str) -> dict[str, Any]:
     from rex.reminder_service import get_reminder_service  # type: ignore[import]
 
     service = get_reminder_service()
-    reminders = service.list_reminders(status="pending")
+    reminders = service.list_reminders(user_id=user_id, status="pending")
     return {"ok": True, "reminders": [_reminder_to_gui(r) for r in reminders]}
 
 
-def _handle_save(reminder_data: dict[str, Any]) -> dict[str, Any]:
+def _handle_save(user_id: str, reminder_data: dict[str, Any]) -> dict[str, Any]:
     from rex.reminder_service import get_reminder_service  # type: ignore[import]
 
     service = get_reminder_service()
@@ -84,39 +123,46 @@ def _handle_save(reminder_data: dict[str, Any]) -> dict[str, Any]:
     }
 
     if reminder_id:
-        existing = service.get_reminder(reminder_id)
-        if existing is not None:
-            existing.title = title
-            existing.remind_at = remind_at
-            existing.metadata = metadata
-            service._save()  # noqa: SLF001
-            return {"ok": True, "reminder": _reminder_to_gui(existing)}
+        updated = service.update_reminder(
+            reminder_id,
+            user_id,
+            title=title,
+            remind_at=remind_at,
+            metadata=metadata,
+        )
+        if updated is not None:
+            return {"ok": True, "reminder": _reminder_to_gui(updated)}
 
-    reminder = service.create_reminder(
-        user_id="default",
-        title=title,
-        remind_at=remind_at,
-        metadata=metadata,
-        reminder_id=reminder_id,
-    )
+    try:
+        reminder = service.create_reminder(
+            user_id=user_id,
+            title=title,
+            remind_at=remind_at,
+            metadata=metadata,
+            reminder_id=reminder_id,
+        )
+    except ValueError:
+        # Caller-supplied ID collides with a reminder it does not own (or the
+        # identity is invalid). Do not overwrite; report as not found.
+        return {"ok": False, "error": f"Reminder {reminder_id!r} not found"}
     return {"ok": True, "reminder": _reminder_to_gui(reminder)}
 
 
-def _handle_delete(reminder_id: str) -> dict[str, Any]:
+def _handle_delete(user_id: str, reminder_id: str) -> dict[str, Any]:
     from rex.reminder_service import get_reminder_service  # type: ignore[import]
 
     service = get_reminder_service()
-    existed = service.delete_reminder(reminder_id)
+    existed = service.delete_reminder(reminder_id, user_id)
     if not existed:
         return {"ok": False, "error": f"Reminder {reminder_id!r} not found"}
     return {"ok": True}
 
 
-def _handle_complete(reminder_id: str) -> dict[str, Any]:
+def _handle_complete(user_id: str, reminder_id: str) -> dict[str, Any]:
     from rex.reminder_service import get_reminder_service  # type: ignore[import]
 
     service = get_reminder_service()
-    marked = service.mark_done(reminder_id)
+    marked = service.mark_done(reminder_id, user_id)
     if not marked:
         return {"ok": False, "error": f"Reminder {reminder_id!r} not found"}
     return {"ok": True}
@@ -131,14 +177,18 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        if command == "list":
-            result = _handle_list()
-        elif command == "save":
-            result = _handle_save(dict(payload.get("reminder") or {}))
-        elif command == "delete":
-            result = _handle_delete(str(payload.get("id") or ""))
-        elif command == "complete":
-            result = _handle_complete(str(payload.get("id") or ""))
+        if command in ("list", "save", "delete", "complete"):
+            user_id = _resolve_user(payload)
+            if user_id is None:
+                result: dict[str, Any] = {"ok": False, "error": _NO_USER_ERROR}
+            elif command == "list":
+                result = _handle_list(user_id)
+            elif command == "save":
+                result = _handle_save(user_id, dict(payload.get("reminder") or {}))
+            elif command == "delete":
+                result = _handle_delete(user_id, str(payload.get("id") or ""))
+            else:
+                result = _handle_complete(user_id, str(payload.get("id") or ""))
         else:
             result = {"ok": False, "error": f"Unknown command: {command!r}"}
     except Exception as exc:

--- a/rex/commands/reminders.py
+++ b/rex/commands/reminders.py
@@ -24,10 +24,40 @@ def _cli():
     return cli
 
 
+def _resolve_reminders_user(args: argparse.Namespace) -> str | None:
+    """Resolve the requesting user for reminder commands, failing closed.
+
+    Uses ``--user`` when given, otherwise the standard identity chain
+    (``rex identify`` session state, then ``runtime.active_user`` /
+    ``runtime.user_id`` in config). Never silently falls back to the
+    ``default`` profile — single-user setups select it explicitly with
+    ``--user default`` or ``rex identify --user default``.
+    """
+    from rex.commands._helpers import _resolve_cli_user
+
+    try:
+        return _resolve_cli_user(args)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return None
+
+
+_NO_USER_MSG = (
+    "Error: No active user for reminders.\n"
+    "Set one with: rex identify --user <id>\n"
+    "Or pass one explicitly: rex reminders ... --user <id>"
+)
+
+
 def cmd_reminders(args: argparse.Namespace) -> int:
     """Manage reminders."""
     service = _cli().get_reminder_service()
     subcommand = args.reminders_command
+
+    user_id = _resolve_reminders_user(args)
+    if user_id is None:
+        print(_NO_USER_MSG)
+        return 1
 
     if subcommand == "add":
         title = args.title
@@ -41,14 +71,6 @@ def cmd_reminders(args: argparse.Namespace) -> int:
 
         followup = bool(getattr(args, "followup", False))
 
-        try:
-            from rex.config_manager import load_config
-
-            config = load_config()
-            user_id = config.get("runtime", {}).get("user_id", "default")
-        except Exception:
-            user_id = "default"
-
         # Compatibility: service might implement create_reminder(...) or add_reminder(...)
         if hasattr(service, "create_reminder"):
             reminder = service.create_reminder(
@@ -58,7 +80,7 @@ def cmd_reminders(args: argparse.Namespace) -> int:
                 followup_enabled=followup,
             )
         else:
-            reminder = service.add_reminder(title, remind_at, follow_up=followup)
+            reminder = service.add_reminder(title, remind_at, follow_up=followup, user_id=user_id)
 
         reminder_id = getattr(reminder, "reminder_id", getattr(reminder, "id", "unknown"))
         remind_at_val = getattr(reminder, "remind_at", getattr(reminder, "remind_at", remind_at))
@@ -75,7 +97,7 @@ def cmd_reminders(args: argparse.Namespace) -> int:
 
     if subcommand == "list":
         status_filter = getattr(args, "status", None)
-        reminders = service.list_reminders(status=status_filter)
+        reminders = service.list_reminders(user_id=user_id, status=status_filter)
 
         if not reminders:
             print("No reminders found.")
@@ -118,9 +140,9 @@ def cmd_reminders(args: argparse.Namespace) -> int:
     if subcommand == "done":
         reminder_id = getattr(args, "reminder_id", None) or getattr(args, "id", None)
         if hasattr(service, "mark_done"):
-            ok = service.mark_done(reminder_id)
+            ok = service.mark_done(reminder_id, user_id)
         else:
-            ok = service.complete_reminder(reminder_id)
+            ok = service.complete_reminder(reminder_id, user_id)
         if ok:
             print(f"Marked reminder {reminder_id} as done.")
             return 0
@@ -130,9 +152,9 @@ def cmd_reminders(args: argparse.Namespace) -> int:
     if subcommand == "cancel":
         reminder_id = getattr(args, "reminder_id", None) or getattr(args, "id", None)
         if hasattr(service, "cancel_reminder"):
-            ok = service.cancel_reminder(reminder_id)
+            ok = service.cancel_reminder(reminder_id, user_id)
         else:
-            ok = service.cancel(reminder_id)
+            ok = service.cancel(reminder_id, user_id)
         if ok:
             print(f"Canceled reminder {reminder_id}.")
             return 0
@@ -263,6 +285,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Create a follow-up cue after reminder fires",
     )
+    reminders_add.add_argument("--user", type=str, help="User ID to act as (owner of the reminder)")
     reminders_add.set_defaults(func=_cli().cmd_reminders, reminders_command="add")
 
     reminders_list = reminders_subparsers.add_parser(
@@ -276,6 +299,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         choices=["pending", "fired", "done", "canceled"],
         help="Filter by status",
     )
+    reminders_list.add_argument("--user", type=str, help="User ID whose reminders to list")
     reminders_list.set_defaults(func=_cli().cmd_reminders, reminders_command="list")
 
     reminders_done = reminders_subparsers.add_parser(
@@ -284,12 +308,18 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         description="Mark a reminder as completed.",
     )
     reminders_done.add_argument("id", type=str, help="Reminder ID to mark as done")
+    reminders_done.add_argument(
+        "--user", type=str, help="User ID to act as (must own the reminder)"
+    )
     reminders_done.set_defaults(func=_cli().cmd_reminders, reminders_command="done")
 
     reminders_cancel = reminders_subparsers.add_parser(
         "cancel",
         help="Cancel a reminder",
         description="Cancel a pending reminder.",
+    )
+    reminders_cancel.add_argument(
+        "--user", type=str, help="User ID to act as (must own the reminder)"
     )
     reminders_cancel.add_argument("id", type=str, help="Reminder ID to cancel")
     reminders_cancel.set_defaults(func=_cli().cmd_reminders, reminders_command="cancel")

--- a/rex/reminder_service.py
+++ b/rex/reminder_service.py
@@ -5,6 +5,22 @@ Reminders can optionally create follow-up cues after they fire.
 
 Reminders integrate with the scheduler system and notification system.
 
+Ownership model (US-303 per-user isolation):
+- Every reminder has exactly one validated owner ``user_id``.
+- Every user-facing operation (get/list/complete/cancel/delete/update)
+  requires the requesting ``user_id`` and only operates on reminders owned
+  by that user. Non-owned reminders behave as if they do not exist.
+- Missing, blank, or malformed user IDs fail closed (``ValueError``).
+- Background firing (``fire_due_reminders`` with no ``user_id``) runs in
+  system context: each due reminder executes as its stored owner (the
+  notification and follow-up cue are attributed to ``reminder.user_id``).
+- Legacy records persisted without a ``user_id`` load as owned by the
+  distinct ``default`` profile. They are not shared and are not reassigned;
+  only callers explicitly operating as ``default`` can access them. Manual
+  reassignment may be added later via a separate administrative tool.
+- Persisted records with an invalid ``user_id`` are quarantined: preserved
+  in the storage file but excluded from all operations.
+
 Usage:
     from rex.reminder_service import get_reminder_service
 
@@ -16,7 +32,7 @@ Usage:
         followup_enabled=True,
     )
     pending = service.list_reminders(user_id="default", status="pending")
-    service.mark_done(reminder.reminder_id)
+    service.mark_done(reminder.reminder_id, user_id="default")
 """
 
 from __future__ import annotations
@@ -29,7 +45,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from rex.identity import validate_user_id
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +93,10 @@ class Reminder(BaseModel):
     )
     user_id: str = Field(
         default="default",
-        description="User/profile ID this reminder belongs to",
+        description=(
+            "User/profile ID this reminder belongs to. Legacy records without "
+            "one belong to the distinct 'default' profile."
+        ),
     )
     title: str = Field(
         ...,
@@ -118,6 +139,12 @@ class Reminder(BaseModel):
         description="Additional metadata",
     )
 
+    @field_validator("user_id")
+    @classmethod
+    def _check_user_id(cls, value: str) -> str:
+        """Reject blank, malformed, or traversal-style owner IDs (fail closed)."""
+        return validate_user_id(value)
+
     def is_due(self, now: datetime | None = None) -> bool:
         """Check if this reminder is due to fire."""
         check_time = _ensure_utc(now or _utc_now())
@@ -149,10 +176,11 @@ class Reminder(BaseModel):
 class ReminderService:
     """Service for managing reminders.
 
-    - Create one-off reminders
-    - List reminders
-    - Mark reminders as done/canceled
-    - Fire due reminders (notifications + optional follow-up cue)
+    - Create one-off reminders (owner recorded and validated)
+    - List reminders (scoped to the requesting owner)
+    - Mark reminders as done/canceled (ownership enforced)
+    - Fire due reminders (notifications + optional follow-up cue, each
+      executing as its stored owner)
     - Optionally register a scheduler job to auto-fire
 
     Backward compatible aliases:
@@ -160,7 +188,8 @@ class ReminderService:
     - cancel(...) -> cancel_reminder(...)
     - fire_due(...) -> fire_due_reminders(...)
     - get(...) -> get_reminder(...)
-    - all_reminders() -> iterable of all reminders
+    - all_reminders() -> iterable of all reminders (system/maintenance
+      context only; must not back a user-facing surface)
     """
 
     def __init__(
@@ -173,6 +202,9 @@ class ReminderService:
 
         self.storage_path = Path(storage_path)
         self._reminders: dict[str, Reminder] = {}
+        # Raw persisted records that failed validation (e.g. invalid owner
+        # user_id). Preserved verbatim on save, excluded from all operations.
+        self._quarantined: list[dict[str, Any]] = []
         self._scheduler_job_registered = False
 
         self._load()
@@ -189,6 +221,7 @@ class ReminderService:
 
         if not path_to_use.exists():
             self._reminders = {}
+            self._quarantined = []
             return
 
         try:
@@ -196,6 +229,7 @@ class ReminderService:
                 data = json.load(f)
 
             loaded: dict[str, Reminder] = {}
+            quarantined: list[dict[str, Any]] = []
             for rem_data in data.get("reminders", []):
                 try:
                     reminder = Reminder.model_validate(rem_data)
@@ -210,16 +244,32 @@ class ReminderService:
                         reminder.canceled_at = _ensure_utc(reminder.canceled_at)
                     loaded[reminder.reminder_id] = reminder
                 except Exception as exc:
-                    logger.debug("Skipping invalid reminder entry: %s", exc)
+                    # Fail closed but preserve the record: invalid entries
+                    # (including invalid owner IDs) are quarantined, not
+                    # dropped and not attributed to any user.
+                    if isinstance(rem_data, dict):
+                        quarantined.append(rem_data)
+                    logger.warning(
+                        "Quarantined invalid reminder entry %r: %s",
+                        rem_data.get("reminder_id") if isinstance(rem_data, dict) else rem_data,
+                        exc,
+                    )
 
             self._reminders = loaded
-            logger.debug("Loaded %d reminders from %s", len(self._reminders), path_to_use)
+            self._quarantined = quarantined
+            logger.debug(
+                "Loaded %d reminders (%d quarantined) from %s",
+                len(self._reminders),
+                len(self._quarantined),
+                path_to_use,
+            )
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to load reminders: %s", e)
             self._reminders = {}
+            self._quarantined = []
 
         # If we loaded from legacy, write back to new path so migration happens naturally.
-        if path_to_use != self.storage_path and self._reminders:
+        if path_to_use != self.storage_path and (self._reminders or self._quarantined):
             try:
                 self._save()
             except Exception:
@@ -227,14 +277,27 @@ class ReminderService:
                 pass
 
     def _save(self) -> None:
-        """Save reminders to disk."""
+        """Save reminders to disk (including quarantined records, verbatim)."""
         self.storage_path.parent.mkdir(parents=True, exist_ok=True)
         try:
             reminders_data = [r.model_dump(mode="json") for r in self._reminders.values()]
+            reminders_data.extend(self._quarantined)
             with open(self.storage_path, "w", encoding="utf-8") as f:
                 json.dump({"reminders": reminders_data}, f, indent=2, default=str)
         except OSError as e:
             logger.error("Failed to save reminders: %s", e)
+
+    def _owned(self, reminder_id: str, user_id: str) -> Reminder | None:
+        """Return the reminder only if it exists and is owned by *user_id*.
+
+        Validates *user_id* (fail closed) and treats non-owned reminders as
+        nonexistent so callers cannot probe other users' reminder IDs.
+        """
+        user_id = validate_user_id(user_id)
+        reminder = self._reminders.get(reminder_id)
+        if reminder is None or reminder.user_id != user_id:
+            return None
+        return reminder
 
     def create_reminder(
         self,
@@ -247,8 +310,18 @@ class ReminderService:
         metadata: dict[str, Any] | None = None,
         reminder_id: str | None = None,
     ) -> Reminder:
-        """Create a new reminder."""
+        """Create a new reminder owned by *user_id*.
+
+        Raises:
+            ValueError: If *user_id* is invalid or *reminder_id* already
+                exists (a caller-supplied ID must never overwrite another
+                reminder, which could belong to a different user).
+        """
+        user_id = validate_user_id(user_id)
         remind_at_utc = _ensure_utc(remind_at)
+
+        if reminder_id and reminder_id in self._reminders:
+            raise ValueError(f"Reminder ID already exists: {reminder_id!r}")
 
         reminder = Reminder(
             reminder_id=reminder_id or f"rem_{uuid.uuid4().hex[:12]}",
@@ -264,27 +337,26 @@ class ReminderService:
 
         self._reminders[reminder.reminder_id] = reminder
         self._save()
-        logger.info("Created reminder %s: %s", reminder.reminder_id, title)
+        logger.info("Created reminder %s for user %s: %s", reminder.reminder_id, user_id, title)
 
         # Try to register scheduler job if available
         self._ensure_scheduler_job()
 
         return reminder
 
-    def get_reminder(self, reminder_id: str) -> Reminder | None:
-        """Get a reminder by ID."""
-        return self._reminders.get(reminder_id)
+    def get_reminder(self, reminder_id: str, user_id: str) -> Reminder | None:
+        """Get a reminder by ID, only if owned by *user_id*."""
+        return self._owned(reminder_id, user_id)
 
     def list_reminders(
         self,
-        user_id: str | None = None,
+        user_id: str,
         status: ReminderStatus | None = None,
         include_past: bool = True,
     ) -> list[Reminder]:
-        """List reminders with optional filtering."""
-        reminders = list(self._reminders.values())
-        if user_id is not None:
-            reminders = [r for r in reminders if r.user_id == user_id]
+        """List reminders owned by *user_id*, with optional filtering."""
+        user_id = validate_user_id(user_id)
+        reminders = [r for r in self._reminders.values() if r.user_id == user_id]
         if status is not None:
             reminders = [r for r in reminders if r.status == status]
         if not include_past:
@@ -293,45 +365,87 @@ class ReminderService:
         reminders.sort(key=lambda r: r.remind_at)
         return reminders
 
-    def mark_done(self, reminder_id: str) -> bool:
-        """Mark a reminder as done."""
-        reminder = self._reminders.get(reminder_id)
+    def update_reminder(
+        self,
+        reminder_id: str,
+        user_id: str,
+        *,
+        title: str | None = None,
+        remind_at: datetime | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Reminder | None:
+        """Update fields on a reminder owned by *user_id*.
+
+        Returns the updated reminder, or None if not found / not owned.
+        """
+        reminder = self._owned(reminder_id, user_id)
+        if reminder is None:
+            return None
+
+        if title is not None:
+            reminder.title = title
+        if remind_at is not None:
+            reminder.remind_at = _ensure_utc(remind_at)
+        if metadata is not None:
+            reminder.metadata = metadata
+        self._save()
+        logger.info("Updated reminder %s for user %s", reminder_id, user_id)
+        return reminder
+
+    def mark_done(self, reminder_id: str, user_id: str) -> bool:
+        """Mark a reminder as done (ownership enforced)."""
+        reminder = self._owned(reminder_id, user_id)
         if reminder is None:
             return False
 
         reminder.status = "done"
         reminder.done_at = _utc_now()
         self._save()
-        logger.info("Marked reminder %s as done", reminder_id)
+        logger.info("Marked reminder %s as done for user %s", reminder_id, user_id)
         return True
 
-    def cancel_reminder(self, reminder_id: str) -> bool:
-        """Cancel a reminder."""
-        reminder = self._reminders.get(reminder_id)
+    def cancel_reminder(self, reminder_id: str, user_id: str) -> bool:
+        """Cancel a reminder (ownership enforced)."""
+        reminder = self._owned(reminder_id, user_id)
         if reminder is None:
             return False
 
         reminder.status = "canceled"
         reminder.canceled_at = _utc_now()
         self._save()
-        logger.info("Canceled reminder %s", reminder_id)
+        logger.info("Canceled reminder %s for user %s", reminder_id, user_id)
         return True
 
-    def delete_reminder(self, reminder_id: str) -> bool:
-        """Delete a reminder."""
-        if reminder_id in self._reminders:
-            del self._reminders[reminder_id]
-            self._save()
-            logger.debug("Deleted reminder %s", reminder_id)
-            return True
-        return False
+    def delete_reminder(self, reminder_id: str, user_id: str) -> bool:
+        """Delete a reminder (ownership enforced)."""
+        if self._owned(reminder_id, user_id) is None:
+            return False
+        del self._reminders[reminder_id]
+        self._save()
+        logger.debug("Deleted reminder %s for user %s", reminder_id, user_id)
+        return True
 
-    def fire_due_reminders(self, now: datetime | None = None) -> list[Reminder]:
-        """Fire all due reminders (notifications + optional follow-up cues)."""
+    def fire_due_reminders(
+        self,
+        now: datetime | None = None,
+        *,
+        user_id: str | None = None,
+    ) -> list[Reminder]:
+        """Fire due reminders (notifications + optional follow-up cues).
+
+        With ``user_id=None`` this runs in system context (the background
+        scheduler job): every user's due reminders fire, each executing as
+        its stored owner. A user-initiated call must pass ``user_id`` and
+        only fires that user's reminders.
+        """
+        if user_id is not None:
+            user_id = validate_user_id(user_id)
         check_time = _ensure_utc(now or _utc_now())
         fired: list[Reminder] = []
 
         for reminder in list(self._reminders.values()):
+            if user_id is not None and reminder.user_id != user_id:
+                continue
             if reminder.is_due(check_time):
                 self._fire_reminder(reminder, now=check_time)
                 fired.append(reminder)
@@ -339,9 +453,14 @@ class ReminderService:
         return fired
 
     def _fire_reminder(self, reminder: Reminder, *, now: datetime | None = None) -> None:
-        """Fire a single reminder."""
+        """Fire a single reminder as its stored owner."""
         fire_time = _ensure_utc(now or _utc_now())
-        logger.info("Firing reminder %s: %s", reminder.reminder_id, reminder.title)
+        logger.info(
+            "Firing reminder %s for user %s: %s",
+            reminder.reminder_id,
+            reminder.user_id,
+            reminder.title,
+        )
 
         self._send_notification(reminder)
 
@@ -422,6 +541,8 @@ class ReminderService:
                 return
 
             def reminder_check_callback(job):
+                # System context: fires every user's due reminders, each
+                # executing as its stored owner.
                 service = get_reminder_service()
                 fired = service.fire_due_reminders()
                 if fired:
@@ -458,6 +579,7 @@ class ReminderService:
             "total": len(self._reminders),
             "by_status": by_status,
             "with_followup": followup_count,
+            "quarantined": len(self._quarantined),
         }
 
     # Backward compatible aliases (codex branch API)
@@ -469,9 +591,13 @@ class ReminderService:
         *,
         follow_up: bool = False,
         metadata: dict[str, Any] | None = None,
-        user_id: str = "default",
+        user_id: str,
     ) -> Reminder:
-        """Alias for older code: add_reminder(title, remind_at, follow_up=...)."""
+        """Alias for older code: add_reminder(title, remind_at, follow_up=...).
+
+        ``user_id`` is required: reminders must record their real owner and
+        never silently fall back to the ``default`` profile.
+        """
         return self.create_reminder(
             user_id=user_id,
             title=title,
@@ -480,21 +606,26 @@ class ReminderService:
             metadata=metadata,
         )
 
-    def cancel(self, reminder_id: str, *, at: datetime | None = None) -> bool:
-        """Alias for older code: cancel(reminder_id)."""
+    def cancel(self, reminder_id: str, user_id: str, *, at: datetime | None = None) -> bool:
+        """Alias for older code: cancel(reminder_id) (ownership enforced)."""
         _ = at  # kept for signature compatibility
-        return self.cancel_reminder(reminder_id)
+        return self.cancel_reminder(reminder_id, user_id)
 
     def fire_due(self, *, now: datetime | None = None) -> list[Reminder]:
-        """Alias for older code: fire_due(now=...)."""
+        """Alias for older code: fire_due(now=...) (system context)."""
         return self.fire_due_reminders(now=now)
 
-    def get(self, reminder_id: str) -> Reminder | None:
-        """Alias for older code: get(reminder_id)."""
-        return self.get_reminder(reminder_id)
+    def get(self, reminder_id: str, user_id: str) -> Reminder | None:
+        """Alias for older code: get(reminder_id) (ownership enforced)."""
+        return self.get_reminder(reminder_id, user_id)
 
     def all_reminders(self) -> Iterable[Reminder]:
-        """Alias for older code: iterable of all reminders."""
+        """Iterable of all reminders, across every owner.
+
+        System/maintenance context only (e.g. diagnostics and tests). Must
+        never back a user-facing list surface — those go through
+        :meth:`list_reminders` with the requesting user's ID.
+        """
         return list(self._reminders.values())
 
 

--- a/tests/test_followup_engine.py
+++ b/tests/test_followup_engine.py
@@ -366,8 +366,8 @@ class TestReminderService:
                 None,
             )
 
-        assert service.mark_done(reminder.reminder_id) is True
-        updated = service.get_reminder(reminder.reminder_id)
+        assert service.mark_done(reminder.reminder_id, "test_user") is True
+        updated = service.get_reminder(reminder.reminder_id, "test_user")
         assert updated is not None
         assert updated.status == "done"
 
@@ -376,8 +376,8 @@ class TestReminderService:
             title="Submit report",
             remind_at=now + timedelta(days=1),
         )
-        assert service.cancel_reminder(reminder2.reminder_id) is True
-        updated2 = service.get_reminder(reminder2.reminder_id)
+        assert service.cancel_reminder(reminder2.reminder_id, "test_user") is True
+        updated2 = service.get_reminder(reminder2.reminder_id, "test_user")
         assert updated2 is not None
         assert updated2.status == "canceled"
 
@@ -397,10 +397,10 @@ class TestReminderService:
         # Depending on now, this might fire; should not error
         assert isinstance(fired, list)
 
-        got = service.get(reminder.reminder_id)
+        got = service.get(reminder.reminder_id, "test_user")
         assert got is not None
 
-        assert service.cancel(reminder.reminder_id) in (True, False)
+        assert service.cancel(reminder.reminder_id, "test_user") is True
 
 
 # =============================================================================
@@ -525,20 +525,20 @@ class TestCLICommands:
         monkeypatch.setattr("rex.cli.get_reminder_service", lambda: reminder_service, raising=False)
         monkeypatch.setattr("rex.cli.get_cue_store", lambda: cue_store, raising=False)
 
-        # Add reminder
+        # Add reminder (explicit --user so identity resolution is deterministic)
         args_add = SimpleNamespace(
             reminders_command="add",
             title="Call mom",
             at="2024-01-02 09:00",
             follow_up=True,  # legacy flag
             followup_enabled=True,  # newer flag
-            user_id="default",
+            user="default",
         )
         result_add = cmd_reminders(args_add)
         assert result_add in (0, 1)
 
         # List reminders
-        args_list = argparse.Namespace(reminders_command="list", status=None)
+        args_list = argparse.Namespace(reminders_command="list", status=None, user="default")
         result_list = cmd_reminders(args_list)
         assert result_list in (0, 1)
         out = capsys.readouterr().out
@@ -546,15 +546,19 @@ class TestCLICommands:
             assert ("Call mom" in out) or (out.strip() != "")
 
         # Mark done if possible
-        reminders = reminder_service.list_reminders()
+        reminders = reminder_service.list_reminders(user_id="default")
         if reminders:
             reminder_id = reminders[0].reminder_id
-            args_done = argparse.Namespace(reminders_command="done", reminder_id=reminder_id)
+            args_done = argparse.Namespace(
+                reminders_command="done", reminder_id=reminder_id, user="default"
+            )
             result_done = cmd_reminders(args_done)
             assert result_done in (0, 1)
 
         # Cancel missing should return non-zero in most implementations
-        args_cancel = argparse.Namespace(reminders_command="cancel", reminder_id="missing")
+        args_cancel = argparse.Namespace(
+            reminders_command="cancel", reminder_id="missing", user="default"
+        )
         result_cancel = cmd_reminders(args_cancel)
         assert result_cancel in (0, 1)
 

--- a/tests/test_reminder_isolation.py
+++ b/tests/test_reminder_isolation.py
@@ -1,0 +1,436 @@
+"""US-303: per-user isolation for reminders and their scheduled execution.
+
+Covers:
+- Cross-user list/get/complete/cancel/delete/update (snooze) denial
+- User-scoped manual firing cannot trigger another user's due reminders
+- Background (system-context) firing executes as the stored owner
+- Missing / blank / malformed / traversal identity fails closed
+- Invalid persisted owner IDs are quarantined, preserved, and inaccessible
+- Ownership survives service restart (reload from disk)
+- Legacy records without a user_id belong to the distinct ``default``
+  profile only
+- Bridge and CLI paths resolve the caller identity, preserve it on create,
+  and enforce ownership on mutation
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+from datetime import UTC, datetime, timedelta
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rex.reminder_service import ReminderService, set_reminder_service
+
+
+def _future(hours: int = 2) -> datetime:
+    return datetime.now(UTC) + timedelta(hours=hours)
+
+
+def _past(hours: int = 1) -> datetime:
+    return datetime.now(UTC) - timedelta(hours=hours)
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> ReminderService:
+    return ReminderService(storage_path=tmp_path / "reminders.json")
+
+
+# =============================================================================
+# Service-level cross-user denial
+# =============================================================================
+
+
+class TestServiceOwnership:
+    def test_list_is_scoped_to_requesting_user(self, svc: ReminderService) -> None:
+        svc.create_reminder("alice", "Alice appointment", _future())
+        svc.create_reminder("bob", "Bob meeting", _future())
+
+        alice_view = svc.list_reminders(user_id="alice")
+        assert [r.title for r in alice_view] == ["Alice appointment"]
+        assert all(r.user_id == "alice" for r in alice_view)
+
+        # Unscoped listing must be impossible, not merely optional.
+        with pytest.raises(TypeError):
+            svc.list_reminders()  # type: ignore[call-arg]
+
+    def test_get_denies_non_owner(self, svc: ReminderService) -> None:
+        r = svc.create_reminder("bob", "Bob secret", _future())
+        assert svc.get_reminder(r.reminder_id, "alice") is None
+        assert svc.get_reminder(r.reminder_id, "bob") is not None
+
+    def test_mark_done_denies_non_owner(self, svc: ReminderService) -> None:
+        r = svc.create_reminder("bob", "Bob task", _future())
+        assert svc.mark_done(r.reminder_id, "alice") is False
+        assert svc.get_reminder(r.reminder_id, "bob").status == "pending"
+        assert svc.mark_done(r.reminder_id, "bob") is True
+
+    def test_cancel_denies_non_owner(self, svc: ReminderService) -> None:
+        r = svc.create_reminder("bob", "Bob task", _future())
+        assert svc.cancel_reminder(r.reminder_id, "alice") is False
+        assert svc.get_reminder(r.reminder_id, "bob").status == "pending"
+
+    def test_delete_denies_non_owner(self, svc: ReminderService) -> None:
+        r = svc.create_reminder("bob", "Bob task", _future())
+        assert svc.delete_reminder(r.reminder_id, "alice") is False
+        assert svc.get_reminder(r.reminder_id, "bob") is not None
+
+    def test_update_snooze_denies_non_owner(self, svc: ReminderService) -> None:
+        original_time = _future()
+        r = svc.create_reminder("bob", "Bob task", original_time)
+
+        snoozed = svc.update_reminder(r.reminder_id, "alice", remind_at=_future(48))
+        assert snoozed is None
+        unchanged = svc.get_reminder(r.reminder_id, "bob")
+        assert unchanged.remind_at == original_time.astimezone(UTC)
+
+        assert svc.update_reminder(r.reminder_id, "bob", title="Renamed") is not None
+
+    def test_create_cannot_overwrite_existing_id(self, svc: ReminderService) -> None:
+        r = svc.create_reminder("alice", "Alice original", _future())
+        with pytest.raises(ValueError):
+            svc.create_reminder("mallory", "Takeover", _future(), reminder_id=r.reminder_id)
+        assert svc.get_reminder(r.reminder_id, "alice").user_id == "alice"
+
+
+# =============================================================================
+# Scheduled / background execution
+# =============================================================================
+
+
+class TestScheduledExecution:
+    def test_user_scoped_fire_cannot_trigger_other_users_work(
+        self, svc: ReminderService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(svc, "_send_notification", lambda reminder: None)
+        svc.create_reminder("alice", "Alice due", _past())
+        bob_due = svc.create_reminder("bob", "Bob due", _past())
+
+        fired = svc.fire_due_reminders(user_id="alice")
+
+        assert [r.user_id for r in fired] == ["alice"]
+        assert svc.get_reminder(bob_due.reminder_id, "bob").status == "pending"
+
+    def test_background_fire_executes_as_stored_owner(
+        self, svc: ReminderService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """System-context firing attributes work to the reminder's owner,
+        not whichever user is currently active in the identity chain."""
+        # Simulate a different currently-active user.
+        monkeypatch.setattr("rex.identity.resolve_active_user", lambda *a, **k: "alice")
+
+        notifications = []
+
+        class RecordingNotifier:
+            def send(self, notification) -> None:
+                notifications.append(notification)
+
+        monkeypatch.setattr("rex.notification.get_notifier", lambda: RecordingNotifier())
+
+        cue_store = MagicMock()
+        monkeypatch.setattr("rex.cue_store.get_cue_store", lambda: cue_store)
+
+        svc.create_reminder("bob", "Bob background task", _past(), followup_enabled=True)
+
+        fired = svc.fire_due_reminders()  # same call the scheduler job makes
+
+        assert len(fired) == 1
+        assert fired[0].user_id == "bob"
+        assert notifications[0].metadata["user_id"] == "bob"
+        assert cue_store.add_cue.call_args.kwargs["user_id"] == "bob"
+
+
+# =============================================================================
+# Fail-closed identity validation
+# =============================================================================
+
+
+class TestFailClosedIdentity:
+    @pytest.mark.parametrize("bad_user", ["", "  ", "../evil", "a/b", "..", ".", "a" * 65])
+    def test_invalid_identity_rejected_everywhere(
+        self, svc: ReminderService, bad_user: str
+    ) -> None:
+        r = svc.create_reminder("alice", "Alice task", _future())
+
+        with pytest.raises(ValueError):
+            svc.create_reminder(bad_user, "X", _future())
+        with pytest.raises(ValueError):
+            svc.list_reminders(user_id=bad_user)
+        with pytest.raises(ValueError):
+            svc.get_reminder(r.reminder_id, bad_user)
+        with pytest.raises(ValueError):
+            svc.mark_done(r.reminder_id, bad_user)
+        with pytest.raises(ValueError):
+            svc.cancel_reminder(r.reminder_id, bad_user)
+        with pytest.raises(ValueError):
+            svc.delete_reminder(r.reminder_id, bad_user)
+        with pytest.raises(ValueError):
+            svc.fire_due_reminders(user_id=bad_user)
+
+    def test_none_identity_rejected(self, svc: ReminderService) -> None:
+        with pytest.raises(ValueError):
+            svc.list_reminders(user_id=None)  # type: ignore[arg-type]
+
+
+# =============================================================================
+# Persistence, restart, legacy and quarantine behavior
+# =============================================================================
+
+
+class TestPersistenceAndMigration:
+    def test_restart_preserves_ownership(self, tmp_path: Path) -> None:
+        path = tmp_path / "reminders.json"
+        svc1 = ReminderService(storage_path=path)
+        a = svc1.create_reminder("alice", "Alice persists", _future())
+        svc1.create_reminder("bob", "Bob persists", _future())
+
+        svc2 = ReminderService(storage_path=path)
+        assert [r.title for r in svc2.list_reminders(user_id="alice")] == ["Alice persists"]
+        assert svc2.get_reminder(a.reminder_id, "bob") is None
+        assert svc2.get_reminder(a.reminder_id, "alice").user_id == "alice"
+
+    def test_legacy_record_without_user_id_belongs_to_default_only(self, tmp_path: Path) -> None:
+        path = tmp_path / "reminders.json"
+        legacy_record = {
+            "reminder_id": "rem_legacy000001",
+            "title": "Legacy unscoped reminder",
+            "remind_at": "2030-01-15T14:00:00Z",
+            "status": "pending",
+        }
+        path.write_text(json.dumps({"reminders": [legacy_record]}), encoding="utf-8")
+
+        svc = ReminderService(storage_path=path)
+
+        # Not visible to, or mutable by, any named user.
+        assert svc.list_reminders(user_id="james") == []
+        assert svc.get_reminder("rem_legacy000001", "james") is None
+        assert svc.mark_done("rem_legacy000001", "james") is False
+        assert svc.delete_reminder("rem_legacy000001", "james") is False
+
+        # Accessible when explicitly operating as the default profile.
+        default_view = svc.list_reminders(user_id="default")
+        assert [r.reminder_id for r in default_view] == ["rem_legacy000001"]
+        assert svc.mark_done("rem_legacy000001", "default") is True
+
+    def test_invalid_persisted_identity_is_quarantined_and_preserved(self, tmp_path: Path) -> None:
+        path = tmp_path / "reminders.json"
+        bad_record = {
+            "reminder_id": "rem_evil00000001",
+            "user_id": "../../etc/passwd",
+            "title": "Traversal owner",
+            "remind_at": "2030-01-15T14:00:00Z",
+            "status": "pending",
+        }
+        path.write_text(json.dumps({"reminders": [bad_record]}), encoding="utf-8")
+
+        svc = ReminderService(storage_path=path)
+
+        # Inaccessible to everyone, including the default profile.
+        assert svc.get_reminder("rem_evil00000001", "default") is None
+        assert svc.list_reminders(user_id="default") == []
+        assert svc.mark_done("rem_evil00000001", "default") is False
+        assert len(svc) == 0
+        assert svc.stats()["quarantined"] == 1
+
+        # Preserved (not deleted) across a save triggered by unrelated work.
+        svc.create_reminder("alice", "New task", _future())
+        saved = json.loads(path.read_text(encoding="utf-8"))
+        saved_ids = {r.get("reminder_id") for r in saved["reminders"]}
+        assert "rem_evil00000001" in saved_ids
+        preserved = next(
+            r for r in saved["reminders"] if r.get("reminder_id") == "rem_evil00000001"
+        )
+        assert preserved["user_id"] == "../../etc/passwd"
+
+        # Still quarantined after another restart.
+        svc3 = ReminderService(storage_path=path)
+        assert svc3.get_reminder("rem_evil00000001", "default") is None
+        assert svc3.stats()["quarantined"] == 1
+
+
+# =============================================================================
+# Bridge (Electron GUI) path
+# =============================================================================
+
+
+def _run_bridge(stdin_data: str) -> dict:
+    """Invoke the reminders bridge main() with the given stdin JSON."""
+    mod = importlib.import_module("rex_reminders_bridge")
+
+    captured = StringIO()
+    with patch("sys.stdin", StringIO(stdin_data)):
+        with patch("sys.stdout", captured):
+            try:
+                mod.main()
+            except SystemExit:
+                pass
+    return json.loads(captured.getvalue().strip())
+
+
+class TestBridgeOwnership:
+    @pytest.fixture(autouse=True)
+    def _isolated_service(self, tmp_path: Path):
+        service = ReminderService(storage_path=tmp_path / "reminders.json")
+        set_reminder_service(service)
+        yield service
+        set_reminder_service(None)
+
+    def test_save_records_the_requesting_user(self, _isolated_service) -> None:
+        result = _run_bridge(
+            json.dumps(
+                {
+                    "command": "save",
+                    "user": "alice",
+                    "reminder": {"title": "Alice via GUI", "dueAt": _future().isoformat()},
+                }
+            )
+        )
+        assert result["ok"] is True
+        stored = _isolated_service.list_reminders(user_id="alice")
+        assert [r.title for r in stored] == ["Alice via GUI"]
+        assert stored[0].user_id == "alice"
+
+    def test_save_does_not_hardcode_default(self, _isolated_service) -> None:
+        _run_bridge(
+            json.dumps(
+                {
+                    "command": "save",
+                    "user": "alice",
+                    "reminder": {"title": "Owned by alice", "dueAt": _future().isoformat()},
+                }
+            )
+        )
+        assert _isolated_service.list_reminders(user_id="default") == []
+
+    def test_list_is_scoped_to_requesting_user(self, _isolated_service) -> None:
+        _isolated_service.create_reminder("alice", "Alice item", _future())
+        _isolated_service.create_reminder("bob", "Bob item", _future())
+
+        result = _run_bridge(json.dumps({"command": "list", "user": "alice"}))
+        assert result["ok"] is True
+        assert [r["title"] for r in result["reminders"]] == ["Alice item"]
+
+    def test_delete_denies_non_owner(self, _isolated_service) -> None:
+        r = _isolated_service.create_reminder("bob", "Bob item", _future())
+        result = _run_bridge(
+            json.dumps({"command": "delete", "user": "alice", "id": r.reminder_id})
+        )
+        assert result["ok"] is False
+        assert _isolated_service.get_reminder(r.reminder_id, "bob") is not None
+
+    def test_complete_denies_non_owner(self, _isolated_service) -> None:
+        r = _isolated_service.create_reminder("bob", "Bob item", _future())
+        result = _run_bridge(
+            json.dumps({"command": "complete", "user": "alice", "id": r.reminder_id})
+        )
+        assert result["ok"] is False
+        assert _isolated_service.get_reminder(r.reminder_id, "bob").status == "pending"
+
+    def test_save_update_denies_non_owner_and_does_not_overwrite(self, _isolated_service) -> None:
+        r = _isolated_service.create_reminder("alice", "Alice original", _future())
+        result = _run_bridge(
+            json.dumps(
+                {
+                    "command": "save",
+                    "user": "bob",
+                    "reminder": {
+                        "id": r.reminder_id,
+                        "title": "Hijacked",
+                        "dueAt": _future().isoformat(),
+                    },
+                }
+            )
+        )
+        assert result["ok"] is False
+        intact = _isolated_service.get_reminder(r.reminder_id, "alice")
+        assert intact.title == "Alice original"
+        assert intact.user_id == "alice"
+
+    def test_missing_identity_fails_closed(
+        self, _isolated_service, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rex.identity.resolve_active_user", lambda *a, **k: None)
+        for command in ({"command": "list"}, {"command": "delete", "id": "rem_x"}):
+            result = _run_bridge(json.dumps(command))
+            assert result["ok"] is False
+            assert "No active user" in result["error"]
+
+    def test_malformed_explicit_identity_fails_closed(self, _isolated_service) -> None:
+        result = _run_bridge(json.dumps({"command": "list", "user": "../evil"}))
+        assert result["ok"] is False
+        assert "No active user" in result["error"]
+
+
+# =============================================================================
+# CLI path
+# =============================================================================
+
+
+class TestCliOwnership:
+    @pytest.fixture(autouse=True)
+    def _isolated_service(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        service = ReminderService(storage_path=tmp_path / "reminders.json")
+        set_reminder_service(service)
+        monkeypatch.setattr("rex.cli.get_reminder_service", lambda: service, raising=False)
+        yield service
+        set_reminder_service(None)
+
+    def _cmd(self):
+        from rex.cli import cmd_reminders
+
+        return cmd_reminders
+
+    def test_add_records_the_requesting_user(self, _isolated_service) -> None:
+        args = argparse.Namespace(
+            reminders_command="add",
+            title="Alice CLI reminder",
+            at="2030-01-02 09:00",
+            followup=False,
+            user="alice",
+        )
+        assert self._cmd()(args) == 0
+        stored = _isolated_service.list_reminders(user_id="alice")
+        assert [r.title for r in stored] == ["Alice CLI reminder"]
+        assert stored[0].user_id == "alice"
+
+    def test_list_is_scoped_to_requesting_user(
+        self, _isolated_service, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _isolated_service.create_reminder("alice", "Alice CLI item", _future())
+        _isolated_service.create_reminder("bob", "Bob CLI secret", _future())
+
+        args = argparse.Namespace(reminders_command="list", status=None, user="alice")
+        assert self._cmd()(args) == 0
+        out = capsys.readouterr().out
+        assert "Alice CLI item" in out
+        assert "Bob CLI secret" not in out
+
+    def test_done_denies_non_owner(self, _isolated_service) -> None:
+        r = _isolated_service.create_reminder("bob", "Bob CLI item", _future())
+        args = argparse.Namespace(reminders_command="done", reminder_id=r.reminder_id, user="alice")
+        assert self._cmd()(args) == 1
+        assert _isolated_service.get_reminder(r.reminder_id, "bob").status == "pending"
+
+    def test_cancel_denies_non_owner(self, _isolated_service) -> None:
+        r = _isolated_service.create_reminder("bob", "Bob CLI item", _future())
+        args = argparse.Namespace(
+            reminders_command="cancel", reminder_id=r.reminder_id, user="alice"
+        )
+        assert self._cmd()(args) == 1
+        assert _isolated_service.get_reminder(r.reminder_id, "bob").status == "pending"
+
+    def test_missing_identity_fails_closed(
+        self, _isolated_service, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rex.identity.resolve_active_user", lambda *a, **k: None)
+        args = argparse.Namespace(reminders_command="list", status=None, user=None)
+        assert self._cmd()(args) == 1
+
+    def test_malformed_explicit_identity_fails_closed(self, _isolated_service) -> None:
+        args = argparse.Namespace(reminders_command="list", status=None, user="../evil")
+        assert self._cmd()(args) == 1

--- a/tests/test_reminder_service.py
+++ b/tests/test_reminder_service.py
@@ -95,10 +95,10 @@ def test_mark_done(tmp_path):
     svc = ReminderService(storage_path=tmp_path / "reminders.json")
     r = svc.create_reminder("bob", "Read book", _future())
 
-    result = svc.mark_done(r.reminder_id)
+    result = svc.mark_done(r.reminder_id, "bob")
 
     assert result is True
-    updated = svc.get_reminder(r.reminder_id)
+    updated = svc.get_reminder(r.reminder_id, "bob")
     assert updated.status == "done"
     assert updated.done_at is not None
 
@@ -110,10 +110,10 @@ def test_cancel_reminder(tmp_path):
     svc = ReminderService(storage_path=tmp_path / "reminders.json")
     r = svc.create_reminder("carol", "Meeting", _future())
 
-    result = svc.cancel_reminder(r.reminder_id)
+    result = svc.cancel_reminder(r.reminder_id, "carol")
 
     assert result is True
-    updated = svc.get_reminder(r.reminder_id)
+    updated = svc.get_reminder(r.reminder_id, "carol")
     assert updated.status == "canceled"
 
 
@@ -124,10 +124,10 @@ def test_delete_reminder(tmp_path):
     svc = ReminderService(storage_path=tmp_path / "reminders.json")
     r = svc.create_reminder("dave", "Exercise", _future())
 
-    deleted = svc.delete_reminder(r.reminder_id)
+    deleted = svc.delete_reminder(r.reminder_id, "dave")
 
     assert deleted is True
-    assert svc.get_reminder(r.reminder_id) is None
+    assert svc.get_reminder(r.reminder_id, "dave") is None
 
 
 def test_fire_due_reminders(tmp_path):
@@ -174,7 +174,7 @@ def test_persistence(tmp_path):
     r = svc1.create_reminder("user", "Persistent", _future())
 
     svc2 = ReminderService(storage_path=path)
-    loaded = svc2.get_reminder(r.reminder_id)
+    loaded = svc2.get_reminder(r.reminder_id, "user")
 
     assert loaded is not None
     assert loaded.title == "Persistent"
@@ -187,17 +187,17 @@ def test_backward_compat_aliases(tmp_path):
 
     svc = ReminderService(storage_path=tmp_path / "reminders.json")
 
-    r = svc.add_reminder("Alias test", _future())
+    r = svc.add_reminder("Alias test", _future(), user_id="alias_user")
     assert r.title == "Alias test"
 
-    got = svc.get(r.reminder_id)
+    got = svc.get(r.reminder_id, "alias_user")
     assert got is not None
 
     all_r = list(svc.all_reminders())
     assert len(all_r) == 1
 
-    svc.cancel(r.reminder_id)
-    assert svc.get(r.reminder_id).status == "canceled"
+    svc.cancel(r.reminder_id, "alias_user")
+    assert svc.get(r.reminder_id, "alias_user").status == "canceled"
 
 
 def test_get_reminder_service_singleton(tmp_path):

--- a/tests/test_us005_bridge_json_io.py
+++ b/tests/test_us005_bridge_json_io.py
@@ -83,7 +83,7 @@ class TestRemindersBridgeJsonIO:
             "sys.modules",
             {"rex.reminder_service": MagicMock(get_reminder_service=lambda: mock_service)},
         ):
-            result = _run_main(REMINDERS_MODULE, '{"action": "list"}')
+            result = _run_main(REMINDERS_MODULE, '{"action": "list", "user": "default"}')
         assert isinstance(result, dict)
         assert "reminders" in result or "error" in result
 
@@ -94,7 +94,7 @@ class TestRemindersBridgeJsonIO:
             "sys.modules",
             {"rex.reminder_service": MagicMock(get_reminder_service=lambda: mock_service)},
         ):
-            result = _run_main(REMINDERS_MODULE, '{"command": "list"}')
+            result = _run_main(REMINDERS_MODULE, '{"command": "list", "user": "default"}')
         assert isinstance(result, dict)
         assert "reminders" in result or "error" in result
 


### PR DESCRIPTION
## Summary

Closes the **reminder / scheduled-job ownership** portion of #303 (per-user isolation). Follow-up to #312 (SuggestionEngine isolation).

### Reproduced defects (against master, before this change)

A repro script against `080add0` demonstrated all of the following:

1. `list_reminders()` with no `user_id` returned **every user's reminders** (GUI bridge list used exactly this path).
2. `mark_done` / `cancel_reminder` / `delete_reminder` operated on a bare `reminder_id` with **zero ownership checks** — user A could complete/cancel/delete user B's reminder.
3. `get_reminder` disclosed any user's reminder by ID.
4. `bridge/rex_reminders_bridge.py` **hardcoded `user_id="default"`** on save, so every GUI-created reminder was misattributed.
5. `create_reminder` with an existing `reminder_id` **silently overwrote** another user's reminder.

### Ownership model

- Every reminder has one validated canonical owner `user_id` (validated via `rex.identity.validate_user_id`, enforced at the Pydantic model and at every service entry point).
- `get / list / update (snooze) / mark_done / cancel / delete` — and the `add_reminder / cancel / get` compat aliases — require the requesting `user_id`; non-owned reminders behave as nonexistent (no existence oracle).
- Missing, blank, malformed, or traversal-style identity **fails closed** (`ValueError` / error response). No path falls back to `default` or the currently active user.
- `create_reminder` rejects caller-supplied IDs that already exist (blocks cross-user overwrite via the bridge save flow).
- **Background execution:** `fire_due_reminders()` with no `user_id` remains the system context used by the `reminder_check` scheduler job — each due reminder executes as its **stored owner** (notification metadata and follow-up cue are attributed to `reminder.user_id`, regardless of who is currently active). User-initiated firing must pass `user_id` and only fires that user's reminders.
- **Bridge:** resolves the caller from an explicit `user` payload field or the standard identity chain (`rex identify` session → `runtime.active_user` → `runtime.user_id` ≠ `default`); fails closed otherwise.
- **CLI:** `rex reminders add|list|done|cancel` gain `--user` and resolve identity via `rex.commands._helpers._resolve_cli_user`; fail closed with guidance when no user is set.
- Audit trail: create/update/done/cancel/delete/fire log lines now include the owner.

### Legacy migration behavior (conservative, per #303 owner guidance)

- Persisted records **without** a `user_id` load as owned by the distinct `default` profile. They are **not shared**, **not reassigned** to James/Cole/the active user, and remain accessible only to callers explicitly operating as `default` (`rex identify --user default`, `--user default`, or `"user": "default"` in the bridge payload).
- Persisted records with an **invalid** `user_id` (e.g. traversal strings) are **quarantined**: preserved verbatim in `data/reminders/reminders.json` across saves and restarts, but excluded from every operation for every user. Nothing is deleted.
- Manual reassignment / an administrative migration tool can be added separately if desired.
- **Behavior note:** on a fresh install (`runtime.active_user: null`, `runtime.user_id: "default"`) the GUI reminders panel and bare CLI now fail closed with an actionable message until an active user is set — set `runtime.active_user` (e.g. to `default`) or run `rex identify`. This is the intended fail-closed default; single-user use keeps working by explicitly selecting the `default` profile.

### Tests added (`tests/test_reminder_isolation.py`, 35 tests)

- Cross-user denial for list, get-by-ID, complete, cancel, delete, and update/snooze at the **service**, **bridge**, and **CLI** layers.
- User-scoped manual firing cannot trigger another user's due reminders.
- System-context (scheduler) firing executes as the stored owner even when a different user is active in the identity chain.
- Missing / blank / malformed / traversal identity fails closed on every operation and surface.
- Invalid persisted identity is quarantined, inaccessible to everyone (including `default`), and preserved verbatim across saves and restarts.
- Restart preserves ownership; legacy no-`user_id` records accessible only to explicit `default`.
- Bridge/CLI creation records the caller's user ID; `default` is never hardcoded.
- **Fails against the prior implementation:** run in a throwaway worktree at `origin/master`, 32/34 of the original tests fail (the two that pass are a behavior-when-parameter-supplied check, since strengthened with an unscoped-call `TypeError` assertion, and the background-owner-attribution regression guard, which was already-correct behavior).

### Verification (exact commands, local)

| Command | Result |
|---|---|
| `pytest -q tests/test_reminder_isolation.py tests/test_reminder_service.py tests/test_followup_engine.py tests/test_us005_bridge_json_io.py` | 69 passed |
| `pytest -q` + related suites (identity, scheduler, cli, us303, suggestion_isolation, bridge_*) | 233 passed |
| `pytest -q` (full suite) | **7455 passed, 84 skipped, 0 failed** in 10:43 |
| `ruff check` (changed files) | All checks passed |
| `black --check` (changed files) | unchanged |
| `mypy rex --ignore-missing-imports` | Success: no issues found in 335 source files |

Fresh-context reviewer pass over the final diff (privacy, authz bypass, migration safety, regressions, test adequacy): no critical/major findings; one minor tautological pre-existing test assertion was tightened.

### Out of scope (remaining #303 work)

Memory (`rex/memory.py` singletons), knowledge base, per-user email accounts, `identity_adapter` fallback, and OpenClaw isolation — tracked in #303.
