### PR TITLE
fix(memory): enforce per-user isolation for working and long-term memory

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -182,14 +182,14 @@
         "filename": "docs/memory.md",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 139
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/memory.md",
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 178
       }
     ],
     "docs/security/SECRET-SCAN.md": [
@@ -342,14 +342,14 @@
         "filename": "tests/test_cli_memory_kb.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 176
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_cli_memory_kb.py",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 256
+        "line_number": 275
       }
     ],
     "tests/test_config_loading.py": [

--- a/bridge/rex_memories_bridge.py
+++ b/bridge/rex_memories_bridge.py
@@ -2,18 +2,30 @@
 
 Reads a JSON command from stdin and writes a JSON response to stdout.
 
+Every command operates on behalf of a resolved user identity (US-303
+per-user isolation):
+
+- An explicit ``"user"`` field in the payload takes precedence (it is
+  validated; malformed IDs fail closed).
+- Otherwise the active user is resolved through the standard identity
+  chain (``rex identify`` session state, then ``runtime.active_user`` /
+  ``runtime.user_id`` in ``config/rex_config.json``).
+- If no user can be resolved, the command fails closed with an error.
+  Single-user setups keep working by explicitly selecting the ``default``
+  profile (``rex identify --user default`` or ``"user": "default"``).
+
 Commands:
-  {"command": "list"}
-    -> {"ok": true, "memories": [...]}
+  {"command": "list", "user"?: "<user_id>"}
+    -> {"ok": true, "memories": [...]}    (only the resolved user's memories)
 
-  {"command": "add", "data": {text, category}}
-    -> {"ok": true, "memory": {...}}
+  {"command": "add", "user"?: "<user_id>", "data": {text, category}}
+    -> {"ok": true, "memory": {...}}      (owned by the resolved user)
 
-  {"command": "update", "id": "<entry_id>", "data": {text, category}}
-    -> {"ok": true, "memory": {...}}
+  {"command": "update", "user"?: "<user_id>", "id": "<entry_id>", "data": {text, category}}
+    -> {"ok": true, "memory": {...}}      (ownership enforced)
 
-  {"command": "delete", "id": "<entry_id>"}
-    -> {"ok": true}
+  {"command": "delete", "user"?: "<user_id>", "id": "<entry_id>"}
+    -> {"ok": true}                       (ownership enforced)
 
 Memory format (GUI):
   {id, text, category, createdAt (ISO), updatedAt (ISO)}
@@ -31,9 +43,36 @@ from rex.bridge_utils import bridge_error_response, repo_root, resolve_python
 _PYTHON_EXE = resolve_python()  # venv-aware interpreter path for subprocess calls
 _REPO_ROOT = repo_root()  # absolute repo root for resolving scripts and config
 
+_NO_USER_ERROR = (
+    "No active user for memories. Set one with 'rex identify --user <id>' "
+    "or include a 'user' field in the request."
+)
+
 
 def _utc_now_iso() -> str:
     return datetime.now(tz=UTC).isoformat()
+
+
+def _resolve_user(payload: dict[str, Any]) -> str | None:
+    """Resolve the requesting user, failing closed on missing/invalid identity.
+
+    Never falls back to ``"default"`` or any other profile implicitly.
+    """
+    from rex.identity import resolve_active_user
+
+    explicit = str(payload.get("user") or "").strip() or None
+    try:
+        config: dict[str, Any] | None
+        try:
+            from rex.config_manager import load_config
+
+            config = load_config()
+        except Exception:
+            config = None
+        return resolve_active_user(explicit, config=config)
+    except ValueError:
+        # Malformed explicit user ID: fail closed, no fallback.
+        return None
 
 
 def _entry_to_gui(entry: Any) -> dict[str, Any]:
@@ -59,15 +98,15 @@ def _entry_to_gui(entry: Any) -> dict[str, Any]:
     }
 
 
-def _handle_list() -> dict[str, Any]:
+def _handle_list(user_id: str) -> dict[str, Any]:
     from rex.memory import get_long_term_memory  # type: ignore[import]
 
-    ltm = get_long_term_memory()
+    ltm = get_long_term_memory(user_id=user_id)
     entries = ltm.search()
     return {"ok": True, "memories": [_entry_to_gui(e) for e in entries]}
 
 
-def _handle_add(data: dict[str, Any]) -> dict[str, Any]:
+def _handle_add(user_id: str, data: dict[str, Any]) -> dict[str, Any]:
     from rex.memory import get_long_term_memory  # type: ignore[import]
 
     text = str(data.get("text") or "").strip()
@@ -77,7 +116,7 @@ def _handle_add(data: dict[str, Any]) -> dict[str, Any]:
         return {"ok": False, "error": "Memory text is required"}
 
     now = _utc_now_iso()
-    ltm = get_long_term_memory()
+    ltm = get_long_term_memory(user_id=user_id)
     entry = ltm.add_entry(
         category=category,
         content={"text": text, "updated_at": now},
@@ -85,7 +124,7 @@ def _handle_add(data: dict[str, Any]) -> dict[str, Any]:
     return {"ok": True, "memory": _entry_to_gui(entry)}
 
 
-def _handle_update(entry_id: str, data: dict[str, Any]) -> dict[str, Any]:
+def _handle_update(user_id: str, entry_id: str, data: dict[str, Any]) -> dict[str, Any]:
     from rex.memory import get_long_term_memory  # type: ignore[import]
 
     text = str(data.get("text") or "").strip()
@@ -94,7 +133,7 @@ def _handle_update(entry_id: str, data: dict[str, Any]) -> dict[str, Any]:
     if not text:
         return {"ok": False, "error": "Memory text is required"}
 
-    ltm = get_long_term_memory()
+    ltm = get_long_term_memory(user_id=user_id)
     entry = ltm.get_entry(entry_id)
     if entry is None:
         return {"ok": False, "error": f"Memory {entry_id!r} not found"}
@@ -108,10 +147,10 @@ def _handle_update(entry_id: str, data: dict[str, Any]) -> dict[str, Any]:
     return {"ok": True, "memory": _entry_to_gui(entry)}
 
 
-def _handle_delete(entry_id: str) -> dict[str, Any]:
+def _handle_delete(user_id: str, entry_id: str) -> dict[str, Any]:
     from rex.memory import get_long_term_memory  # type: ignore[import]
 
-    ltm = get_long_term_memory()
+    ltm = get_long_term_memory(user_id=user_id)
     deleted = ltm.forget(entry_id)
     if not deleted:
         return {"ok": False, "error": f"Memory {entry_id!r} not found"}
@@ -127,14 +166,20 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        if command == "list":
-            result = _handle_list()
-        elif command == "add":
-            result = _handle_add(dict(payload.get("data") or {}))
-        elif command == "update":
-            result = _handle_update(str(payload.get("id") or ""), dict(payload.get("data") or {}))
-        elif command == "delete":
-            result = _handle_delete(str(payload.get("id") or ""))
+        if command in ("list", "add", "update", "delete"):
+            user_id = _resolve_user(payload)
+            if user_id is None:
+                result: dict[str, Any] = {"ok": False, "error": _NO_USER_ERROR}
+            elif command == "list":
+                result = _handle_list(user_id)
+            elif command == "add":
+                result = _handle_add(user_id, dict(payload.get("data") or {}))
+            elif command == "update":
+                result = _handle_update(
+                    user_id, str(payload.get("id") or ""), dict(payload.get("data") or {})
+                )
+            else:
+                result = _handle_delete(user_id, str(payload.get("id") or ""))
         else:
             result = {"ok": False, "error": f"Unknown command: {command!r}"}
     except Exception as exc:

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -13,6 +13,23 @@ The memory system enables Rex to:
 - Remember important information with automatic cleanup
 - Protect sensitive data from being exposed
 
+## Ownership and Isolation (US-303)
+
+Both stores are strictly per-user:
+
+- Every operation requires an explicit `user_id`, validated by
+  `rex.identity.validate_user_id`. Missing, blank, malformed, or
+  traversal-style identity fails closed (`TypeError`/`ValueError`).
+- There is **no silent fallback** to `default`, the active user, or any
+  other profile. Single-user setups select the `default` profile
+  explicitly (`--user default` or `rex identify --user default`).
+- Stores are partitioned on disk per user (see [Storage](#storage)), so
+  entry IDs may repeat across users without collision, and one user can
+  never read, search, delete, clear, or overwrite another user's entries.
+- Process-level instances are cached per validated `user_id`; a user never
+  receives an object backed by another user's file or in-memory entries.
+- Logs identify the owning user, never memory content.
+
 ## Working Memory
 
 Working memory stores recent interactions and task summaries, providing immediate context for conversations.
@@ -29,8 +46,8 @@ Working memory stores recent interactions and task summaries, providing immediat
 ```python
 from rex.memory import get_working_memory, remember_context, get_recent_context
 
-# Get the working memory instance
-wm = get_working_memory()
+# Get the working memory instance for one user
+wm = get_working_memory(user_id="james")
 
 # Add an entry
 wm.add_entry("User asked about weather in Dallas")
@@ -42,25 +59,30 @@ recent = wm.get_recent(5)  # Returns list of strings
 entries = wm.get_recent_with_timestamps(5)
 # Returns: [{"content": "...", "timestamp": "..."}, ...]
 
-# Clear all entries
+# Clear all entries (this user only)
 wm.clear()
 
 # Convenience functions
-remember_context("User prefers dark mode")
-context = get_recent_context(3)
+remember_context("User prefers dark mode", user_id="james")
+context = get_recent_context(3, user_id="james")
 ```
 
 ### CLI Commands
 
+Every `rex memory` command resolves the requesting user from `--user`,
+then the `rex identify` session, then `runtime.active_user` /
+`runtime.user_id` in config. With no resolvable user the command fails
+closed with an actionable error.
+
 ```bash
 # Show recent working memory entries
-rex memory recent 10
+rex memory recent 10 --user james
 
-# Clear working memory
-rex memory clear
+# Clear working memory (this user only)
+rex memory clear --user james
 
 # Show memory statistics
-rex memory stats
+rex memory stats --user james
 ```
 
 ## Long-Term Memory
@@ -78,7 +100,7 @@ Long-term memory stores structured entries organized by category with support fo
 ### Memory Entry Structure
 
 Each entry contains:
-- `entry_id`: Unique identifier
+- `entry_id`: Unique identifier (unique within one user's store)
 - `category`: Category name (e.g., "preferences", "facts")
 - `content`: Dictionary with the stored data
 - `created_at`: Creation timestamp
@@ -95,8 +117,8 @@ from rex.memory import (
     get_user_preferences,
 )
 
-# Get the long-term memory instance
-ltm = get_long_term_memory()
+# Get the long-term memory instance for one user
+ltm = get_long_term_memory(user_id="james")
 
 # Add an entry
 entry = ltm.add_entry(
@@ -118,7 +140,7 @@ entry = ltm.add_entry(
     sensitive=True,
 )
 
-# Search entries
+# Search entries (this user's entries only)
 results = ltm.search(category="preferences")
 results = ltm.search(keyword="theme")
 results = ltm.search(category="preferences", keyword="dark")
@@ -139,37 +161,37 @@ categories = ltm.list_categories()
 counts = ltm.count_by_category()
 
 # Convenience functions
-add_user_preference("notification_sound", "chime")
-prefs = get_user_preferences("notification")
+add_user_preference("notification_sound", "chime", user_id="james")
+prefs = get_user_preferences("notification", user_id="james")
 ```
 
 ### CLI Commands
 
 ```bash
 # Add a long-term memory entry
-rex memory add "preferences" '{"theme": "dark"}'
+rex memory add "preferences" '{"theme": "dark"}' --user james
 
 # Add with expiration (7 days)
-rex memory add "temp" '{"key": "value"}' --ttl=7d
+rex memory add "temp" '{"key": "value"}' --ttl=7d --user james
 
 # Add sensitive entry
-rex memory add "secrets" '{"api_key": "xxx"}' --sensitive
+rex memory add "secrets" '{"api_key": "xxx"}' --sensitive --user james
 
-# Search entries
-rex memory search "theme"
-rex memory search --category preferences
+# Search entries (this user's entries only)
+rex memory search "theme" --user james
+rex memory search --category preferences --user james
 
 # Search and show sensitive content
-rex memory search "api_key" --show-sensitive
+rex memory search "api_key" --show-sensitive --user james
 
-# Delete an entry
-rex memory forget mem_abc123
+# Delete an entry (must own it)
+rex memory forget mem_abc123 --user james
 
-# Run retention policy
-rex memory retention
+# Run retention policy (this user's store only)
+rex memory retention --user james
 
 # Show statistics
-rex memory stats
+rex memory stats --user james
 ```
 
 ### TTL Formats
@@ -189,6 +211,8 @@ Entries marked as sensitive are protected:
 2. Use `--show-sensitive` flag to view content
 3. The `to_safe_dict()` method returns redacted content
 4. Sensitive entries are included in searches but content is hidden
+5. Sensitive entries are isolated per user like everything else — another
+   user cannot see them at all, with or without `--show-sensitive`
 
 ```python
 # Check if entry is sensitive
@@ -200,20 +224,52 @@ if entry.sensitive:
 
 ## Retention Policies
 
-Expired entries are automatically managed:
+Expired entries are automatically managed, always per user:
 
-1. **On Startup**: Expired entries are deleted when LongTermMemory loads
-2. **Manual**: Call `run_retention_policy()` to clean up
-3. **CLI**: Run `rex memory retention`
+1. **On Startup**: Expired entries are deleted when a user's LongTermMemory loads
+2. **Manual**: Call `run_retention_policy()` on a user's store
+3. **CLI**: Run `rex memory retention --user <id>`
+4. **Scheduled**: `schedule_memory_cleanup(scheduler)` registers a job that
+   runs `run_memory_cleanup()`, which compacts **each user's store
+   independently**. A failure in one user's store never touches another
+   user's file; directory names that are not valid user IDs are ignored
+   and never treated as users.
 
 Entries without `expires_at` never expire.
 
 ## Storage
 
-Memory is persisted to JSON files:
+Memory is persisted to JSON files, partitioned per user:
 
-- Working Memory: `data/memory/working_memory.json`
-- Long-Term Memory: `data/memory/long_term_memory.json`
+- Working Memory: `data/memory/<user_id>/working_memory.json`
+- Long-Term Memory: `data/memory/<user_id>/long_term_memory.json`
+
+### Legacy unscoped files and migration
+
+Installations that predate per-user isolation stored one shared
+`data/memory/working_memory.json` and `data/memory/long_term_memory.json`
+at the data-dir root. Policy:
+
+- Those files belong **only** to the distinct `default` profile. They are
+  not shared, and they are never reassigned to a named user. Named users
+  never read them; a named user accessing memory first neither sees nor
+  consumes them.
+- Migration runs only when a caller explicitly requests
+  `user_id="default"` (e.g. `rex memory stats --user default`).
+- Migration is idempotent and crash-safe: the legacy file is copied into
+  `data/memory/default/` via a temp file and atomic replace. Only after
+  the default-profile copy exists is the original renamed to
+  `<name>.json.pre-user-isolation.bak` at the data-dir root — it is
+  preserved, never deleted.
+- A failed or partial migration leaves the original untouched and fails
+  the requesting call; the next explicit `default` access retries.
+
+**Recovery**: to undo a migration, delete
+`data/memory/default/<name>.json` and rename
+`data/memory/<name>.json.pre-user-isolation.bak` back to
+`data/memory/<name>.json`. To reassign legacy data to a named user,
+manually copy the file into `data/memory/<user_id>/` — there is
+deliberately no automatic reassignment tool.
 
 ### Storage Format
 
@@ -264,6 +320,8 @@ Common categories for organizing entries:
 3. **Mark sensitive data** - Protect credentials and personal info
 4. **Clean up regularly** - Run retention policy periodically
 5. **Use convenience functions** - `add_user_preference()` for common tasks
+6. **Always pass the real requester's `user_id`** - never hardcode a
+   profile on behalf of someone else
 
 ## Integration
 
@@ -272,17 +330,17 @@ The memory system integrates with other Rex components:
 ```python
 from rex.memory import remember_context, get_recent_context
 
-# In assistant.py - track conversation context
-async def generate_reply(self, user_input: str) -> str:
-    # Add to working memory
-    remember_context(f"User: {user_input}")
+# In assistant code - track conversation context for the identified user
+async def generate_reply(self, user_input: str, user_id: str) -> str:
+    # Add to this user's working memory
+    remember_context(f"User: {user_input}", user_id=user_id)
 
-    # Get recent context for LLM
-    context = get_recent_context(5)
+    # Get this user's recent context for the LLM
+    context = get_recent_context(5, user_id=user_id)
 
     # ... generate reply ...
 
-    remember_context(f"Rex: {reply}")
+    remember_context(f"Rex: {reply}", user_id=user_id)
     return reply
 ```
 
@@ -292,15 +350,17 @@ async def generate_reply(self, user_input: str) -> str:
 
 | Method | Description |
 |--------|-------------|
+| `WorkingMemory(user_id=...)` | Construct a store owned by one user |
 | `add_entry(content)` | Add a new entry |
 | `get_recent(n)` | Get last n entries (content only) |
 | `get_recent_with_timestamps(n)` | Get last n entries with timestamps |
-| `clear()` | Remove all entries |
+| `clear()` | Remove all entries (this owner only) |
 
 ### LongTermMemory
 
 | Method | Description |
 |--------|-------------|
+| `LongTermMemory(user_id=...)` | Construct a store owned by one user |
 | `add_entry(category, content, expires_in, sensitive)` | Add entry |
 | `get_entry(entry_id)` | Get entry by ID |
 | `search(category, keyword, include_sensitive, include_expired)` | Search entries |
@@ -309,15 +369,26 @@ async def generate_reply(self, user_input: str) -> str:
 | `list_categories()` | List all categories |
 | `count_by_category()` | Count entries per category |
 
-### Convenience Functions
+Both classes also accept an explicit `storage_path` for unit tests; the
+production getters below always use the validated per-user path.
+
+### Module Functions
 
 | Function | Description |
 |----------|-------------|
-| `add_user_preference(key, value, ...)` | Add user preference |
-| `get_user_preferences(key)` | Get user preferences |
-| `add_fact(topic, content, ...)` | Add a fact |
-| `remember_context(summary)` | Add to working memory |
-| `get_recent_context(n)` | Get recent working memory |
+| `get_working_memory(user_id=...)` | Per-user working memory instance |
+| `get_long_term_memory(user_id=...)` | Per-user long-term memory instance |
+| `set_working_memory(wm, user_id=...)` | Inject an instance for one user (testing) |
+| `set_long_term_memory(ltm, user_id=...)` | Inject an instance for one user (testing) |
+| `add_user_preference(key, value, ..., user_id=...)` | Add user preference |
+| `get_user_preferences(key, user_id=...)` | Get user preferences |
+| `add_fact(topic, content, ..., user_id=...)` | Add a fact |
+| `remember_context(summary, user_id=...)` | Add to working memory |
+| `get_recent_context(n, user_id=...)` | Get recent working memory |
+| `list_memory_user_ids()` | Validated user IDs with a store on disk |
+| `run_memory_cleanup()` | Compact every user's store independently |
+| `schedule_memory_cleanup(scheduler, ...)` | Register the per-user cleanup job |
+| `memory_store_metrics()` | Aggregate entry counts (no content) |
 
 ---
 

--- a/rex/app.py
+++ b/rex/app.py
@@ -20,7 +20,7 @@ import time
 from rex.audio.speaker_discovery import start_smart_speaker_discovery
 from rex.credentials import get_credential_manager
 from rex.logging_utils import _LEVEL_NAMES, configure_logging
-from rex.memory import get_long_term_memory, get_working_memory
+from rex.memory import memory_store_metrics
 from rex.service_supervisor import ServiceSupervisor
 from rex.services import initialize_services
 
@@ -186,9 +186,9 @@ def main(argv: list[str] | None = None) -> int:
         if "memory_store" in services_to_manage:
 
             def start_memory_store():
-                get_working_memory()
-                get_long_term_memory()
-                logger.info("Memory store initialized")
+                # Per-user stores load lazily on first authenticated access
+                # (US-303 isolation); there is no global store to pre-warm.
+                logger.info("Memory store initialized (per-user stores load lazily)")
 
             def stop_memory_store():
                 logger.info("Memory store shutdown complete")
@@ -197,12 +197,7 @@ def main(argv: list[str] | None = None) -> int:
                 return True
 
             def memory_metrics():
-                wm = get_working_memory()
-                ltm = get_long_term_memory()
-                return {
-                    "working_memory": wm.stats(),
-                    "long_term_memory": ltm.stats(),
-                }
+                return memory_store_metrics()
 
             _supervisor.register_service(
                 name="memory_store",

--- a/rex/commands/memory.py
+++ b/rex/commands/memory.py
@@ -59,16 +59,46 @@ def cmd_remember(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_memory_user(args: argparse.Namespace) -> str | None:
+    """Resolve the requesting user for memory commands, failing closed.
+
+    Uses ``--user`` when given, otherwise the standard identity chain
+    (``rex identify`` session state, then ``runtime.active_user`` /
+    ``runtime.user_id`` in config). Never silently falls back to the
+    ``default`` profile — single-user setups select it explicitly with
+    ``--user default`` or ``rex identify --user default``.
+    """
+    from rex.commands._helpers import _resolve_cli_user
+
+    try:
+        return _resolve_cli_user(args)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return None
+
+
+_NO_USER_MSG = (
+    "Error: No active user for memory.\n"
+    "Set one with: rex identify --user <id>\n"
+    "Or pass one explicitly: rex memory ... --user <id>"
+)
+
+
 def cmd_memory(args: argparse.Namespace) -> int:
-    """Manage working and long-term memory."""
+    """Manage the requesting user's working and long-term memory."""
     import json
 
     from rex.memory import get_long_term_memory, get_working_memory
 
     subcommand = args.memory_command
 
+    user_id = _resolve_memory_user(args)
+    if user_id is None:
+        print(_NO_USER_MSG)
+        return 1
+
     if subcommand == "recent":
-        wm = get_working_memory()
+        wm = get_working_memory(user_id=user_id)
         n = int(getattr(args, "count", 10))
         entries = wm.get_recent_with_timestamps(n)
 
@@ -76,7 +106,7 @@ def cmd_memory(args: argparse.Namespace) -> int:
             print("No working memory entries.")
             return 0
 
-        print("Recent Working Memory")
+        print(f"Recent Working Memory (user: {user_id})")
         print("=" * 60)
         print()
 
@@ -91,7 +121,7 @@ def cmd_memory(args: argparse.Namespace) -> int:
         return 0
 
     if subcommand == "add":
-        ltm = get_long_term_memory()
+        ltm = get_long_term_memory(user_id=user_id)
         category = args.category
         try:
             content = json.loads(args.content)
@@ -121,7 +151,7 @@ def cmd_memory(args: argparse.Namespace) -> int:
         return 0
 
     if subcommand == "search":
-        ltm = get_long_term_memory()
+        ltm = get_long_term_memory(user_id=user_id)
         keyword = args.keyword
         category = args.category
         show_sensitive = args.show_sensitive
@@ -136,7 +166,7 @@ def cmd_memory(args: argparse.Namespace) -> int:
             print("No matching memory entries found.")
             return 0
 
-        print("Long-Term Memory Search Results")
+        print(f"Long-Term Memory Search Results (user: {user_id})")
         print("=" * 60)
         print()
 
@@ -159,7 +189,7 @@ def cmd_memory(args: argparse.Namespace) -> int:
         return 0
 
     if subcommand == "forget":
-        ltm = get_long_term_memory()
+        ltm = get_long_term_memory(user_id=user_id)
         entry_id = args.entry_id
         if ltm.forget(entry_id):
             print(f"Deleted memory entry: {entry_id}")
@@ -168,23 +198,23 @@ def cmd_memory(args: argparse.Namespace) -> int:
         return 1
 
     if subcommand == "clear":
-        wm = get_working_memory()
+        wm = get_working_memory(user_id=user_id)
         count = len(wm)
         wm.clear()
         print(f"Cleared {count} working memory entries.")
         return 0
 
     if subcommand == "retention":
-        ltm = get_long_term_memory()
+        ltm = get_long_term_memory(user_id=user_id)
         deleted = ltm.run_retention_policy()
         print(f"Retention policy deleted {deleted} expired entries.")
         return 0
 
     if subcommand == "stats":
-        wm = get_working_memory()
-        ltm = get_long_term_memory()
+        wm = get_working_memory(user_id=user_id)
+        ltm = get_long_term_memory(user_id=user_id)
 
-        print("Memory Statistics")
+        print(f"Memory Statistics (user: {user_id})")
         print("=" * 60)
         print()
         print(f"Working Memory: {len(wm)} entries")
@@ -379,6 +409,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     memory_recent.add_argument(
         "--show-sensitive", action="store_true", help="No-op (kept for compatibility)"
     )
+    memory_recent.add_argument("--user", type=str, help="User ID whose memory to read")
     memory_recent.set_defaults(func=_cli().cmd_memory, memory_command="recent")
 
     memory_add = memory_subparsers.add_parser(
@@ -396,6 +427,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     memory_add.add_argument(
         "--sensitive", action="store_true", help="Mark this entry as containing sensitive data"
     )
+    memory_add.add_argument("--user", type=str, help="User ID to act as (owner of the entry)")
     memory_add.set_defaults(func=_cli().cmd_memory, memory_command="add")
 
     memory_search = memory_subparsers.add_parser(
@@ -410,6 +442,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     memory_search.add_argument(
         "--show-sensitive", action="store_true", help="Show content of sensitive entries"
     )
+    memory_search.add_argument("--user", type=str, help="User ID whose memory to search")
     memory_search.set_defaults(func=_cli().cmd_memory, memory_command="search")
 
     memory_forget = memory_subparsers.add_parser(
@@ -418,6 +451,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         description="Delete a specific entry from long-term memory.",
     )
     memory_forget.add_argument("entry_id", type=str, help="ID of the entry to delete")
+    memory_forget.add_argument("--user", type=str, help="User ID to act as (must own the entry)")
     memory_forget.set_defaults(func=_cli().cmd_memory, memory_command="forget")
 
     memory_clear = memory_subparsers.add_parser(
@@ -425,6 +459,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         help="Clear all working memory",
         description="Remove all entries from working memory.",
     )
+    memory_clear.add_argument("--user", type=str, help="User ID whose working memory to clear")
     memory_clear.set_defaults(func=_cli().cmd_memory, memory_command="clear")
 
     memory_retention = memory_subparsers.add_parser(
@@ -432,6 +467,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         help="Run retention policy",
         description="Delete all expired entries from long-term memory.",
     )
+    memory_retention.add_argument("--user", type=str, help="User ID whose memory retention to run")
     memory_retention.set_defaults(func=_cli().cmd_memory, memory_command="retention")
 
     memory_stats = memory_subparsers.add_parser(
@@ -439,6 +475,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         help="Show memory statistics",
         description="Display statistics about working and long-term memory.",
     )
+    memory_stats.add_argument("--user", type=str, help="User ID whose statistics to show")
     memory_stats.set_defaults(func=_cli().cmd_memory, memory_command="stats")
 
     memory_parser.set_defaults(func=_cli().cmd_memory, memory_command="stats")

--- a/rex/memory.py
+++ b/rex/memory.py
@@ -8,6 +8,38 @@ as well as structured memory capabilities:
 
 Re-exports from memory_utils for backward compatibility.
 
+Ownership model (US-303 per-user isolation):
+- Every working-memory and long-term-memory operation requires an explicit
+  validated ``user_id`` (see :func:`rex.identity.validate_user_id`).
+- Stores are partitioned on disk per user::
+
+      data/memory/<user_id>/working_memory.json
+      data/memory/<user_id>/long_term_memory.json
+
+- Missing, blank, malformed, or traversal-style identity fails closed
+  (``TypeError``/``ValueError``); there is no silent fallback to ``default``,
+  the active user, or any other profile.
+- Process-level instances are cached in dictionaries keyed by validated
+  ``user_id``; one user never receives an object backed by another user's
+  path or in-memory entries.
+- User IDs that differ only by case from an existing profile are rejected
+  on every platform: Windows/macOS filesystems are case-insensitive, so
+  "James" and "james" would otherwise silently alias one on-disk store.
+
+Legacy unscoped-file migration:
+- The pre-isolation shared files ``data/memory/working_memory.json`` and
+  ``data/memory/long_term_memory.json`` belong only to the distinct
+  ``default`` profile. They are never shared and never reassigned to a named
+  user, and named users never read them.
+- Migration runs only when a caller explicitly requests
+  ``user_id="default"``. It is idempotent and crash-safe: the legacy file is
+  copied into ``data/memory/default/`` via a temp file + atomic replace, and
+  only after the default-profile copy exists is the original moved aside as
+  ``<name>.json.pre-user-isolation.bak`` (never deleted). A failed or
+  partial migration leaves the original untouched and is retried on the next
+  explicit ``default`` access. To recover manually, restore the ``.bak``
+  file to its original name and remove ``data/memory/default/<name>.json``.
+
 Usage:
     from rex.memory import (
         get_working_memory,
@@ -16,12 +48,12 @@ Usage:
         remember_context,
     )
 
-    # Working memory
-    wm = get_working_memory()
+    # Working memory (owner-scoped)
+    wm = get_working_memory(user_id="james")
     wm.add_entry("User asked about weather")
 
-    # Long-term memory
-    ltm = get_long_term_memory()
+    # Long-term memory (owner-scoped)
+    ltm = get_long_term_memory(user_id="james")
     entry = ltm.add_entry("preferences", {"theme": "dark"})
 """
 
@@ -29,12 +61,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+from rex.identity import validate_user_id
 
 # Re-export existing memory utilities for backward compatibility
 from .memory_utils import (  # noqa: F401
@@ -54,16 +90,99 @@ logger = logging.getLogger(__name__)
 # Default data directory for structured memory
 _DATA_DIR = Path("data/memory")
 
+# The distinct profile that owns pre-isolation legacy data. Never used as an
+# implicit fallback; callers must select it explicitly.
+DEFAULT_PROFILE = "default"
 
-def _ensure_data_dir() -> Path:
-    """Ensure the data directory exists."""
-    _DATA_DIR.mkdir(parents=True, exist_ok=True)
-    return _DATA_DIR
+# Suffix appended to a legacy shared store file once its content has been
+# migrated into the explicit ``default`` profile.
+LEGACY_BACKUP_SUFFIX = ".pre-user-isolation.bak"
+
+_WORKING_MEMORY_FILENAME = "working_memory.json"
+_LONG_TERM_MEMORY_FILENAME = "long_term_memory.json"
 
 
 def _utc_now() -> datetime:
     """Return the current UTC datetime."""
     return datetime.now(UTC)
+
+
+def _reject_case_conflicts(user_id: str) -> None:
+    """Fail closed when *user_id* differs only by case from a known profile.
+
+    Windows (NTFS) and macOS (APFS/HFS+) filesystems are case-insensitive,
+    so two IDs differing only by case would silently alias one on-disk
+    store — user "James" would read and rewrite user "james"'s files. The
+    later spelling is rejected on every platform so behavior is consistent
+    and fail-closed.
+
+    Raises:
+        ValueError: If a case-variant of *user_id* already exists in the
+            process registries or as a memory directory on disk.
+    """
+    folded = user_id.casefold()
+    known_ids: set[str] = set(_working_memories) | set(_long_term_memories)
+    if _DATA_DIR.is_dir():
+        known_ids.update(entry.name for entry in _DATA_DIR.iterdir() if entry.is_dir())
+    for existing in known_ids:
+        if existing != user_id and existing.casefold() == folded:
+            raise ValueError(
+                f"Invalid user_id: {user_id!r} (conflicts with an existing memory profile)"
+            )
+
+
+def _user_memory_dir(user_id: str) -> Path:
+    """Return the per-user memory directory for a validated user ID."""
+    user_id = validate_user_id(user_id)
+    _reject_case_conflicts(user_id)
+    return _DATA_DIR / user_id
+
+
+def _migrate_legacy_default_store(filename: str) -> None:
+    """Migrate a pre-isolation shared store file to the ``default`` profile.
+
+    Called only when a caller explicitly requests ``user_id="default"``.
+    Idempotent and crash-safe:
+
+    1. If ``data/memory/<filename>`` does not exist, do nothing.
+    2. If the default-profile copy does not exist yet, copy the legacy file
+       via a temp file and atomic replace. A failure here propagates (the
+       caller fails closed), leaves the original untouched, and is retried
+       on the next explicit ``default`` access.
+    3. Only once the default-profile copy exists is the original moved aside
+       as ``<filename>.pre-user-isolation.bak`` — preserved, never deleted.
+       If the move fails, the original stays in place and the move is
+       retried later; migration itself is already complete.
+    """
+    legacy = _DATA_DIR / filename
+    if not legacy.is_file():
+        return
+
+    target = _DATA_DIR / DEFAULT_PROFILE / filename
+    if not target.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # PID-unique temp file: concurrent first-time migrations (e.g. two
+        # GUI bridge processes) each copy privately, and os.replace is
+        # atomic, so interleaved writes can never publish a corrupt store.
+        tmp_copy = target.with_name(f"{target.name}.migrating.{os.getpid()}")
+        try:
+            shutil.copyfile(legacy, tmp_copy)
+            os.replace(tmp_copy, target)
+        finally:
+            tmp_copy.unlink(missing_ok=True)
+        logger.info("Migrated legacy shared %s into the 'default' profile store", filename)
+
+    backup = _DATA_DIR / (filename + LEGACY_BACKUP_SUFFIX)
+    if not backup.exists():
+        try:
+            legacy.rename(backup)
+            logger.info("Preserved legacy %s as %s", filename, backup.name)
+        except OSError as exc:
+            logger.warning(
+                "Could not move legacy %s aside: %s (original left in place)",
+                filename,
+                exc,
+            )
 
 
 # =============================================================================
@@ -76,14 +195,16 @@ class WorkingMemory:
 
     Holds an ordered list of recent entries, automatically persisting to disk
     and loading on startup. Useful for maintaining immediate conversational
-    context.
+    context. Each instance is backed by exactly one owner's store.
 
     Attributes:
         max_entries: Maximum number of entries to retain (default 100).
         storage_path: Path to the persistence file.
+        user_id: Validated owner of this store, or None for an explicit
+            custom ``storage_path`` (unit-test instances).
 
     Example:
-        wm = WorkingMemory()
+        wm = WorkingMemory(user_id="james")
         wm.add_entry("User asked about the weather in Dallas")
         wm.add_entry("Checked weather API - sunny, 72°F")
 
@@ -96,22 +217,42 @@ class WorkingMemory:
         self,
         storage_path: Path | str | None = None,
         max_entries: int = 100,
+        *,
+        user_id: str | None = None,
     ) -> None:
-        """Initialize working memory.
+        """Initialize working memory for one owner.
 
         Args:
-            storage_path: Path to the persistence file. Defaults to
-                data/memory/working_memory.json
+            storage_path: Explicit persistence file (unit-test support). When
+                omitted, a validated ``user_id`` is required and the store
+                lives at ``data/memory/<user_id>/working_memory.json``.
             max_entries: Maximum entries to retain before oldest are removed.
-        """
-        if storage_path is None:
-            _ensure_data_dir()
-            storage_path = _DATA_DIR / "working_memory.json"
+            user_id: Owner of this store. Validated; fails closed when the
+                default per-user path is used and no owner is given.
 
+        Raises:
+            ValueError: If neither ``storage_path`` nor a valid ``user_id``
+                is provided, or if ``user_id`` is invalid.
+        """
+        if user_id is not None:
+            user_id = validate_user_id(user_id)
+
+        if storage_path is None:
+            if user_id is None:
+                raise ValueError("WorkingMemory requires a user_id (or an explicit storage_path)")
+            if user_id == DEFAULT_PROFILE:
+                _migrate_legacy_default_store(_WORKING_MEMORY_FILENAME)
+            storage_path = _user_memory_dir(user_id) / _WORKING_MEMORY_FILENAME
+
+        self.user_id = user_id
         self.storage_path = Path(storage_path)
         self.max_entries = max_entries
         self._entries: list[dict[str, Any]] = []
         self._load()
+
+    def _owner_label(self) -> str:
+        """Owner identifier for logging (never memory content)."""
+        return self.user_id if self.user_id is not None else "<custom-path>"
 
     def _load(self) -> None:
         """Load entries from disk."""
@@ -120,9 +261,17 @@ class WorkingMemory:
                 with open(self.storage_path, encoding="utf-8") as f:
                     data = json.load(f)
                     self._entries = data.get("entries", [])
-                    logger.debug(f"Loaded {len(self._entries)} working memory entries")
+                    logger.debug(
+                        "Loaded %d working memory entries for owner '%s'",
+                        len(self._entries),
+                        self._owner_label(),
+                    )
             except (json.JSONDecodeError, OSError) as e:
-                logger.warning(f"Failed to load working memory: {e}")
+                logger.warning(
+                    "Failed to load working memory for owner '%s': %s",
+                    self._owner_label(),
+                    e,
+                )
                 self._entries = []
 
     def _save(self) -> None:
@@ -132,7 +281,11 @@ class WorkingMemory:
             with open(self.storage_path, "w", encoding="utf-8") as f:
                 json.dump({"entries": self._entries}, f, indent=2, default=str)
         except OSError as e:
-            logger.error(f"Failed to save working memory: {e}")
+            logger.error(
+                "Failed to save working memory for owner '%s': %s",
+                self._owner_label(),
+                e,
+            )
 
     def add_entry(self, content: str) -> None:
         """Add a new entry to working memory.
@@ -176,9 +329,10 @@ class WorkingMemory:
         return self._entries[-n:] if n < len(self._entries) else self._entries.copy()
 
     def clear(self) -> None:
-        """Clear all working memory entries."""
+        """Clear all working memory entries for this owner."""
         self._entries = []
         self._save()
+        logger.debug("Cleared working memory for owner '%s'", self._owner_label())
 
     def __len__(self) -> int:
         """Return the number of entries."""
@@ -271,10 +425,11 @@ class LongTermMemory:
     - Sensitive data flagging
     - Keyword-based search across content
 
-    Entries are persisted to disk as JSON.
+    Entries are persisted to disk as JSON. Each instance is backed by exactly
+    one owner's store; entry IDs may repeat across owners without collision.
 
     Example:
-        ltm = LongTermMemory()
+        ltm = LongTermMemory(user_id="james")
 
         # Add a preference that expires in 30 days
         entry = ltm.add_entry(
@@ -293,21 +448,41 @@ class LongTermMemory:
     def __init__(
         self,
         storage_path: Path | str | None = None,
+        *,
+        user_id: str | None = None,
     ) -> None:
-        """Initialize long-term memory.
+        """Initialize long-term memory for one owner.
 
         Args:
-            storage_path: Path to the persistence file. Defaults to
-                data/memory/long_term_memory.json
-        """
-        if storage_path is None:
-            _ensure_data_dir()
-            storage_path = _DATA_DIR / "long_term_memory.json"
+            storage_path: Explicit persistence file (unit-test support). When
+                omitted, a validated ``user_id`` is required and the store
+                lives at ``data/memory/<user_id>/long_term_memory.json``.
+            user_id: Owner of this store. Validated; fails closed when the
+                default per-user path is used and no owner is given.
 
+        Raises:
+            ValueError: If neither ``storage_path`` nor a valid ``user_id``
+                is provided, or if ``user_id`` is invalid.
+        """
+        if user_id is not None:
+            user_id = validate_user_id(user_id)
+
+        if storage_path is None:
+            if user_id is None:
+                raise ValueError("LongTermMemory requires a user_id (or an explicit storage_path)")
+            if user_id == DEFAULT_PROFILE:
+                _migrate_legacy_default_store(_LONG_TERM_MEMORY_FILENAME)
+            storage_path = _user_memory_dir(user_id) / _LONG_TERM_MEMORY_FILENAME
+
+        self.user_id = user_id
         self.storage_path = Path(storage_path)
         self._entries: dict[str, MemoryEntry] = {}
         self._load()
         self.run_retention_policy()
+
+    def _owner_label(self) -> str:
+        """Owner identifier for logging (never memory content)."""
+        return self.user_id if self.user_id is not None else "<custom-path>"
 
     def _load(self) -> None:
         """Load entries from disk."""
@@ -318,9 +493,17 @@ class LongTermMemory:
                     for entry_data in data.get("entries", []):
                         entry = MemoryEntry.model_validate(entry_data)
                         self._entries[entry.entry_id] = entry
-                    logger.debug(f"Loaded {len(self._entries)} long-term memory entries")
+                    logger.debug(
+                        "Loaded %d long-term memory entries for owner '%s'",
+                        len(self._entries),
+                        self._owner_label(),
+                    )
             except (json.JSONDecodeError, OSError) as e:
-                logger.warning(f"Failed to load long-term memory: {e}")
+                logger.warning(
+                    "Failed to load long-term memory for owner '%s': %s",
+                    self._owner_label(),
+                    e,
+                )
                 self._entries = {}
 
     def _save(self) -> None:
@@ -331,7 +514,11 @@ class LongTermMemory:
             with open(self.storage_path, "w", encoding="utf-8") as f:
                 json.dump({"entries": entries_data}, f, indent=2, default=str)
         except OSError as e:
-            logger.error(f"Failed to save long-term memory: {e}")
+            logger.error(
+                "Failed to save long-term memory for owner '%s': %s",
+                self._owner_label(),
+                e,
+            )
 
     def add_entry(
         self,
@@ -368,7 +555,12 @@ class LongTermMemory:
         self._entries[entry.entry_id] = entry
         self._save()
 
-        logger.debug(f"Added memory entry: {entry.entry_id} in category '{category}'")
+        logger.debug(
+            "Added memory entry %s in category '%s' for owner '%s'",
+            entry.entry_id,
+            category,
+            self._owner_label(),
+        )
         return entry
 
     def get_entry(self, entry_id: str) -> MemoryEntry | None:
@@ -466,7 +658,7 @@ class LongTermMemory:
         if entry_id in self._entries:
             del self._entries[entry_id]
             self._save()
-            logger.debug(f"Deleted memory entry: {entry_id}")
+            logger.debug("Deleted memory entry %s for owner '%s'", entry_id, self._owner_label())
             return True
         return False
 
@@ -485,7 +677,11 @@ class LongTermMemory:
 
         if expired_ids:
             self._save()
-            logger.info(f"Retention policy deleted {len(expired_ids)} expired entries")
+            logger.info(
+                "Retention policy deleted %d expired entries for owner '%s'",
+                len(expired_ids),
+                self._owner_label(),
+            )
 
         return len(expired_ids)
 
@@ -503,7 +699,11 @@ class LongTermMemory:
         # Always rewrite storage to compact the file
         self._save()
         logger.info(
-            f"Memory store compacted: {removed} expired entries removed, {len(self)} active entries retained"
+            "Memory store compacted for owner '%s': %d expired entries removed, "
+            "%d active entries retained",
+            self._owner_label(),
+            removed,
+            len(self),
         )
         return removed
 
@@ -544,39 +744,67 @@ class LongTermMemory:
 
 
 # =============================================================================
-# Global Instances (Singleton Pattern)
+# Per-User Instance Registries
 # =============================================================================
 
-_working_memory: WorkingMemory | None = None
-_long_term_memory: LongTermMemory | None = None
+_working_memories: dict[str, WorkingMemory] = {}
+_long_term_memories: dict[str, LongTermMemory] = {}
 
 
-def get_working_memory() -> WorkingMemory:
-    """Get the global working memory instance."""
-    global _working_memory
-    if _working_memory is None:
-        _working_memory = WorkingMemory()
-    return _working_memory
+def get_working_memory(*, user_id: str) -> WorkingMemory:
+    """Get the working memory instance owned by *user_id*.
+
+    Args:
+        user_id: Validated owner of the store. Required; missing or invalid
+            identity fails closed (``TypeError``/``ValueError``).
+
+    Returns:
+        The per-user WorkingMemory instance (created lazily).
+    """
+    user_id = validate_user_id(user_id)
+    instance = _working_memories.get(user_id)
+    if instance is None:
+        instance = WorkingMemory(user_id=user_id)
+        _working_memories[user_id] = instance
+    return instance
 
 
-def set_working_memory(wm: WorkingMemory) -> None:
-    """Set the global working memory instance (for testing)."""
-    global _working_memory
-    _working_memory = wm
+def set_working_memory(wm: WorkingMemory | None, *, user_id: str) -> None:
+    """Set (or clear) the working memory instance for *user_id* (for testing)."""
+    user_id = validate_user_id(user_id)
+    if wm is None:
+        _working_memories.pop(user_id, None)
+    else:
+        _reject_case_conflicts(user_id)
+        _working_memories[user_id] = wm
 
 
-def get_long_term_memory() -> LongTermMemory:
-    """Get the global long-term memory instance."""
-    global _long_term_memory
-    if _long_term_memory is None:
-        _long_term_memory = LongTermMemory()
-    return _long_term_memory
+def get_long_term_memory(*, user_id: str) -> LongTermMemory:
+    """Get the long-term memory instance owned by *user_id*.
+
+    Args:
+        user_id: Validated owner of the store. Required; missing or invalid
+            identity fails closed (``TypeError``/``ValueError``).
+
+    Returns:
+        The per-user LongTermMemory instance (created lazily).
+    """
+    user_id = validate_user_id(user_id)
+    instance = _long_term_memories.get(user_id)
+    if instance is None:
+        instance = LongTermMemory(user_id=user_id)
+        _long_term_memories[user_id] = instance
+    return instance
 
 
-def set_long_term_memory(ltm: LongTermMemory) -> None:
-    """Set the global long-term memory instance (for testing)."""
-    global _long_term_memory
-    _long_term_memory = ltm
+def set_long_term_memory(ltm: LongTermMemory | None, *, user_id: str) -> None:
+    """Set (or clear) the long-term memory instance for *user_id* (for testing)."""
+    user_id = validate_user_id(user_id)
+    if ltm is None:
+        _long_term_memories.pop(user_id, None)
+    else:
+        _reject_case_conflicts(user_id)
+        _long_term_memories[user_id] = ltm
 
 
 # =============================================================================
@@ -589,19 +817,23 @@ def add_user_preference(
     value: Any,
     expires_in: timedelta | None = None,
     sensitive: bool = False,
+    *,
+    user_id: str,
 ) -> MemoryEntry:
-    """Add a user preference to long-term memory.
+    """Add a user preference to *user_id*'s long-term memory.
 
     Args:
         key: Preference key (e.g., 'theme', 'language').
         value: Preference value.
         expires_in: Optional expiration time.
         sensitive: Whether this is sensitive data.
+        user_id: Owner of the preference. Required; fails closed on
+            missing or invalid identity.
 
     Returns:
         The created MemoryEntry.
     """
-    ltm = get_long_term_memory()
+    ltm = get_long_term_memory(user_id=user_id)
     return ltm.add_entry(
         category="user_preferences",
         content={key: value},
@@ -610,16 +842,18 @@ def add_user_preference(
     )
 
 
-def get_user_preferences(key: str | None = None) -> list[MemoryEntry]:
-    """Get user preferences from long-term memory.
+def get_user_preferences(key: str | None = None, *, user_id: str) -> list[MemoryEntry]:
+    """Get *user_id*'s preferences from long-term memory.
 
     Args:
         key: Optional key to search for.
+        user_id: Owner whose preferences to read. Required; fails closed on
+            missing or invalid identity.
 
     Returns:
         List of matching preference entries.
     """
-    ltm = get_long_term_memory()
+    ltm = get_long_term_memory(user_id=user_id)
     return ltm.search(category="user_preferences", keyword=key)
 
 
@@ -627,18 +861,22 @@ def add_fact(
     topic: str,
     content: dict[str, Any],
     expires_in: timedelta | None = None,
+    *,
+    user_id: str,
 ) -> MemoryEntry:
-    """Add a fact to long-term memory.
+    """Add a fact to *user_id*'s long-term memory.
 
     Args:
         topic: The topic or subject of the fact.
         content: Fact data.
         expires_in: Optional expiration time.
+        user_id: Owner of the fact. Required; fails closed on missing or
+            invalid identity.
 
     Returns:
         The created MemoryEntry.
     """
-    ltm = get_long_term_memory()
+    ltm = get_long_term_memory(user_id=user_id)
     return ltm.add_entry(
         category="facts",
         content={"topic": topic, **content},
@@ -646,27 +884,83 @@ def add_fact(
     )
 
 
-def remember_context(summary: str) -> None:
-    """Add a context summary to working memory.
+def remember_context(summary: str, *, user_id: str) -> None:
+    """Add a context summary to *user_id*'s working memory.
 
     Args:
         summary: A summary of the current context or interaction.
+        user_id: Owner of the context. Required; fails closed on missing or
+            invalid identity.
     """
-    wm = get_working_memory()
+    wm = get_working_memory(user_id=user_id)
     wm.add_entry(summary)
 
 
-def get_recent_context(n: int = 5) -> list[str]:
-    """Get recent context from working memory.
+def get_recent_context(n: int = 5, *, user_id: str) -> list[str]:
+    """Get recent context from *user_id*'s working memory.
 
     Args:
         n: Number of entries to retrieve.
+        user_id: Owner whose context to read. Required; fails closed on
+            missing or invalid identity.
 
     Returns:
         List of recent context summaries.
     """
-    wm = get_working_memory()
+    wm = get_working_memory(user_id=user_id)
     return wm.get_recent(n)
+
+
+# =============================================================================
+# Per-User Maintenance (cleanup scheduling and metrics)
+# =============================================================================
+
+
+def list_memory_user_ids() -> list[str]:
+    """Discover user IDs that have a per-user memory directory on disk.
+
+    Only directory names that pass :func:`rex.identity.validate_user_id` are
+    returned; anything else (including the legacy shared files and their
+    backups at the data-dir root) is ignored and never treated as a user.
+    """
+    if not _DATA_DIR.is_dir():
+        return []
+    users: list[str] = []
+    for entry in sorted(_DATA_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        try:
+            validate_user_id(entry.name)
+        except ValueError:
+            logger.warning("Ignoring invalid memory directory name: %r", entry.name)
+            continue
+        users.append(entry.name)
+    return users
+
+
+def run_memory_cleanup() -> dict[str, int]:
+    """Compact every known user's long-term store, each independently.
+
+    Covers users discovered on disk plus any live registry instances (e.g.
+    test-injected stores). A failure in one user's store is logged and never
+    affects another user's store.
+
+    Returns:
+        Mapping of user_id to the number of expired entries removed. Users
+        whose cleanup failed are omitted.
+    """
+    user_ids = sorted(set(list_memory_user_ids()) | set(_long_term_memories))
+    results: dict[str, int] = {}
+    for user_id in user_ids:
+        try:
+            removed = get_long_term_memory(user_id=user_id).compact()
+        except Exception:
+            logger.exception(
+                "Memory cleanup failed for owner '%s'; other stores unaffected", user_id
+            )
+            continue
+        results[user_id] = removed
+    return results
 
 
 def schedule_memory_cleanup(
@@ -676,9 +970,10 @@ def schedule_memory_cleanup(
 ) -> None:
     """Register a scheduled memory cleanup job with the scheduler.
 
-    Registers a callback that runs compact() on the global long-term memory
-    at the given interval. Expired entries are removed and the store is
-    compacted on each run.
+    Registers a callback that runs :func:`run_memory_cleanup` at the given
+    interval: every user's long-term store is compacted independently, one
+    user's failure never touches another user's file, and invalid directory
+    names are ignored.
 
     Args:
         scheduler: A Scheduler instance from rex.scheduler.
@@ -687,9 +982,14 @@ def schedule_memory_cleanup(
     """
 
     def _cleanup_callback(job: Any) -> None:  # noqa: ARG001
-        ltm = get_long_term_memory()
-        removed = ltm.compact()
-        logger.info(f"Scheduled memory cleanup complete: {removed} entries removed")
+        results = run_memory_cleanup()
+        removed = sum(results.values())
+        logger.info(
+            "Scheduled memory cleanup complete: %d expired entries removed "
+            "across %d user store(s)",
+            removed,
+            len(results),
+        )
 
     # Register callback and add the job
     scheduler.register_callback("memory_cleanup", _cleanup_callback)
@@ -700,6 +1000,30 @@ def schedule_memory_cleanup(
         callback_name="memory_cleanup",
     )
     logger.info(f"Memory cleanup scheduled every {interval_seconds}s (job_id={job_id})")
+
+
+def memory_store_metrics() -> dict[str, Any]:
+    """Aggregate entry counts across all per-user stores (no content).
+
+    Used by the service supervisor for health metrics. Counts only — never
+    memory content, categories, or entry IDs.
+    """
+    user_ids = sorted(
+        set(list_memory_user_ids()) | set(_working_memories) | set(_long_term_memories)
+    )
+    working_total = 0
+    long_term_total = 0
+    for user_id in user_ids:
+        try:
+            working_total += len(get_working_memory(user_id=user_id))
+            long_term_total += len(get_long_term_memory(user_id=user_id))
+        except Exception:
+            logger.exception("Failed to collect memory metrics for owner '%s'", user_id)
+    return {
+        "user_count": len(user_ids),
+        "working_memory_entries": working_total,
+        "long_term_memory_entries": long_term_total,
+    }
 
 
 # Update __all__ to include new exports
@@ -714,6 +1038,9 @@ __all__ = [
     "append_history_entry",
     "load_recent_history",
     "export_transcript",
+    # Ownership constants
+    "DEFAULT_PROFILE",
+    "LEGACY_BACKUP_SUFFIX",
     # Working memory
     "WorkingMemory",
     "get_working_memory",
@@ -729,5 +1056,9 @@ __all__ = [
     "add_fact",
     "remember_context",
     "get_recent_context",
+    # Per-user maintenance
+    "list_memory_user_ids",
+    "run_memory_cleanup",
     "schedule_memory_cleanup",
+    "memory_store_metrics",
 ]

--- a/tests/test_cli_memory_kb.py
+++ b/tests/test_cli_memory_kb.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import rex.memory
 from rex.cli import _parse_ttl, cmd_kb, cmd_memory, main
 from rex.knowledge_base import KnowledgeBase, set_knowledge_base
 from rex.memory import (
@@ -15,6 +16,15 @@ from rex.memory import (
     set_long_term_memory,
     set_working_memory,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registries(tmp_path, monkeypatch):
+    """Keep per-user registries and the data dir isolated from the real ones."""
+    monkeypatch.setattr(rex.memory, "_DATA_DIR", tmp_path / "memdata")
+    monkeypatch.setattr(rex.memory, "_working_memories", {})
+    monkeypatch.setattr(rex.memory, "_long_term_memories", {})
+
 
 # =============================================================================
 # TTL Parsing Tests
@@ -79,9 +89,10 @@ class TestMemoryCLI:
         wm = WorkingMemory(storage_path=storage)
         wm.add_entry("Entry 1")
         wm.add_entry("Entry 2")
-        set_working_memory(wm)
+        set_working_memory(wm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "recent"
         args.count = 5
 
@@ -96,9 +107,10 @@ class TestMemoryCLI:
         """Test 'rex memory recent' with no entries."""
         storage = tmp_path / "wm.json"
         wm = WorkingMemory(storage_path=storage)
-        set_working_memory(wm)
+        set_working_memory(wm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "recent"
         args.count = 5
 
@@ -112,9 +124,10 @@ class TestMemoryCLI:
         """Test 'rex memory add' command."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "add"
         args.category = "test"
         args.content = '{"key": "value"}'
@@ -132,9 +145,10 @@ class TestMemoryCLI:
         """Test 'rex memory add' with TTL."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "add"
         args.category = "temp"
         args.content = '{"temp": true}'
@@ -153,9 +167,10 @@ class TestMemoryCLI:
         """Test 'rex memory add' with sensitive flag."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "add"
         args.category = "secrets"
         args.content = '{"api_key": "secret"}'
@@ -173,9 +188,10 @@ class TestMemoryCLI:
         """Test 'rex memory add' with invalid JSON."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "add"
         args.category = "test"
         args.content = "not valid json"
@@ -192,9 +208,10 @@ class TestMemoryCLI:
         """Test 'rex memory add' with invalid TTL."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "add"
         args.category = "test"
         args.content = '{"key": "value"}'
@@ -212,9 +229,10 @@ class TestMemoryCLI:
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
         ltm.add_entry(category="facts", content={"topic": "weather"})
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "search"
         args.keyword = "weather"
         args.category = None
@@ -232,9 +250,10 @@ class TestMemoryCLI:
         ltm = LongTermMemory(storage_path=storage)
         ltm.add_entry(category="preferences", content={"theme": "dark"})
         ltm.add_entry(category="facts", content={"fact": "test"})
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "search"
         args.keyword = None
         args.category = "preferences"
@@ -256,9 +275,10 @@ class TestMemoryCLI:
             content={"password": "secret123"},
             sensitive=True,
         )
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "search"
         args.keyword = "password"
         args.category = None
@@ -280,9 +300,10 @@ class TestMemoryCLI:
             content={"password": "secret123"},
             sensitive=True,
         )
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "search"
         args.keyword = "password"
         args.category = None
@@ -299,9 +320,10 @@ class TestMemoryCLI:
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
         entry = ltm.add_entry(category="temp", content={"temp": True})
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "forget"
         args.entry_id = entry.entry_id
 
@@ -315,9 +337,10 @@ class TestMemoryCLI:
         """Test 'rex memory forget' with non-existent entry."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "forget"
         args.entry_id = "nonexistent"
 
@@ -333,9 +356,10 @@ class TestMemoryCLI:
         wm = WorkingMemory(storage_path=storage)
         wm.add_entry("Entry 1")
         wm.add_entry("Entry 2")
-        set_working_memory(wm)
+        set_working_memory(wm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "clear"
 
         result = cmd_memory(args)
@@ -349,9 +373,10 @@ class TestMemoryCLI:
         """Test 'rex memory retention' command."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "retention"
 
         result = cmd_memory(args)
@@ -368,10 +393,11 @@ class TestMemoryCLI:
         ltm = LongTermMemory(storage_path=ltm_storage)
         wm.add_entry("Working memory entry")
         ltm.add_entry(category="facts", content={"fact": 1})
-        set_working_memory(wm)
-        set_long_term_memory(ltm)
+        set_working_memory(wm, user_id="alice")
+        set_long_term_memory(ltm, user_id="alice")
 
         args = MagicMock()
+        args.user = "alice"
         args.memory_command = "stats"
 
         result = cmd_memory(args)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
+import rex.memory
 from rex.memory import (
     LongTermMemory,
     MemoryEntry,
@@ -17,6 +20,15 @@ from rex.memory import (
     set_long_term_memory,
     set_working_memory,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registries(tmp_path, monkeypatch):
+    """Keep per-user registries and the data dir isolated from the real ones."""
+    monkeypatch.setattr(rex.memory, "_DATA_DIR", tmp_path / "memdata")
+    monkeypatch.setattr(rex.memory, "_working_memories", {})
+    monkeypatch.setattr(rex.memory, "_long_term_memories", {})
+
 
 # =============================================================================
 # WorkingMemory Tests
@@ -408,24 +420,24 @@ class TestLongTermMemory:
 
 
 class TestSingletonPattern:
-    """Tests for the global singleton instances."""
+    """Tests for the per-user instance registry."""
 
     def test_get_and_set_working_memory(self, tmp_path):
-        """Test get/set working memory singleton."""
+        """Test get/set working memory for one user."""
         storage = tmp_path / "wm.json"
         wm = WorkingMemory(storage_path=storage)
-        set_working_memory(wm)
+        set_working_memory(wm, user_id="alice")
 
-        retrieved = get_working_memory()
+        retrieved = get_working_memory(user_id="alice")
         assert retrieved is wm
 
     def test_get_and_set_long_term_memory(self, tmp_path):
-        """Test get/set long-term memory singleton."""
+        """Test get/set long-term memory for one user."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
-        retrieved = get_long_term_memory()
+        retrieved = get_long_term_memory(user_id="alice")
         assert retrieved is ltm
 
 
@@ -436,9 +448,9 @@ class TestConvenienceFunctions:
         """Test adding a user preference."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
-        entry = add_user_preference("theme", "dark")
+        entry = add_user_preference("theme", "dark", user_id="alice")
         assert entry.category == "user_preferences"
         assert entry.content == {"theme": "dark"}
 
@@ -446,38 +458,38 @@ class TestConvenienceFunctions:
         """Test getting user preferences."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
-        add_user_preference("theme", "dark")
-        add_user_preference("language", "en")
+        add_user_preference("theme", "dark", user_id="alice")
+        add_user_preference("language", "en", user_id="alice")
 
-        prefs = get_user_preferences()
+        prefs = get_user_preferences(user_id="alice")
         assert len(prefs) == 2
 
-        prefs = get_user_preferences("theme")
+        prefs = get_user_preferences("theme", user_id="alice")
         assert len(prefs) == 1
 
     def test_remember_context(self, tmp_path):
         """Test remember_context adds to working memory."""
         storage = tmp_path / "wm.json"
         wm = WorkingMemory(storage_path=storage)
-        set_working_memory(wm)
+        set_working_memory(wm, user_id="alice")
 
-        remember_context("User asked about weather")
-        recent = get_recent_context(1)
+        remember_context("User asked about weather", user_id="alice")
+        recent = get_recent_context(1, user_id="alice")
         assert recent[0] == "User asked about weather"
 
     def test_get_recent_context(self, tmp_path):
         """Test get_recent_context retrieves from working memory."""
         storage = tmp_path / "wm.json"
         wm = WorkingMemory(storage_path=storage)
-        set_working_memory(wm)
+        set_working_memory(wm, user_id="alice")
 
         wm.add_entry("Context 1")
         wm.add_entry("Context 2")
         wm.add_entry("Context 3")
 
-        recent = get_recent_context(2)
+        recent = get_recent_context(2, user_id="alice")
         assert len(recent) == 2
         assert recent == ["Context 2", "Context 3"]
 

--- a/tests/test_memory_cleanup.py
+++ b/tests/test_memory_cleanup.py
@@ -6,12 +6,24 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
+import rex.memory
 from rex.memory import (
     LongTermMemory,
     MemoryEntry,
     schedule_memory_cleanup,
     set_long_term_memory,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Keep per-user registries and the data dir isolated from the real ones."""
+    monkeypatch.setattr(rex.memory, "_DATA_DIR", tmp_path / "memdata")
+    monkeypatch.setattr(rex.memory, "_working_memories", {})
+    monkeypatch.setattr(rex.memory, "_long_term_memories", {})
+
 
 # =============================================================================
 # Expired Memory Removal
@@ -115,7 +127,7 @@ class TestScheduledCleanup:
         assert kwargs["schedule"] == "interval:3600"
 
     def test_cleanup_callback_calls_compact(self, tmp_path: Path) -> None:
-        """The registered callback invokes compact() on the global LTM."""
+        """The registered callback compacts each registered user's LTM."""
         storage = tmp_path / "ltm.json"
         ltm = LongTermMemory(storage_path=storage)
 
@@ -127,7 +139,7 @@ class TestScheduledCleanup:
             expires_at=past,
         )
         ltm._entries[entry.entry_id] = entry
-        set_long_term_memory(ltm)
+        set_long_term_memory(ltm, user_id="alice")
 
         # Capture the callback that gets registered
         captured_callback = None

--- a/tests/test_memory_isolation.py
+++ b/tests/test_memory_isolation.py
@@ -1,0 +1,777 @@
+"""US-303: per-user isolation for working memory and long-term memory.
+
+Covers:
+- Cross-user read/search/get/forget/clear denial for both stores
+- Per-user searches, categories, counts, statistics, and retention
+- Sensitive entries remain isolated per owner
+- Registry returns distinct per-user instances; testing setters are scoped
+- Ownership survives registry reset (restart simulation)
+- Missing / blank / malformed / traversal identity fails closed
+- Legacy unscoped files migrate only for the explicit ``default`` profile,
+  idempotently and crash-safely, preserving the original as a backup
+- CLI ``rex memory`` operations resolve identity and stay owner-scoped
+- Scheduled cleanup compacts each user's store independently and ignores
+  invalid directory names
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+from datetime import UTC, datetime, timedelta
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+BAD_USER_IDS = ["", "  ", "..", ".", "../evil", "a/b", "a\\b", "..\\..\\evil", "a" * 65]
+
+
+@pytest.fixture()
+def mem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """rex.memory with an isolated data dir and empty per-user registries."""
+    import rex.memory as memory_module
+
+    monkeypatch.setattr(memory_module, "_DATA_DIR", tmp_path / "memdata")
+    monkeypatch.setattr(memory_module, "_working_memories", {})
+    monkeypatch.setattr(memory_module, "_long_term_memories", {})
+    return memory_module
+
+
+def _write_legacy_files(mem) -> None:
+    """Create pre-isolation shared store files at the data-dir root."""
+    mem._DATA_DIR.mkdir(parents=True, exist_ok=True)
+    (mem._DATA_DIR / "working_memory.json").write_text(
+        json.dumps(
+            {"entries": [{"content": "legacy shared note", "timestamp": "2024-01-01T00:00:00Z"}]}
+        ),
+        encoding="utf-8",
+    )
+    (mem._DATA_DIR / "long_term_memory.json").write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "entry_id": "mem_legacy000001",
+                        "category": "facts",
+                        "content": {"note": "legacy shared fact"},
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "expires_at": None,
+                        "sensitive": False,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+# =============================================================================
+# Store-level cross-user isolation
+# =============================================================================
+
+
+class TestWorkingMemoryIsolation:
+    def test_entries_invisible_to_other_user(self, mem) -> None:
+        mem.get_working_memory(user_id="alice").add_entry("alice private context")
+
+        assert mem.get_working_memory(user_id="bob").get_recent(10) == []
+        assert mem.get_working_memory(user_id="alice").get_recent(10) == ["alice private context"]
+
+    def test_clear_does_not_touch_other_user(self, mem) -> None:
+        mem.get_working_memory(user_id="alice").add_entry("alice keeps this")
+        mem.get_working_memory(user_id="bob").add_entry("bob entry")
+
+        mem.get_working_memory(user_id="bob").clear()
+
+        assert mem.get_working_memory(user_id="alice").get_recent(10) == ["alice keeps this"]
+        assert mem.get_working_memory(user_id="bob").get_recent(10) == []
+
+    def test_stats_are_per_user(self, mem) -> None:
+        mem.get_working_memory(user_id="alice").add_entry("one")
+        mem.get_working_memory(user_id="alice").add_entry("two")
+        mem.get_working_memory(user_id="bob").add_entry("only")
+
+        assert mem.get_working_memory(user_id="alice").stats()["entries"] == 2
+        assert mem.get_working_memory(user_id="bob").stats()["entries"] == 1
+
+    def test_storage_files_are_partitioned_per_user(self, mem) -> None:
+        mem.get_working_memory(user_id="alice").add_entry("alice data")
+        mem.get_working_memory(user_id="bob").add_entry("bob data")
+
+        alice_file = mem._DATA_DIR / "alice" / "working_memory.json"
+        bob_file = mem._DATA_DIR / "bob" / "working_memory.json"
+        assert alice_file.exists()
+        assert bob_file.exists()
+        assert "bob data" not in alice_file.read_text(encoding="utf-8")
+        assert "alice data" not in bob_file.read_text(encoding="utf-8")
+
+
+class TestLongTermMemoryIsolation:
+    def test_entries_invisible_to_other_user(self, mem) -> None:
+        mem.get_long_term_memory(user_id="alice").add_entry(
+            category="facts", content={"note": "alice fact"}
+        )
+
+        assert mem.get_long_term_memory(user_id="bob").search() == []
+        assert len(mem.get_long_term_memory(user_id="alice").search()) == 1
+
+    def test_get_by_id_denies_non_owner(self, mem) -> None:
+        entry = mem.get_long_term_memory(user_id="alice").add_entry(
+            category="facts", content={"note": "alice fact"}
+        )
+
+        assert mem.get_long_term_memory(user_id="bob").get_entry(entry.entry_id) is None
+        assert mem.get_long_term_memory(user_id="alice").get_entry(entry.entry_id) is not None
+
+    def test_forget_denies_non_owner(self, mem) -> None:
+        entry = mem.get_long_term_memory(user_id="alice").add_entry(
+            category="facts", content={"note": "alice fact"}
+        )
+
+        assert mem.get_long_term_memory(user_id="bob").forget(entry.entry_id) is False
+        assert mem.get_long_term_memory(user_id="alice").get_entry(entry.entry_id) is not None
+
+    def test_search_categories_counts_are_per_user(self, mem) -> None:
+        alice = mem.get_long_term_memory(user_id="alice")
+        bob = mem.get_long_term_memory(user_id="bob")
+        alice.add_entry(category="medical", content={"note": "alice topic"})
+        alice.add_entry(category="prefs", content={"theme": "dark"})
+        bob.add_entry(category="shopping", content={"item": "milk"})
+
+        assert bob.search(keyword="alice topic") == []
+        assert bob.list_categories() == ["shopping"]
+        assert alice.list_categories() == ["medical", "prefs"]
+        assert bob.count_by_category() == {"shopping": 1}
+        assert alice.stats()["entries"] == 2
+        assert bob.stats()["entries"] == 1
+
+    def test_sensitive_entries_remain_isolated(self, mem) -> None:
+        mem.get_long_term_memory(user_id="alice").add_entry(
+            category="medical",
+            content={"diagnosis": "confidential"},
+            sensitive=True,
+        )
+
+        bob = mem.get_long_term_memory(user_id="bob")
+        assert bob.search(include_sensitive=True) == []
+        assert bob.search(keyword="confidential", include_sensitive=True) == []
+
+    def test_retention_is_per_user(self, mem) -> None:
+        alice = mem.get_long_term_memory(user_id="alice")
+        bob = mem.get_long_term_memory(user_id="bob")
+        past = datetime.now(UTC) - timedelta(days=1)
+        expired = mem.MemoryEntry(category="temp", content={"stale": True}, expires_at=past)
+        alice._entries[expired.entry_id] = expired
+        bob.add_entry(category="keep", content={"fresh": True})
+
+        assert bob.run_retention_policy() == 0
+        assert alice.run_retention_policy() == 1
+        assert len(bob) == 1
+
+    def test_same_entry_id_does_not_collide_across_users(self, mem) -> None:
+        alice = mem.get_long_term_memory(user_id="alice")
+        bob = mem.get_long_term_memory(user_id="bob")
+        alice.add_entry(category="facts", content={"owner": "alice"}, entry_id="mem_shared0001")
+        bob.add_entry(category="facts", content={"owner": "bob"}, entry_id="mem_shared0001")
+
+        assert alice.get_entry("mem_shared0001").content == {"owner": "alice"}
+        assert bob.get_entry("mem_shared0001").content == {"owner": "bob"}
+
+
+# =============================================================================
+# Registry / singleton behavior and persistence
+# =============================================================================
+
+
+class TestRegistry:
+    def test_distinct_instances_per_user(self, mem) -> None:
+        assert mem.get_working_memory(user_id="alice") is not mem.get_working_memory(user_id="bob")
+        assert mem.get_long_term_memory(user_id="alice") is not mem.get_long_term_memory(
+            user_id="bob"
+        )
+
+    def test_same_instance_for_same_user(self, mem) -> None:
+        assert mem.get_working_memory(user_id="alice") is mem.get_working_memory(user_id="alice")
+        assert mem.get_long_term_memory(user_id="alice") is mem.get_long_term_memory(
+            user_id="alice"
+        )
+
+    def test_instance_never_backed_by_other_users_path(self, mem) -> None:
+        alice_wm = mem.get_working_memory(user_id="alice")
+        bob_wm = mem.get_working_memory(user_id="bob")
+        assert "alice" in str(alice_wm.storage_path)
+        assert "alice" not in str(bob_wm.storage_path)
+        assert alice_wm.storage_path != bob_wm.storage_path
+
+    def test_testing_setters_are_user_scoped(self, mem, tmp_path: Path) -> None:
+        custom = mem.WorkingMemory(storage_path=tmp_path / "custom_wm.json")
+        custom.add_entry("injected for alice")
+        mem.set_working_memory(custom, user_id="alice")
+
+        assert mem.get_working_memory(user_id="alice") is custom
+        assert mem.get_working_memory(user_id="bob") is not custom
+        assert mem.get_working_memory(user_id="bob").get_recent(10) == []
+
+        custom_ltm = mem.LongTermMemory(storage_path=tmp_path / "custom_ltm.json")
+        mem.set_long_term_memory(custom_ltm, user_id="alice")
+        assert mem.get_long_term_memory(user_id="alice") is custom_ltm
+        assert mem.get_long_term_memory(user_id="bob") is not custom_ltm
+
+    def test_testing_setters_validate_user(self, mem, tmp_path: Path) -> None:
+        wm = mem.WorkingMemory(storage_path=tmp_path / "wm.json")
+        with pytest.raises(ValueError):
+            mem.set_working_memory(wm, user_id="../evil")
+        ltm = mem.LongTermMemory(storage_path=tmp_path / "ltm.json")
+        with pytest.raises(ValueError):
+            mem.set_long_term_memory(ltm, user_id="")
+
+    def test_restart_preserves_ownership(self, mem, monkeypatch: pytest.MonkeyPatch) -> None:
+        entry = mem.get_long_term_memory(user_id="alice").add_entry(
+            category="facts", content={"note": "persists"}
+        )
+        mem.get_working_memory(user_id="alice").add_entry("alice context persists")
+
+        # Simulate a process restart: fresh registries, reload from disk.
+        monkeypatch.setattr(mem, "_working_memories", {})
+        monkeypatch.setattr(mem, "_long_term_memories", {})
+
+        assert mem.get_long_term_memory(user_id="alice").get_entry(entry.entry_id) is not None
+        assert mem.get_long_term_memory(user_id="bob").get_entry(entry.entry_id) is None
+        assert mem.get_working_memory(user_id="alice").get_recent(10) == ["alice context persists"]
+        assert mem.get_working_memory(user_id="bob").get_recent(10) == []
+
+
+# =============================================================================
+# Fail-closed identity validation
+# =============================================================================
+
+
+class TestFailClosedIdentity:
+    def test_missing_identity_fails_closed(self, mem) -> None:
+        with pytest.raises(TypeError):
+            mem.get_working_memory()  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            mem.get_long_term_memory()  # type: ignore[call-arg]
+        with pytest.raises(ValueError):
+            mem.get_working_memory(user_id=None)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            mem.get_long_term_memory(user_id=None)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad_user", BAD_USER_IDS)
+    def test_invalid_identity_rejected_everywhere(self, mem, bad_user: str) -> None:
+        with pytest.raises(ValueError):
+            mem.get_working_memory(user_id=bad_user)
+        with pytest.raises(ValueError):
+            mem.get_long_term_memory(user_id=bad_user)
+        with pytest.raises(ValueError):
+            mem.add_user_preference("theme", "dark", user_id=bad_user)
+        with pytest.raises(ValueError):
+            mem.get_user_preferences(user_id=bad_user)
+        with pytest.raises(ValueError):
+            mem.add_fact("topic", {"x": 1}, user_id=bad_user)
+        with pytest.raises(ValueError):
+            mem.remember_context("summary", user_id=bad_user)
+        with pytest.raises(ValueError):
+            mem.get_recent_context(user_id=bad_user)
+
+    def test_convenience_functions_require_user_id(self, mem) -> None:
+        with pytest.raises(TypeError):
+            mem.remember_context("no identity")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            mem.get_recent_context()  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            mem.add_user_preference("theme", "dark")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            mem.get_user_preferences()  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            mem.add_fact("topic", {"x": 1})  # type: ignore[call-arg]
+
+    @pytest.mark.parametrize("bad_user", ["..", "../evil", "a/b", "a\\b", "..\\..\\evil"])
+    def test_traversal_ids_cannot_influence_storage_paths(self, mem, bad_user: str) -> None:
+        data_dir = mem._DATA_DIR
+        with pytest.raises(ValueError):
+            mem.get_working_memory(user_id=bad_user)
+        with pytest.raises(ValueError):
+            mem.get_long_term_memory(user_id=bad_user)
+        # Nothing may have been created anywhere (inside or outside the data dir).
+        assert not data_dir.exists() or list(data_dir.iterdir()) == []
+        assert not (data_dir.parent / "evil").exists()
+
+    def test_direct_construction_without_identity_or_path_fails(self, mem) -> None:
+        with pytest.raises(ValueError):
+            mem.WorkingMemory()
+        with pytest.raises(ValueError):
+            mem.LongTermMemory()
+
+    def test_case_variant_ids_cannot_alias_another_users_store(self, mem) -> None:
+        """Windows/macOS filesystems are case-insensitive: 'James' must never
+        open (or overwrite) 'james''s store, on any platform."""
+        mem.get_working_memory(user_id="james").add_entry("james private data")
+        mem.get_long_term_memory(user_id="james").add_entry(
+            category="facts", content={"note": "james fact"}
+        )
+
+        for variant in ("James", "JAMES", "jAmEs"):
+            with pytest.raises(ValueError):
+                mem.get_working_memory(user_id=variant)
+            with pytest.raises(ValueError):
+                mem.get_long_term_memory(user_id=variant)
+            with pytest.raises(ValueError):
+                mem.remember_context("hijack attempt", user_id=variant)
+
+        # The original owner is unaffected.
+        assert mem.get_working_memory(user_id="james").get_recent(10) == ["james private data"]
+
+    def test_case_variant_rejected_before_any_file_exists(self, mem) -> None:
+        """Registry-only collision (no directory saved yet) is also rejected."""
+        mem.get_working_memory(user_id="james")  # cached, nothing written yet
+
+        with pytest.raises(ValueError):
+            mem.get_working_memory(user_id="James")
+
+    def test_case_variant_rejected_across_restart(self, mem, monkeypatch) -> None:
+        mem.get_working_memory(user_id="james").add_entry("persisted")
+
+        monkeypatch.setattr(mem, "_working_memories", {})
+        monkeypatch.setattr(mem, "_long_term_memories", {})
+
+        with pytest.raises(ValueError):
+            mem.get_working_memory(user_id="James")
+        assert mem.get_working_memory(user_id="james").get_recent(10) == ["persisted"]
+
+    def test_case_variant_rejected_in_testing_setters(self, mem, tmp_path: Path) -> None:
+        mem.get_working_memory(user_id="james")
+        injected = mem.WorkingMemory(storage_path=tmp_path / "wm.json")
+        with pytest.raises(ValueError):
+            mem.set_working_memory(injected, user_id="James")
+        injected_ltm = mem.LongTermMemory(storage_path=tmp_path / "ltm.json")
+        mem.get_long_term_memory(user_id="james")
+        with pytest.raises(ValueError):
+            mem.set_long_term_memory(injected_ltm, user_id="James")
+
+
+# =============================================================================
+# Convenience functions are owner-scoped
+# =============================================================================
+
+
+class TestConvenienceFunctions:
+    def test_preferences_are_per_user(self, mem) -> None:
+        mem.add_user_preference("theme", "dark", user_id="alice")
+
+        assert mem.get_user_preferences(user_id="bob") == []
+        prefs = mem.get_user_preferences(user_id="alice")
+        assert len(prefs) == 1
+        assert prefs[0].content == {"theme": "dark"}
+
+    def test_facts_are_per_user(self, mem) -> None:
+        mem.add_fact("weather", {"info": "sunny"}, user_id="alice")
+
+        assert mem.get_long_term_memory(user_id="bob").search(category="facts") == []
+        assert len(mem.get_long_term_memory(user_id="alice").search(category="facts")) == 1
+
+    def test_context_is_per_user(self, mem) -> None:
+        mem.remember_context("alice asked about results", user_id="alice")
+
+        assert mem.get_recent_context(5, user_id="bob") == []
+        assert mem.get_recent_context(5, user_id="alice") == ["alice asked about results"]
+
+
+# =============================================================================
+# Legacy unscoped-file migration (default profile only)
+# =============================================================================
+
+
+class TestLegacyMigration:
+    def test_legacy_files_migrate_only_for_explicit_default(self, mem) -> None:
+        _write_legacy_files(mem)
+
+        wm = mem.get_working_memory(user_id="default")
+        ltm = mem.get_long_term_memory(user_id="default")
+
+        assert wm.get_recent(10) == ["legacy shared note"]
+        assert ltm.get_entry("mem_legacy000001") is not None
+        assert (mem._DATA_DIR / "default" / "working_memory.json").exists()
+        assert (mem._DATA_DIR / "default" / "long_term_memory.json").exists()
+
+    def test_named_user_never_sees_or_consumes_legacy_data(self, mem) -> None:
+        _write_legacy_files(mem)
+        legacy_wm = (mem._DATA_DIR / "working_memory.json").read_text(encoding="utf-8")
+        legacy_ltm = (mem._DATA_DIR / "long_term_memory.json").read_text(encoding="utf-8")
+
+        assert mem.get_working_memory(user_id="james").get_recent(10) == []
+        assert mem.get_long_term_memory(user_id="james").get_entry("mem_legacy000001") is None
+        assert mem.get_long_term_memory(user_id="james").search() == []
+
+        # Originals untouched; no default-profile store was created.
+        assert (mem._DATA_DIR / "working_memory.json").read_text(encoding="utf-8") == legacy_wm
+        assert (mem._DATA_DIR / "long_term_memory.json").read_text(encoding="utf-8") == legacy_ltm
+        assert not (mem._DATA_DIR / "default").exists()
+
+    def test_migration_is_idempotent(self, mem, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_legacy_files(mem)
+
+        assert mem.get_working_memory(user_id="default").get_recent(10) == ["legacy shared note"]
+
+        # Repeated access and a simulated restart must not duplicate or lose data.
+        monkeypatch.setattr(mem, "_working_memories", {})
+        monkeypatch.setattr(mem, "_long_term_memories", {})
+        wm = mem.get_working_memory(user_id="default")
+        ltm = mem.get_long_term_memory(user_id="default")
+        assert wm.get_recent(10) == ["legacy shared note"]
+        assert len(ltm.search(include_expired=True)) == 1
+
+    def test_legacy_source_preserved_as_backup_after_migration(self, mem) -> None:
+        _write_legacy_files(mem)
+        original_wm = (mem._DATA_DIR / "working_memory.json").read_text(encoding="utf-8")
+        original_ltm = (mem._DATA_DIR / "long_term_memory.json").read_text(encoding="utf-8")
+
+        mem.get_working_memory(user_id="default")
+        mem.get_long_term_memory(user_id="default")
+
+        wm_backup = mem._DATA_DIR / ("working_memory.json" + mem.LEGACY_BACKUP_SUFFIX)
+        ltm_backup = mem._DATA_DIR / ("long_term_memory.json" + mem.LEGACY_BACKUP_SUFFIX)
+        assert wm_backup.exists()
+        assert ltm_backup.exists()
+        assert wm_backup.read_text(encoding="utf-8") == original_wm
+        assert ltm_backup.read_text(encoding="utf-8") == original_ltm
+        # The unscoped originals no longer sit at the shared path.
+        assert not (mem._DATA_DIR / "working_memory.json").exists()
+        assert not (mem._DATA_DIR / "long_term_memory.json").exists()
+
+    def test_failed_migration_does_not_destroy_original(self, mem) -> None:
+        _write_legacy_files(mem)
+        original = (mem._DATA_DIR / "long_term_memory.json").read_text(encoding="utf-8")
+
+        def _boom(src: object, dst: object) -> None:
+            raise OSError("simulated copy failure")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(mem.shutil, "copyfile", _boom)
+            with pytest.raises(OSError):
+                mem.get_long_term_memory(user_id="default")
+
+        # Original intact, nothing partial exposed as the default store.
+        assert (mem._DATA_DIR / "long_term_memory.json").read_text(encoding="utf-8") == original
+        assert not (mem._DATA_DIR / "default" / "long_term_memory.json").exists()
+
+        # Recovery: once copying works again, migration completes.
+        ltm = mem.get_long_term_memory(user_id="default")
+        assert ltm.get_entry("mem_legacy000001") is not None
+
+
+# =============================================================================
+# CLI path
+# =============================================================================
+
+
+class TestCliOwnership:
+    def _cmd(self):
+        from rex.cli import cmd_memory
+
+        return cmd_memory
+
+    @staticmethod
+    def _args(**kwargs) -> argparse.Namespace:
+        return argparse.Namespace(**kwargs)
+
+    def test_add_and_search_are_scoped_to_requesting_user(
+        self, mem, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        add_args = self._args(
+            memory_command="add",
+            category="medical",
+            content='{"note": "alice cli secret"}',
+            ttl=None,
+            sensitive=False,
+            user="alice",
+        )
+        assert self._cmd()(add_args) == 0
+        capsys.readouterr()
+
+        bob_search = self._args(
+            memory_command="search",
+            keyword="alice cli secret",
+            category=None,
+            show_sensitive=True,
+            user="bob",
+        )
+        assert self._cmd()(bob_search) == 0
+        out = capsys.readouterr().out
+        assert "alice cli secret" not in out
+        assert "No matching memory entries" in out
+
+        alice_search = self._args(
+            memory_command="search",
+            keyword="alice cli secret",
+            category=None,
+            show_sensitive=True,
+            user="alice",
+        )
+        assert self._cmd()(alice_search) == 0
+        assert "alice cli secret" in capsys.readouterr().out
+
+    def test_recent_is_scoped_to_requesting_user(
+        self, mem, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mem.get_working_memory(user_id="alice").add_entry("alice recent context")
+
+        args = self._args(memory_command="recent", count=10, user="bob")
+        assert self._cmd()(args) == 0
+        out = capsys.readouterr().out
+        assert "alice recent context" not in out
+        assert "No working memory entries" in out
+
+    def test_forget_denies_non_owner(self, mem, capsys: pytest.CaptureFixture[str]) -> None:
+        entry = mem.get_long_term_memory(user_id="alice").add_entry(
+            category="facts", content={"note": "keep"}
+        )
+
+        args = self._args(memory_command="forget", entry_id=entry.entry_id, user="bob")
+        assert self._cmd()(args) == 1
+        assert mem.get_long_term_memory(user_id="alice").get_entry(entry.entry_id) is not None
+
+    def test_clear_only_clears_requesting_user(
+        self, mem, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mem.get_working_memory(user_id="alice").add_entry("alice keeps this")
+        mem.get_working_memory(user_id="bob").add_entry("bob entry")
+
+        args = self._args(memory_command="clear", user="bob")
+        assert self._cmd()(args) == 0
+        assert mem.get_working_memory(user_id="alice").get_recent(10) == ["alice keeps this"]
+        assert mem.get_working_memory(user_id="bob").get_recent(10) == []
+
+    def test_retention_only_touches_requesting_user(
+        self, mem, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        alice = mem.get_long_term_memory(user_id="alice")
+        past = datetime.now(UTC) - timedelta(days=1)
+        expired = mem.MemoryEntry(category="temp", content={"stale": True}, expires_at=past)
+        alice._entries[expired.entry_id] = expired
+
+        args = self._args(memory_command="retention", user="bob")
+        assert self._cmd()(args) == 0
+        assert "deleted 0" in capsys.readouterr().out
+        assert expired.entry_id in alice._entries
+
+        args = self._args(memory_command="retention", user="alice")
+        assert self._cmd()(args) == 0
+        assert "deleted 1" in capsys.readouterr().out
+
+    def test_stats_are_scoped_to_requesting_user(
+        self, mem, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mem.get_working_memory(user_id="alice").add_entry("one")
+        mem.get_long_term_memory(user_id="alice").add_entry(category="facts", content={"a": 1})
+
+        args = self._args(memory_command="stats", user="bob")
+        assert self._cmd()(args) == 0
+        out = capsys.readouterr().out
+        assert "Working Memory: 0" in out
+        assert "Long-Term Memory: 0" in out
+
+    def test_missing_identity_fails_closed(
+        self, mem, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("rex.identity.resolve_active_user", lambda *a, **k: None)
+        args = self._args(memory_command="stats", user=None)
+        assert self._cmd()(args) == 1
+        out = capsys.readouterr().out
+        assert "No active user" in out
+        assert "rex identify" in out
+
+    def test_malformed_explicit_identity_fails_closed(
+        self, mem, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        args = self._args(memory_command="recent", count=5, user="../evil")
+        assert self._cmd()(args) == 1
+
+
+# =============================================================================
+# Bridge (Electron GUI) path
+# =============================================================================
+
+
+def _run_bridge(stdin_data: str) -> dict:
+    """Invoke the memories bridge main() with the given stdin JSON."""
+    mod = importlib.import_module("rex_memories_bridge")
+
+    captured = StringIO()
+    with patch("sys.stdin", StringIO(stdin_data)):
+        with patch("sys.stdout", captured):
+            try:
+                mod.main()
+            except SystemExit:
+                pass
+    return json.loads(captured.getvalue().strip())
+
+
+class TestBridgeOwnership:
+    def test_add_records_the_requesting_user(self, mem) -> None:
+        result = _run_bridge(
+            json.dumps({"command": "add", "user": "alice", "data": {"text": "alice gui memory"}})
+        )
+        assert result["ok"] is True
+        assert len(mem.get_long_term_memory(user_id="alice").search()) == 1
+        assert mem.get_long_term_memory(user_id="bob").search() == []
+
+    def test_list_is_scoped_to_requesting_user(self, mem) -> None:
+        mem.get_long_term_memory(user_id="alice").add_entry(
+            category="general", content={"text": "alice item"}
+        )
+
+        result = _run_bridge(json.dumps({"command": "list", "user": "bob"}))
+        assert result["ok"] is True
+        assert result["memories"] == []
+
+    def test_update_denies_non_owner(self, mem) -> None:
+        entry = mem.get_long_term_memory(user_id="alice").add_entry(
+            category="general", content={"text": "alice original"}
+        )
+
+        result = _run_bridge(
+            json.dumps(
+                {
+                    "command": "update",
+                    "user": "bob",
+                    "id": entry.entry_id,
+                    "data": {"text": "hijacked"},
+                }
+            )
+        )
+        assert result["ok"] is False
+        intact = mem.get_long_term_memory(user_id="alice").get_entry(entry.entry_id)
+        assert intact.content["text"] == "alice original"
+
+    def test_delete_denies_non_owner(self, mem) -> None:
+        entry = mem.get_long_term_memory(user_id="alice").add_entry(
+            category="general", content={"text": "alice keeps"}
+        )
+
+        result = _run_bridge(json.dumps({"command": "delete", "user": "bob", "id": entry.entry_id}))
+        assert result["ok"] is False
+        assert mem.get_long_term_memory(user_id="alice").get_entry(entry.entry_id) is not None
+
+    def test_missing_identity_fails_closed(self, mem, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("rex.identity.resolve_active_user", lambda *a, **k: None)
+        result = _run_bridge(json.dumps({"command": "list"}))
+        assert result["ok"] is False
+        assert "No active user" in result["error"]
+
+    def test_malformed_explicit_identity_fails_closed(self, mem) -> None:
+        result = _run_bridge(json.dumps({"command": "list", "user": "../evil"}))
+        assert result["ok"] is False
+        assert "No active user" in result["error"]
+
+
+# =============================================================================
+# Scheduled cleanup
+# =============================================================================
+
+
+class TestScheduledCleanup:
+    @staticmethod
+    def _seed_expired(mem, user_id: str, count: int) -> None:
+        ltm = mem.get_long_term_memory(user_id=user_id)
+        past = datetime.now(UTC) - timedelta(days=1)
+        for i in range(count):
+            entry = mem.MemoryEntry(
+                entry_id=f"exp_{user_id}_{i}",
+                category="temp",
+                content={"i": i},
+                expires_at=past,
+            )
+            ltm._entries[entry.entry_id] = entry
+        ltm._save()
+
+    def test_cleanup_compacts_each_user_store_independently(self, mem) -> None:
+        self._seed_expired(mem, "alice", 2)
+        self._seed_expired(mem, "bob", 3)
+        keeper = mem.get_long_term_memory(user_id="alice").add_entry(
+            category="keep", content={"fresh": True}
+        )
+
+        results = mem.run_memory_cleanup()
+
+        assert results["alice"] == 2
+        assert results["bob"] == 3
+        assert mem.get_long_term_memory(user_id="alice").get_entry(keeper.entry_id) is not None
+
+    def test_failure_in_one_store_does_not_stop_others(
+        self, mem, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._seed_expired(mem, "alice", 1)
+        self._seed_expired(mem, "bob", 2)
+
+        broken = mem.get_long_term_memory(user_id="alice")
+        monkeypatch.setattr(broken, "compact", MagicMock(side_effect=OSError("disk error")))
+
+        results = mem.run_memory_cleanup()
+
+        assert "alice" not in results
+        assert results["bob"] == 2
+        # Bob's store was compacted on disk despite Alice's failure.
+        bob_file = mem._DATA_DIR / "bob" / "long_term_memory.json"
+        assert "exp_bob_0" not in bob_file.read_text(encoding="utf-8")
+
+    def test_invalid_directory_names_are_never_treated_as_users(self, mem) -> None:
+        self._seed_expired(mem, "alice", 1)
+        (mem._DATA_DIR / "not a valid user!").mkdir(parents=True)
+
+        assert mem.list_memory_user_ids() == ["alice"]
+        results = mem.run_memory_cleanup()
+        assert set(results) == {"alice"}
+
+    def test_cleanup_ignores_legacy_root_files(self, mem) -> None:
+        _write_legacy_files(mem)
+        legacy = (mem._DATA_DIR / "long_term_memory.json").read_text(encoding="utf-8")
+
+        results = mem.run_memory_cleanup()
+
+        assert results == {}
+        # Legacy file untouched: cleanup is not an explicit default request.
+        assert (mem._DATA_DIR / "long_term_memory.json").read_text(encoding="utf-8") == legacy
+
+    def test_schedule_memory_cleanup_callback_runs_per_user(self, mem) -> None:
+        self._seed_expired(mem, "alice", 1)
+        self._seed_expired(mem, "bob", 1)
+
+        captured_callback = None
+
+        def capture_callback(name: str, cb: object) -> None:
+            nonlocal captured_callback
+            captured_callback = cb
+
+        scheduler = MagicMock()
+        scheduler.register_callback.side_effect = capture_callback
+
+        mem.schedule_memory_cleanup(scheduler, interval_seconds=60)
+        assert captured_callback is not None
+        captured_callback(MagicMock())
+
+        assert len(mem.get_long_term_memory(user_id="alice").search(include_expired=True)) == 0
+        assert len(mem.get_long_term_memory(user_id="bob").search(include_expired=True)) == 0
+
+
+# =============================================================================
+# Supervisor metrics
+# =============================================================================
+
+
+class TestStoreMetrics:
+    def test_metrics_aggregate_counts_without_content(self, mem) -> None:
+        mem.get_working_memory(user_id="alice").add_entry("secret alice context")
+        mem.get_long_term_memory(user_id="bob").add_entry(
+            category="facts", content={"note": "secret bob fact"}
+        )
+
+        metrics = mem.memory_store_metrics()
+
+        assert metrics["user_count"] == 2
+        assert metrics["working_memory_entries"] == 1
+        assert metrics["long_term_memory_entries"] == 1
+        assert "secret" not in json.dumps(metrics)

--- a/tests/test_us005_bridge_json_io.py
+++ b/tests/test_us005_bridge_json_io.py
@@ -120,9 +120,9 @@ class TestMemoriesBridgeJsonIO:
         mock_ltm.search.return_value = []
         with patch.dict(
             "sys.modules",
-            {"rex.memory": MagicMock(get_long_term_memory=lambda: mock_ltm)},
+            {"rex.memory": MagicMock(get_long_term_memory=lambda **kwargs: mock_ltm)},
         ):
-            result = _run_main(MEMORIES_MODULE, '{"action": "list"}')
+            result = _run_main(MEMORIES_MODULE, '{"action": "list", "user": "default"}')
         assert isinstance(result, dict)
         assert "memories" in result or "error" in result
 
@@ -131,9 +131,9 @@ class TestMemoriesBridgeJsonIO:
         mock_ltm.search.return_value = []
         with patch.dict(
             "sys.modules",
-            {"rex.memory": MagicMock(get_long_term_memory=lambda: mock_ltm)},
+            {"rex.memory": MagicMock(get_long_term_memory=lambda **kwargs: mock_ltm)},
         ):
-            result = _run_main(MEMORIES_MODULE, '{"command": "list"}')
+            result = _run_main(MEMORIES_MODULE, '{"command": "list", "user": "default"}')
         assert isinstance(result, dict)
         assert "memories" in result or "error" in result
 

--- a/tests/test_us015_bridge_error_reporting.py
+++ b/tests/test_us015_bridge_error_reporting.py
@@ -136,7 +136,7 @@ class TestMemoriesBridgeTraceback:
         import rex_memories_bridge
 
         with patch.object(rex_memories_bridge, "_handle_list", side_effect=OSError("disk full")):
-            result = _run_main("rex_memories_bridge", '{"command": "list"}')
+            result = _run_main("rex_memories_bridge", '{"command": "list", "user": "default"}')
 
         assert result["ok"] is False
         assert "disk full" in result["error"]


### PR DESCRIPTION
## Summary

Closes the working-memory / long-term-memory gap of #303. Previously `rex/memory.py` held one process-global `WorkingMemory` and one global `LongTermMemory` backed by shared `data/memory/working_memory.json` / `long_term_memory.json`, with no user identity anywhere in the API, CLI, or GUI bridge — any user could read, search, delete, clear, or overwrite any other user's working context, preferences, facts, and sensitive entries.

### Reproduced defect (against `master` @ bf5a315)

```
same object for both users: True
cole reads james's sensitive entry by id: {'note': 'james private diagnosis'}
cole finds it by search: [{'note': 'james private diagnosis'}]
cole reads james's working memory: ['james: asked about test results']
cole deletes james's entry: True
cole clears james's working memory: cleared
LEAK REPRODUCED
```

## Ownership model

- Every getter, setter, and convenience function (`get_working_memory`, `get_long_term_memory`, `set_*`, `add_user_preference`, `get_user_preferences`, `add_fact`, `remember_context`, `get_recent_context`) now requires keyword-only `user_id`, validated by `rex.identity.validate_user_id`. Missing identity → `TypeError`; blank/malformed/traversal identity → `ValueError`. No fallback to `default`, the active user, or any other profile.
- Stores are partitioned at `data/memory/<user_id>/working_memory.json` and `data/memory/<user_id>/long_term_memory.json`; process caches are dicts keyed by validated `user_id`. Entry IDs may repeat across users without collision.
- User IDs differing only by case from an existing profile are rejected on every platform — NTFS/APFS are case-insensitive, so `James` would otherwise silently alias `james`'s on-disk store (found by fresh-context review, fixed + regression-tested).
- CLI: every `rex memory` subcommand (`recent`, `add`, `search`, `forget`, `clear`, `retention`, `stats`) accepts `--user` and otherwise resolves through the same `_resolve_cli_user` identity chain as the reminders work, failing closed with an actionable message.
- Bridge: `bridge/rex_memories_bridge.py` mirrors the reminders bridge — explicit `"user"` payload field or the identity chain, fail-closed otherwise; `update`/`delete` can only touch the resolved user's own store.
- Scheduled cleanup: `schedule_memory_cleanup` now runs `run_memory_cleanup()`, which compacts each user's long-term store independently; invalid directory names are ignored (never treated as users), one user's failure never touches another user's file, and logs identify the owner without content.
- Supervisor metrics (`rex/app.py`): aggregate entry counts only via `memory_store_metrics()` — no content, categories, or entry IDs.
- Custom `storage_path` on the classes remains for unit tests only; production getters always use the validated per-user path.

## Legacy migration policy

- The pre-isolation root files belong **only** to the distinct `default` profile; named users never read or consume them (a named user accessing memory first sees an empty store and leaves the legacy files byte-identical).
- Migration runs only on explicit `user_id="default"`: PID-unique temp copy + atomic `os.replace` (crash-safe, idempotent, safe under concurrent bridge processes); only after the default copy exists is the original renamed to `<name>.json.pre-user-isolation.bak` — preserved, never deleted.
- A failed copy propagates (fail closed), leaves the original untouched, and is retried on the next explicit `default` access. Recovery steps documented in `docs/memory.md`.
- No automatic James/Cole reassignment tool (per scope).

## Tests

`tests/test_memory_isolation.py` — 66 tests covering all 20 required scenarios: cross-user invisibility of WM/LTM entries, denial of get-by-ID/forget/clear across users, per-user search/categories/counts/stats/retention, sensitive-entry isolation, distinct registry instances + user-scoped testing setters, restart persistence, missing/invalid/traversal identity fail-closed, case-variant rejection (fresh + across restart + setters), default-only legacy migration, named-user-first non-consumption, idempotency, backup preservation, simulated migration failure, CLI ownership for every subcommand, bridge ownership, per-user scheduled cleanup with failure isolation and invalid-directory rejection, and content-free metrics.

RED-phase evidence: the full suite was written first and run against the unmodified implementation — **62/62 errored** (`get_working_memory() … no attribute '_working_memories'` / missing `user_id` API), so nothing passes vacuously.

Updated to the owner-scoped API: `tests/test_memory.py`, `tests/test_memory_cleanup.py`, `tests/test_cli_memory_kb.py`, `tests/test_us005_bridge_json_io.py`, `tests/test_us015_bridge_error_reporting.py` (all with isolated data-dir/registry fixtures so tests never touch the real `data/memory`).

## Validation (exact local results)

| Command | Result |
|---|---|
| `pytest -q tests/test_memory_isolation.py` (x3) | `62 passed` each run (66 after review fixes: `169 passed` across the 5 memory suites) |
| `pytest -q` (21 affected suites: memory, CLI, identity, scheduler, supervisor, reminders/suggestions isolation, bridges) | `456 passed` |
| `ruff check` (all changed files) | `All checks passed!` |
| `black --check` (all changed files) | `9 files would be left unchanged` |
| `mypy rex --ignore-missing-imports` | `Success: no issues found in 335 source files` |
| `pytest -q` (full suite, final code) | `7521 passed, 84 skipped in 0:10:13` |
| `git status` after full suite | no tracked files modified by tests |

## Fresh-context review

A fresh-context reviewer inspected the final diff for cross-user reads, cross-user deletion, unsafe fallbacks, path traversal, migration data loss, singleton leakage, cleanup isolation, and test adequacy. Findings and dispositions:

1. **Major — case-insensitive filesystem aliasing** (`James` opens `james`'s store on NTFS/APFS): **fixed** — `_reject_case_conflicts()` rejects case-variants of any registered or on-disk profile on all platforms; 4 regression tests added.
2. **Minor — concurrent first-time `default` migration race** between bridge processes: **fixed** — PID-unique temp file + atomic replace.
3. **Minor — Windows reserved device names** (`con`, `nul`, …) pass `validate_user_id` and silently break persistence: **deferred** — that validator is shared identity infrastructure (also affects reminders/suggestions/Memory profiles) and this task mandates using it as-is; flagged on #303 as a follow-up.

All other categories: no issues found (reviewer confirmed no remaining unscoped caller repo-wide).

## Out of scope (unchanged)

Knowledge base, email credentials, OpenClaw adapters, GUI settings, unrelated scheduler stores, `rex/user_facts.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
