### PR TITLE
fix(email): enforce per-user account ownership and credential routing

### DIFF
--- a/bridge/rex_email_bridge.py
+++ b/bridge/rex_email_bridge.py
@@ -2,16 +2,36 @@
 
 Reads a JSON command from stdin and writes a JSON response to stdout.
 
+Every command operates on behalf of a resolved user identity (US-303
+per-user isolation):
+
+- An explicit ``"user"`` field in the payload takes precedence (it is
+  validated; malformed IDs fail closed).
+- Otherwise the active user is resolved through the standard identity
+  chain (``rex identify`` session state, then ``runtime.active_user`` /
+  ``runtime.user_id`` in ``config/rex_config.json``).
+- If no user can be resolved, the command fails closed with an error.
+  Single-user setups keep working by explicitly selecting the ``default``
+  profile (``rex identify --user default`` or ``"user": "default"``).
+
+Provider routing is per-user: a ``gmail`` account assigned to the user in
+``users.{id}.email_accounts`` is served with that user's own token; the
+legacy global ``email.provider`` + ``GMAIL_ACCESS_TOKEN`` path applies only
+to the explicit ``default`` profile.  Named users never inherit the global
+credentials.  Credential references and secrets are never returned to the
+renderer.
+
 Commands:
-  {"command": "list", "limit": 20}
+  {"command": "list", "limit": 20, "user"?: "<user_id>"}
     -> {"ok": true, "messages": [...], "configured": bool}
 
 Message format (GUI):
   {id, thread_id, subject, sender, recipients, body_text, received_at,
    labels, is_read, priority}
 
-When no email provider is configured, returns {"ok": true, "messages": [],
-"configured": false} so the GUI can show an empty-state prompt.
+When the resolved user has no email provider configured, returns
+{"ok": true, "messages": [], "configured": false} so the GUI can show an
+empty-state prompt.
 """
 
 from __future__ import annotations
@@ -27,6 +47,33 @@ OUTLOOK_EMAIL_UNSUPPORTED = (
     "only store app credentials; Rex cannot read Outlook mail until Microsoft "
     "Graph OAuth token support is added."
 )
+
+_NO_USER_ERROR = (
+    "No active user for email. Set one with 'rex identify --user <id>' "
+    "or include a 'user' field in the request."
+)
+
+
+def _resolve_user(payload: dict[str, Any]) -> str | None:
+    """Resolve the requesting user, failing closed on missing/invalid identity.
+
+    Never falls back to ``"default"`` or any other profile implicitly.
+    """
+    from rex.identity import resolve_active_user
+
+    explicit = str(payload.get("user") or "").strip() or None
+    try:
+        config: dict[str, Any] | None
+        try:
+            from rex.config_manager import load_config
+
+            config = load_config()
+        except Exception:
+            config = None
+        return resolve_active_user(explicit, config=config)
+    except ValueError:
+        # Malformed explicit user ID: fail closed, no fallback.
+        return None
 
 
 def _msg_to_gui(msg: Any) -> dict[str, Any]:
@@ -44,28 +91,25 @@ def _msg_to_gui(msg: Any) -> dict[str, Any]:
     }
 
 
-def _handle_list(limit: int) -> dict[str, Any]:
-    from rex.config import load_config
-    from rex.integrations.email_service import EmailService
+def _handle_list(user_id: str, limit: int) -> dict[str, Any]:
+    from rex.integrations.email_service import create_email_service_for_user
 
-    cfg = load_config()
-    provider = getattr(cfg, "email_provider", "none") or "none"
-    if str(provider).lower() == "outlook":
+    svc, provider = create_email_service_for_user(user_id)
+    if provider == "outlook":
         return {
             "ok": False,
             "error": OUTLOOK_EMAIL_UNSUPPORTED,
             "messages": [],
             "configured": True,
         }
-
-    svc = EmailService(email_provider=provider)
+    if svc is None:
+        return {"ok": True, "messages": [], "configured": False}
 
     messages = svc.list_inbox(limit=limit)
-    configured = provider != "none"
     return {
         "ok": True,
         "messages": [_msg_to_gui(m) for m in messages],
-        "configured": configured,
+        "configured": True,
     }
 
 
@@ -78,11 +122,26 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        if command == "list":
+        user_id = _resolve_user(payload)
+        if not user_id:
+            result = {
+                "ok": False,
+                "error": _NO_USER_ERROR,
+                "messages": [],
+                "configured": False,
+            }
+        elif command == "list":
             limit = int(payload.get("limit") or 20)
-            result = _handle_list(limit)
+            result = _handle_list(user_id, limit)
         else:
             result = {"ok": False, "error": f"Unknown command: {command!r}"}
+    except PermissionError:
+        result = {
+            "ok": False,
+            "error": _NO_USER_ERROR,
+            "messages": [],
+            "configured": False,
+        }
     except Exception as exc:
         result = bridge_error_response(exc)
 

--- a/docs/claude/CONFIG_AND_SECURITY.md
+++ b/docs/claude/CONFIG_AND_SECURITY.md
@@ -352,6 +352,7 @@ Deprecated flat-field aliases that currently emit `DeprecationWarning`:
 | `email_accounts` | `email.accounts` | json-only | runtime | `[]` |
 | `email_default_account_id` | `email.default_account_id` | json-only | runtime | `""` |
 | `user_email_accounts` | `users.{id}.email_accounts` | json-only | runtime | `{}` |
+| `user_default_email_accounts` | `users.{id}.default_email_account_id` | json-only | runtime | `{}` |
 | `calendar_provider` | `calendar.provider` | json-only | runtime | `"none"` |
 
 #### Conversational Follow-ups (`conversation.followups.*` in rex_config.json)

--- a/docs/email.md
+++ b/docs/email.md
@@ -51,6 +51,18 @@ class EmailSummary(BaseModel):
 
 ## Using the Email Service
 
+### Per-User Ownership (required)
+
+Every operation that reads or mutates email data requires an explicit,
+validated `user_id`. Missing, blank, malformed, or traversal-style
+identities fail closed (`PermissionError`) **before** any account or
+credential lookup. There is no fallback to `default`, to the active user,
+to the global default account, or to another user's backend or credential.
+
+Single-user setups select the legacy profile explicitly with
+`user_id="default"` (or `rex identify --user default` / `--user default`
+on the CLI).
+
 ### Getting the Email Service Instance
 
 ```python
@@ -59,11 +71,15 @@ from rex.email_service import get_email_service
 email_service = get_email_service()
 ```
 
+The returned service enforces per-user account ownership internally;
+backends are resolved lazily per validated user and authorized account,
+and a backend resolved for one user is never reused for another.
+
 ### Connecting to Email
 
 ```python
-# Connect (loads credentials and initializes)
-if email_service.connect():
+# Connect the requesting user's authorized backend
+if email_service.connect("default"):
     print("Connected to email service")
 else:
     print("Failed to connect")
@@ -72,8 +88,8 @@ else:
 ### Fetching Unread Emails
 
 ```python
-# Fetch up to 10 unread emails
-unread = email_service.fetch_unread(limit=10)
+# Fetch up to 10 unread emails for one user
+unread = email_service.fetch_unread(limit=10, user_id="default")
 
 for email in unread:
     print(f"{email.id}: {email.subject}")
@@ -109,26 +125,30 @@ print(f"Category: {category}")
 ### Marking Emails as Read
 
 ```python
-email_service.mark_as_read(email_id='email-123')
+email_service.mark_as_read('email-123', user_id="default")
 ```
 
 ### Summarizing Emails
 
 ```python
-summary = email_service.summarize(email_id='email-123')
+summary = email_service.summarize('email-123', user_id="default")
 print(summary)
 ```
 
 ## CLI Commands
+
+Every `rex email` subcommand runs as one validated user. The user comes
+from `--user <id>`, the `rex identify` session, or `runtime.active_user`
+in config; without one the command fails closed with instructions.
 
 ### Fetch Unread Emails
 
 Display unread emails with categorization:
 
 ```bash
-rex email unread
-rex email unread --limit 5
-rex email unread -v  # Verbose output with importance scores
+rex email unread --user james
+rex email unread --user james --limit 5
+rex email unread --user james -v  # Verbose output with importance scores
 ```
 
 ## Configuration
@@ -201,13 +221,24 @@ initialize_scheduler_system(start_scheduler=True)
 
 This creates a job that:
 - Runs every 10 minutes (configurable)
-- Fetches unread emails
-- Categorizes them
-- Publishes an `email.unread` event
+- Iterates the explicitly configured account owners, each in an isolated
+  owner context (one owner's failure never falls through to another)
+- Fetches and categorizes each owner's unread email as that owner
+- Publishes a per-owner `email.unread.user.<user_id>` event with the
+  message payload, plus a safe envelope (count/user only) on the shared
+  `email.unread` topic
+
+If no owners are configured, the job does not touch real email (fail
+closed).
 
 ## Event Integration
 
-Subscribe to email events to trigger actions:
+Private email fields (subjects, senders, snippets) are published only on
+user-scoped topics — `email.unread.user.<user_id>` — so a consumer acting
+for one user cannot observe another user's payload. The shared
+`email.unread` topic carries only `{count, user_id, account_id}`.
+
+Subscribe to a user's email events to trigger actions:
 
 ```python
 from rex.event_bus import get_event_bus
@@ -220,7 +251,7 @@ def handle_new_emails(event):
         if email['category'] == 'important':
             print(f"⚠️  Important: {email['subject']}")
 
-event_bus.subscribe('email.unread', handle_new_emails)
+event_bus.subscribe('email.unread.user.james', handle_new_emails)
 ```
 
 ## Example: Email Notification Workflow
@@ -248,8 +279,8 @@ def email_notifier(event):
             print(f"    From: {email['from_addr']}")
             print()
 
-# Subscribe to email events
-event_bus.subscribe('email.unread', email_notifier)
+# Subscribe to this user's email events (private payloads are user-scoped)
+event_bus.subscribe('email.unread.user.james', email_notifier)
 
 print("Email notification system active")
 ```
@@ -260,21 +291,63 @@ print("Email notification system active")
 from rex.email_service import get_email_service
 
 email_service = get_email_service()
-email_service.connect()
+email_service.connect("james")
 
-unread = email_service.fetch_unread()
+unread = email_service.fetch_unread(user_id="james")
 
 for email in unread:
     # Check for vacation auto-replies
     if 'out of office' in email.subject.lower() or 'vacation' in email.snippet.lower():
         print(f"Auto-reply detected from {email.from_addr}")
         # Mark as read automatically
-        email_service.mark_as_read(email.id)
+        email_service.mark_as_read(email.id, user_id="james")
 ```
 
 ## Multi-Account Configuration
 
-Rex supports multiple email accounts per user. Accounts are configured in `config/rex_config.json` under the `email` key.
+Rex supports multiple email accounts per user. Account **definitions**
+(non-secret connection metadata) live in `config/rex_config.json` under the
+`email` key; account **ownership** is assigned per user under the `users`
+key.
+
+### Ownership Model
+
+- `email.accounts` is the canonical list of account definitions
+  (host/port/address/`credential_ref`). It grants no access by itself.
+- `users.{user_id}.email_accounts` is the authoritative authorization map:
+  a user may use only the accounts assigned to them there, and each
+  `account_id` must reference a real `email.accounts` definition.
+- `users.{user_id}.default_email_account_id` selects that user's default
+  account (it must be one of their own accounts).
+- Credential lookup happens only after ownership validation, and only with
+  the authorized account definition's own `credential_ref`.
+- Unauthorized and nonexistent accounts are indistinguishable to callers.
+
+### Legacy Accounts (single-user configs)
+
+`email.accounts` entries not assigned to any user belong **only** to the
+distinct `default` profile. They are never shared with, or silently
+reassigned to, named users — a named user gets email access only through an
+explicit `users.{user_id}.email_accounts` assignment. The legacy
+`email.default_account_id` applies only to the `default` profile, and the
+legacy global `GMAIL_ACCESS_TOKEN` environment behaviour (GUI inbox) is
+likewise `default`-profile-only.
+
+To assign an existing account to a named user, add (no secrets involved —
+credentials stay in the credential manager):
+
+```json
+{
+  "users": {
+    "james": {
+      "email_accounts": [
+        {"account_id": "personal", "backend": "imap", "credentials_key": "email:personal"}
+      ],
+      "default_email_account_id": "personal"
+    }
+  }
+}
+```
 
 ### Configuration Format
 
@@ -350,34 +423,45 @@ Then configure the credential mapping to point `email:personal` to `EMAIL_PERSON
 
 ### Account Selection (Routing)
 
-When sending or reading email, accounts are selected using this precedence:
+Accounts are always selected **within the requesting user's authorized
+set**, using this precedence:
 
-1. **Explicit** `account_id` argument (highest priority)
-2. **Default** from `email.default_account_id`
-3. **Fallback** to first account in the list
+1. **Explicit** `account_id` argument (after ownership validation — a
+   foreign or nonexistent account is rejected with a generic error)
+2. That user's `users.{user_id}.default_email_account_id`
+3. The legacy `email.default_account_id` — only for the explicit `default`
+   profile
+4. The first account assigned to that user (deterministic, config order)
+5. No authorized account: the operation fails closed / reports
+   not-configured — never another user's account
 
-If no accounts are configured, the stub backend is used automatically.
+If no accounts are configured anywhere, the stub backend is used
+automatically for offline development.
 
 ### CLI Commands
 
 ```bash
-# List configured accounts
-rex email accounts list
+# List your own configured accounts (only yours are shown)
+rex email accounts list --user james
 
-# Set the default account
-rex email accounts set-active --account-id work
+# Set your default account (must be one of your own accounts;
+# never changes another user's routing)
+rex email accounts set-active --account-id work --user james
 
-# Test account connectivity
-rex email test-connection --account-id personal
+# Test connectivity for one of your accounts
+rex email test-connection --account-id personal --user james
 
-# Send an email via a specific account
+# Send an email via a specific account you own
 rex email send --account-id work --to recipient@example.com \
-  --subject "Hello" --body "Message body"
+  --subject "Hello" --body "Message body" --user james
 ```
 
 ### Notification Account Selection
 
-Notifications that use the email channel can specify which account to use via the `email_account_id` metadata key:
+Notifications that use the email channel must name the owning user via the
+`email_user_id` metadata key (delivery is skipped otherwise — it never
+falls back to another user's account), and may pick one of that user's
+accounts with `email_account_id`:
 
 ```python
 notification = NotificationRequest(
@@ -387,12 +471,14 @@ notification = NotificationRequest(
     channel_preferences=["email"],
     metadata={
         "to_email": "admin@example.com",
-        "email_account_id": "work",  # Use the work account
+        "email_user_id": "james",     # Owner whose account sends the email
+        "email_account_id": "work",   # One of that user's accounts (optional)
     },
 )
 ```
 
-If `email_account_id` is not set, the default account routing rules apply.
+If `email_account_id` is not set, the owner's per-user default routing
+rules apply.
 
 ## Security Considerations
 

--- a/rex/cli.py
+++ b/rex/cli.py
@@ -87,6 +87,7 @@ from rex.commands._epilog import CLI_EPILOG  # noqa: E402
 from rex.commands._helpers import (  # noqa: E402,F401
     _get_version,
     _load_email_config_safe,
+    _load_email_resolver_safe,
     _parse_datetime_strict,
     _parse_ttl,
     _resolve_cli_user,

--- a/rex/commands/_helpers.py
+++ b/rex/commands/_helpers.py
@@ -31,6 +31,16 @@ def _load_email_config_safe():
         return None
 
 
+def _load_email_resolver_safe():
+    """Load the per-user EmailAccountResolver, returning None on failure."""
+    try:
+        from rex.email_accounts import EmailAccountResolver
+
+        return EmailAccountResolver.load()
+    except Exception:
+        return None
+
+
 def _resolve_cli_user(args: argparse.Namespace) -> str | None:
     """Resolve active user context for commands that accept ``--user``."""
     from rex.identity import resolve_active_user

--- a/rex/commands/email_calendar.py
+++ b/rex/commands/email_calendar.py
@@ -23,26 +23,65 @@ def _cli():
     return cli
 
 
+_NO_USER_MSG = (
+    "Error: No active user for email.\n"
+    "Set one with: rex identify --user <id>\n"
+    "Or pass one explicitly: rex email ... --user <id>"
+)
+
+
+def _resolve_email_user(args: argparse.Namespace) -> str | None:
+    """Resolve the requesting user for email commands, failing closed.
+
+    Uses ``--user`` when given, otherwise the standard identity chain
+    (``rex identify`` session state, then ``runtime.active_user`` /
+    ``runtime.user_id`` in config). Never silently falls back to the
+    ``default`` profile — single-user setups select it explicitly with
+    ``--user default`` or ``rex identify --user default``.
+    """
+    try:
+        user = _cli()._resolve_cli_user(args)
+        return str(user) if user else None
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return None
+
+
 def cmd_email(args: argparse.Namespace) -> int:
-    """Manage email."""
+    """Manage email.  Every subcommand runs as one validated user."""
     from rex.assistant_errors import IntegrationNotConfiguredError
 
-    _ = _cli()._resolve_cli_user(args)
+    user = _resolve_email_user(args)
+    if not user:
+        print(_NO_USER_MSG)
+        return 1
+
+    subcommand = args.email_command
+
+    if subcommand == "accounts":
+        return _cmd_email_accounts(args, user)
+
+    if subcommand == "test-connection":
+        return _cmd_email_test_connection(args, user)
+
     try:
         email_service = _cli().get_email_service()
     except IntegrationNotConfiguredError:
         print("Email integration not configured. Set IMAP/SMTP credentials in config.")
         return 1
-    subcommand = args.email_command
 
     if subcommand == "unread":
         if not email_service.connected:
-            if not email_service.connect():
+            if not email_service.connect(user):
                 print("Error: Failed to connect to email service")
                 return 1
 
         limit = getattr(args, "limit", None) or 10
-        unread = email_service.fetch_unread(limit=limit)
+        try:
+            unread = email_service.fetch_unread(limit=limit, user_id=user)
+        except PermissionError as exc:
+            print(f"Error: {exc}")
+            return 1
         print("Unread Email Summary")
         print("=" * 80)
         print()
@@ -68,38 +107,34 @@ def cmd_email(args: argparse.Namespace) -> int:
         print(f"Total: {len(unread)} unread emails")
         return 0
 
-    if subcommand == "accounts":
-        return _cmd_email_accounts(args)
-
     if subcommand == "send":
-        return _cmd_email_send(args)
-
-    if subcommand == "test-connection":
-        return _cmd_email_test_connection(args)
+        return _cmd_email_send(args, user)
 
     print("Unknown email subcommand. Use 'rex email --help'")
     return 1
 
 
-def _cmd_email_accounts(args: argparse.Namespace) -> int:
-    """Handle 'rex email accounts' subcommands."""
+def _cmd_email_accounts(args: argparse.Namespace, user: str) -> int:
+    """Handle 'rex email accounts' subcommands for one validated user."""
     accounts_cmd = getattr(args, "accounts_command", "list")
+    resolver = _cli()._load_email_resolver_safe()
 
     if accounts_cmd == "list":
-        email_config = _cli()._load_email_config_safe()
-        if not email_config or not email_config.accounts:
-            print("No email accounts configured.")
+        accounts = [] if resolver is None else resolver.accounts_for_user(user)
+        if resolver is None or not accounts:
+            print(f"No email accounts configured for user '{user}'.")
             print()
-            print("To configure accounts, add an 'email' section to config/rex_config.json.")
+            print("To configure accounts, add an 'email' section to config/rex_config.json")
+            print(f"and assign them to this user under users.{user}.email_accounts.")
             print("See docs/email.md for details.")
             return 0
 
-        print("Email Accounts")
+        print(f"Email Accounts for user '{user}'")
         print("=" * 60)
         print()
 
-        default_id = email_config.default_account_id
-        for acct in email_config.accounts:
+        default_id = resolver.default_account_id_for_user(user)
+        for acct in accounts:
             is_default = " (default)" if acct.id == default_id else ""
             print(f"  {acct.id}{is_default}")
             if acct.label:
@@ -110,7 +145,7 @@ def _cmd_email_accounts(args: argparse.Namespace) -> int:
             print(f"    Cred:    {acct.credential_ref}")
             print()
 
-        print(f"Total: {len(email_config.accounts)} account(s)")
+        print(f"Total: {len(accounts)} account(s)")
         return 0
 
     if accounts_cmd == "set-active":
@@ -119,17 +154,21 @@ def _cmd_email_accounts(args: argparse.Namespace) -> int:
             print("Error: --account-id is required")
             return 1
 
-        email_config = _cli()._load_email_config_safe()
-        if not email_config:
+        if resolver is None:
             print("Error: No email configuration found")
             return 1
 
-        ids = email_config.list_account_ids()
-        if account_id not in ids:
-            print(f"Error: Account '{account_id}' not found. Available: {', '.join(ids)}")
+        owned = resolver.account_ids_for_user(user)
+        if account_id not in owned:
+            # Foreign and nonexistent accounts are indistinguishable; only
+            # the requesting user's own accounts are ever revealed.
+            print(f"Error: Account '{account_id}' is not available for user '{user}'.")
+            if owned:
+                print(f"Available: {', '.join(owned)}")
             return 1
 
-        # Update the config file
+        # Update only this user's default; never another user's routing and
+        # never the legacy global default.
         try:
             import json as _json
 
@@ -139,11 +178,14 @@ def _cmd_email_accounts(args: argparse.Namespace) -> int:
             else:
                 config_data = {}
 
-            if "email" not in config_data:
-                config_data["email"] = {}
-            config_data["email"]["default_account_id"] = account_id
+            users_block = config_data.setdefault("users", {})
+            user_entry = users_block.setdefault(user, {})
+            if not isinstance(user_entry, dict):
+                print("Error: Invalid users section in config")
+                return 1
+            user_entry["default_email_account_id"] = account_id
             config_path.write_text(_json.dumps(config_data, indent=2) + "\n", encoding="utf-8")
-            print(f"Default email account set to '{account_id}'")
+            print(f"Default email account for user '{user}' set to '{account_id}'")
             return 0
         except Exception as exc:
             print(f"Error updating config: {exc}")
@@ -153,8 +195,8 @@ def _cmd_email_accounts(args: argparse.Namespace) -> int:
     return 1
 
 
-def _cmd_email_send(args: argparse.Namespace) -> int:
-    """Handle 'rex email send'."""
+def _cmd_email_send(args: argparse.Namespace, user: str) -> int:
+    """Handle 'rex email send' for one validated user."""
     to = getattr(args, "to", None)
     subject = getattr(args, "subject", None)
     body = getattr(args, "body", None)
@@ -172,16 +214,21 @@ def _cmd_email_send(args: argparse.Namespace) -> int:
         print("Email integration not configured. Set IMAP/SMTP credentials in config.")
         return 1
     if not email_service.connected:
-        if not email_service.connect():
+        if not email_service.connect(user):
             print("Error: Failed to connect to email service")
             return 1
 
-    result = email_service.send(
-        to=to,
-        subject=subject,
-        body=body,
-        account_id=account_id,
-    )
+    try:
+        result = email_service.send(
+            to=to,
+            subject=subject,
+            body=body,
+            account_id=account_id,
+            user_id=user,
+        )
+    except PermissionError as exc:
+        print(f"Error: {exc}")
+        return 1
 
     if result.get("ok"):
         msg_id = result.get("message_id") or "(stub)"
@@ -192,27 +239,35 @@ def _cmd_email_send(args: argparse.Namespace) -> int:
     return 1
 
 
-def _cmd_email_test_connection(args: argparse.Namespace) -> int:
-    """Handle 'rex email test-connection'."""
+def _cmd_email_test_connection(args: argparse.Namespace, user: str) -> int:
+    """Handle 'rex email test-connection' for one validated user."""
     account_id = getattr(args, "account_id", None)
 
-    email_config = _cli()._load_email_config_safe()
-    if not email_config or not email_config.accounts:
+    resolver = _cli()._load_email_resolver_safe()
+    if resolver is None or not resolver.has_configured_accounts():
         print("No email accounts configured. Using stub backend.")
         print("Connection test: OK (stub mode)")
         return 0
 
-    acct = email_config.get_account(account_id)
+    owned = resolver.account_ids_for_user(user)
+    try:
+        resolved_id = resolver.resolve_account_id(user, account_id)
+    except PermissionError:
+        resolved_id = None
+    acct = resolver.get_account_definition(resolved_id) if resolved_id else None
     if acct is None:
-        available = ", ".join(email_config.list_account_ids())
-        print(f"Error: Account not found. Available: {available}")
+        # Only the requesting user's own accounts are ever revealed.
+        if owned:
+            print(f"Error: Account not available. Available for user '{user}': {', '.join(owned)}")
+        else:
+            print(f"Error: No email accounts configured for user '{user}'.")
         return 1
 
     print(f"Testing connection for account '{acct.id}' ({acct.address})...")
     print(f"  IMAP: {acct.imap.host}:{acct.imap.port}")
     print(f"  SMTP: {acct.smtp.host}:{acct.smtp.port}")
 
-    # Check credentials
+    # Check credentials (only this account's own credential_ref is consulted)
     try:
         from rex.credentials import get_credential_manager
 
@@ -232,14 +287,10 @@ def _cmd_email_test_connection(args: argparse.Namespace) -> int:
 
     # Try IMAP connect
     try:
-        from rex.email_backends.account_router import resolve_backend
+        from rex.email_backends.account_router import build_backend_for_account
 
-        backend, _ = resolve_backend(
-            email_config,
-            account_id=acct.id,
-            credential_getter=cm.get_token,
-        )
-        if backend.connect():
+        backend = build_backend_for_account(acct, credential_getter=cm.get_token)
+        if backend is not None and backend.connect():
             print("  IMAP connection: OK")
             backend.disconnect()
         else:
@@ -369,6 +420,9 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     email_unread.add_argument(
         "-v", "--verbose", action="store_true", help="Show detailed email information"
     )
+    email_unread.add_argument(
+        "--user", type=str, default=None, help="User context for this command"
+    )
     email_unread.set_defaults(func=_cli().cmd_email, email_command="unread")
 
     # email accounts
@@ -385,7 +439,10 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 
     email_accounts_list = email_accounts_sub.add_parser(
         "list",
-        help="List configured email accounts",
+        help="List the selected user's email accounts",
+    )
+    email_accounts_list.add_argument(
+        "--user", type=str, default=None, help="User context for this command"
     )
     email_accounts_list.set_defaults(
         func=cmd_email, email_command="accounts", accounts_command="list"
@@ -393,13 +450,16 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 
     email_accounts_set_active = email_accounts_sub.add_parser(
         "set-active",
-        help="Set the default email account",
+        help="Set the selected user's default email account",
     )
     email_accounts_set_active.add_argument(
         "--account-id",
         type=str,
         required=True,
-        help="Account ID to set as default",
+        help="Account ID to set as this user's default",
+    )
+    email_accounts_set_active.add_argument(
+        "--user", type=str, default=None, help="User context for this command"
     )
     email_accounts_set_active.set_defaults(
         func=cmd_email, email_command="accounts", accounts_command="set-active"
@@ -419,6 +479,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     email_send.add_argument("--subject", type=str, required=True, help="Email subject")
     email_send.add_argument("--body", type=str, required=True, help="Email body text")
     email_send.add_argument("--account-id", type=str, default=None, help="Account ID to send from")
+    email_send.add_argument("--user", type=str, default=None, help="User context for this command")
     email_send.set_defaults(func=_cli().cmd_email, email_command="send")
 
     # email test-connection
@@ -428,6 +489,9 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         description="Verify IMAP/SMTP connectivity for a configured account.",
     )
     email_test_conn.add_argument("--account-id", type=str, default=None, help="Account ID to test")
+    email_test_conn.add_argument(
+        "--user", type=str, default=None, help="User context for this command"
+    )
     email_test_conn.set_defaults(func=_cli().cmd_email, email_command="test-connection")
 
     email_parser.set_defaults(func=_cli().cmd_email, email_command="unread")

--- a/rex/config.py
+++ b/rex/config.py
@@ -350,6 +350,10 @@ class AppConfig:
     # Keyed by user_id; each value is the list of email accounts for that user.
     user_email_accounts: Dict[str, List[UserEmailAccount]] = field(default_factory=dict)
 
+    # Per-user default email account selection (issue #303).
+    # Keyed by user_id; value is the account_id of that user's default account.
+    user_default_email_accounts: Dict[str, str] = field(default_factory=dict)
+
     # Location and weather
     default_location: Optional[str] = None
     default_timezone: Optional[str] = None
@@ -836,6 +840,24 @@ def _parse_user_email_accounts(
     return result
 
 
+def _parse_user_default_email_accounts(users_block: object) -> Dict[str, str]:
+    """Parse ``users.{user_id}.default_email_account_id`` into a per-user map.
+
+    Each user's default may only reference an account assigned to that user;
+    ownership is enforced at resolution time by ``rex.email_accounts``.
+    """
+    result: Dict[str, str] = {}
+    if not isinstance(users_block, dict):
+        return result
+    for user_id, user_data in users_block.items():
+        if not isinstance(user_data, dict):
+            continue
+        default_id = user_data.get("default_email_account_id")
+        if isinstance(default_id, str) and default_id.strip():
+            result[str(user_id)] = default_id.strip()
+    return result
+
+
 def _parse_model_routing(raw: object) -> ModelRoutingConfig:
     """Parse ``model_routing`` block from JSON config."""
     if not isinstance(raw, dict):
@@ -1081,6 +1103,10 @@ def build_app_config(json_config: dict) -> AppConfig:
         user_email_accounts=_parse_user_email_accounts(
             _get_nested(json_config, "users", {}),
             _get_nested(json_config, "email.accounts", []),
+        ),
+        # Per-user default email account selection (issue #303)
+        user_default_email_accounts=_parse_user_default_email_accounts(
+            _get_nested(json_config, "users", {}),
         ),
         # History persistence
         persist_history=bool(_get_nested(json_config, "runtime.persist_history", True)),

--- a/rex/email_accounts.py
+++ b/rex/email_accounts.py
@@ -1,0 +1,361 @@
+"""Canonical per-user email account authorization and routing (issue #303).
+
+This module is the single source of truth for deciding **which email accounts
+a user may touch** and **which account serves a request**.  Every real email
+surface (service, CLI, Electron bridge, OpenClaw tools, scheduler, notification
+channel) must route account selection through :class:`EmailAccountResolver`.
+
+Ownership model
+---------------
+- ``email.accounts`` in ``config/rex_config.json`` is the canonical non-secret
+  connection-metadata list (host/port/address/``credential_ref``).
+- ``users.{user_id}.email_accounts`` is the authoritative authorization map
+  assigning account IDs to users (parsed into
+  ``AppConfig.user_email_accounts``).
+- ``users.{user_id}.default_email_account_id`` selects that user's default
+  account.  It must reference an account the user owns; a foreign or unknown
+  default is ignored (fail closed to the user's own fallback).
+- Legacy ``email.accounts`` entries not assigned to any user belong **only**
+  to the distinct ``default`` profile.  They are never shared with or
+  silently reassigned to named users.
+- Legacy ``email.default_account_id`` applies only to the ``default`` profile.
+
+Routing order (always within the requesting user's authorized set):
+
+1. Explicit requested account ID (after ownership validation).
+2. The user's configured default account.
+3. Legacy global default — only for the explicit ``default`` profile.
+4. The first account assigned to the user (deterministic, config order).
+5. Otherwise: no account (callers fail closed / report not-configured).
+
+Unauthorized and nonexistent accounts are indistinguishable to callers:
+both raise :class:`EmailAccountAccessError` with the same generic message.
+Credential lookup happens only *after* ownership validation and only with the
+authorized account definition's own ``credential_ref``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from rex.identity import validate_user_id
+
+logger = logging.getLogger(__name__)
+
+#: Runtime config file backing the authorization map.
+_CONFIG_PATH = Path("config/rex_config.json")
+
+
+def config_stamp() -> int | None:
+    """Modification stamp of the runtime config file.
+
+    Used by long-lived services to invalidate cached resolvers so that
+    revoking or reassigning a user's email accounts takes effect without a
+    process restart.
+    """
+    try:
+        return _CONFIG_PATH.stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+#: The distinct legacy single-user profile.  Legacy global accounts and the
+#: legacy global default belong to this profile only.
+DEFAULT_PROFILE = "default"
+
+#: Generic message for unauthorized-or-nonexistent accounts.  Must not vary
+#: with account existence so callers cannot enumerate other users' accounts.
+ACCOUNT_UNAVAILABLE_MSG = "Email account {account_id!r} is not available for user {user_id!r}"
+
+_IDENTITY_REQUIRED_MSG = (
+    "Email operations require an explicit valid user identity; "
+    "refusing to fall back to a default or shared account"
+)
+
+
+class EmailAccountAccessError(PermissionError):
+    """The requested account is not available to the requesting user.
+
+    Raised both for accounts owned by another user and for accounts that do
+    not exist, with an identical message shape, so the two cases cannot be
+    distinguished by the caller.
+    """
+
+
+class EmailIdentityError(PermissionError):
+    """A real email operation was attempted without a valid user identity."""
+
+
+def require_user_id(user_id: object) -> str:
+    """Validate *user_id* for email operations, failing closed.
+
+    Returns:
+        The validated user ID.
+
+    Raises:
+        EmailIdentityError: If *user_id* is missing, blank, malformed, or
+            traversal-style.  Raised before any account or credential lookup.
+    """
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise EmailIdentityError(_IDENTITY_REQUIRED_MSG)
+    try:
+        return validate_user_id(user_id)
+    except ValueError as exc:
+        raise EmailIdentityError(_IDENTITY_REQUIRED_MSG) from exc
+
+
+class EmailAccountResolver:
+    """Authorization and routing for per-user email accounts.
+
+    Args:
+        email_config:  Parsed ``EmailConfig`` (canonical account definitions).
+        user_accounts: ``{user_id: [UserEmailAccount, ...]}`` authorization map.
+        user_defaults: ``{user_id: account_id}`` per-user default selection.
+    """
+
+    def __init__(
+        self,
+        email_config: Any,
+        user_accounts: dict[str, list[Any]] | None = None,
+        user_defaults: dict[str, str] | None = None,
+    ) -> None:
+        self._email_config = email_config
+        self._user_accounts: dict[str, list[Any]] = dict(user_accounts or {})
+        self._user_defaults: dict[str, str] = dict(user_defaults or {})
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_raw_config(cls, raw_config: dict[str, Any] | None) -> EmailAccountResolver:
+        """Build a resolver from the merged runtime config dict."""
+        from rex.config import _parse_user_default_email_accounts, _parse_user_email_accounts
+        from rex.email_backends.account_config import EmailConfig
+
+        raw = raw_config or {}
+        email_section = raw.get("email")
+        if not isinstance(email_section, dict):
+            email_section = {}
+        # Only pass the keys EmailConfig knows about; the email section may
+        # also carry unrelated keys such as ``provider``.
+        try:
+            email_config = EmailConfig.model_validate(
+                {
+                    "default_account_id": email_section.get("default_account_id"),
+                    "accounts": email_section.get("accounts") or [],
+                }
+            )
+        except Exception as exc:
+            logger.warning("Invalid email account configuration ignored: %s", exc)
+            email_config = EmailConfig()
+
+        users_block = raw.get("users")
+        user_accounts = _parse_user_email_accounts(users_block, email_section.get("accounts") or [])
+        user_defaults = _parse_user_default_email_accounts(users_block)
+        return cls(email_config, user_accounts, user_defaults)
+
+    @classmethod
+    def load(cls) -> EmailAccountResolver:
+        """Build a resolver from ``config/rex_config.json``."""
+        from rex.config_manager import load_config
+
+        try:
+            raw = load_config()
+        except Exception as exc:
+            logger.warning("Failed to load config for email account resolution: %s", exc)
+            raw = {}
+        return cls.from_raw_config(raw)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def email_config(self) -> Any:
+        return self._email_config
+
+    def has_configured_accounts(self) -> bool:
+        """True when any real account definition exists."""
+        return bool(getattr(self._email_config, "accounts", None))
+
+    def get_account_definition(self, account_id: str) -> Any | None:
+        """Return the canonical account definition for *account_id*, if any."""
+        for acct in getattr(self._email_config, "accounts", []) or []:
+            if acct.id == account_id:
+                return acct
+        return None
+
+    # ------------------------------------------------------------------
+    # Authorization
+    # ------------------------------------------------------------------
+
+    def entries_for_user(self, user_id: str) -> list[Any]:
+        """Return the ``UserEmailAccount`` entries authorized for *user_id*.
+
+        For the ``default`` profile this includes legacy account definitions
+        that no user has claimed.  Named users get only explicit assignments.
+        """
+        validated = require_user_id(user_id)
+        entries = list(self._user_accounts.get(validated, []))
+        if validated == DEFAULT_PROFILE:
+            assigned = {
+                entry.account_id
+                for user_entries in self._user_accounts.values()
+                for entry in user_entries
+            }
+            have = {entry.account_id for entry in entries}
+            from rex.config import UserEmailAccount
+
+            for acct in getattr(self._email_config, "accounts", []) or []:
+                if acct.id not in assigned and acct.id not in have:
+                    entries.append(
+                        UserEmailAccount(
+                            account_id=acct.id,
+                            display_name=acct.label or acct.address,
+                            backend="imap",
+                            credentials_key=acct.credential_ref,
+                        )
+                    )
+        return entries
+
+    def account_ids_for_user(self, user_id: str) -> list[str]:
+        """Return account IDs authorized for *user_id* (deterministic order)."""
+        return [entry.account_id for entry in self.entries_for_user(user_id)]
+
+    def configured_user_ids(self) -> list[str]:
+        """Return the users with at least one authorized account.
+
+        Only valid user IDs are returned (invalid persisted IDs are skipped,
+        fail closed).  The ``default`` profile is included when legacy
+        unassigned accounts exist.  Order is deterministic.
+        """
+        ids: list[str] = []
+        for user_id in self._user_accounts:
+            try:
+                validated = require_user_id(user_id)
+            except EmailIdentityError:
+                logger.warning("Skipping email accounts assigned to an invalid user ID")
+                continue
+            if self._user_accounts.get(validated) and validated not in ids:
+                ids.append(validated)
+        if DEFAULT_PROFILE not in ids and self.entries_for_user(DEFAULT_PROFILE):
+            ids.append(DEFAULT_PROFILE)
+        return ids
+
+    def is_account_authorized(self, user_id: str, account_id: str) -> bool:
+        return account_id in self.account_ids_for_user(user_id)
+
+    def check_account_access(self, user_id: str, account_id: str) -> None:
+        """Raise :class:`EmailAccountAccessError` unless *user_id* owns *account_id*."""
+        validated = require_user_id(user_id)
+        if not self.is_account_authorized(validated, account_id):
+            raise EmailAccountAccessError(
+                ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
+            )
+
+    def accounts_for_user(self, user_id: str) -> list[Any]:
+        """Return the canonical account definitions authorized for *user_id*."""
+        definitions = []
+        for entry in self.entries_for_user(user_id):
+            definition = self.get_account_definition(entry.account_id)
+            if definition is not None:
+                definitions.append(definition)
+        return definitions
+
+    def provider_entry_for_user(self, user_id: str) -> Any | None:
+        """Return the user's first OAuth-provider account entry, if any.
+
+        Used by the GUI inbox surfaces: a ``gmail``/``outlook`` backend entry
+        carries its own ``credentials_key`` and does not reference an
+        ``email.accounts`` IMAP definition.
+        """
+        for entry in self.entries_for_user(user_id):
+            if getattr(entry, "backend", "") in ("gmail", "outlook"):
+                return entry
+        return None
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+
+    def default_account_id_for_user(self, user_id: str) -> str | None:
+        """Return the user's effective default account ID, or ``None``.
+
+        A configured default that the user does not own is ignored (fail
+        closed) rather than granting access or aborting.
+        """
+        validated = require_user_id(user_id)
+        owned = self.account_ids_for_user(validated)
+        configured = self._user_defaults.get(validated)
+        if configured:
+            if configured in owned:
+                return configured
+            logger.warning(
+                "Ignoring default email account for user %r: not owned by that user",
+                validated,
+            )
+        if validated == DEFAULT_PROFILE:
+            legacy = getattr(self._email_config, "default_account_id", None)
+            if legacy and legacy in owned:
+                return str(legacy)
+        return None
+
+    def resolve_account_id(self, user_id: str, account_id: str | None = None) -> str | None:
+        """Resolve the account that serves a request for *user_id*.
+
+        Returns:
+            The resolved account ID, or ``None`` when the user has no
+            authorized accounts (callers fail closed or report
+            not-configured).
+
+        Raises:
+            EmailIdentityError: On missing/invalid identity.
+            EmailAccountAccessError: When *account_id* is explicitly requested
+                but is not available to this user (unauthorized or
+                nonexistent — indistinguishable).
+        """
+        validated = require_user_id(user_id)
+        owned = self.account_ids_for_user(validated)
+
+        if account_id:
+            if account_id not in owned:
+                raise EmailAccountAccessError(
+                    ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
+                )
+            return account_id
+
+        default_id = self.default_account_id_for_user(validated)
+        if default_id:
+            return default_id
+
+        # Deterministic fallback: first authorized account that has a real
+        # definition; else the first authorized entry (stub-mode setups).
+        for owned_id in owned:
+            if self.get_account_definition(owned_id) is not None:
+                return owned_id
+        return owned[0] if owned else None
+
+    def resolve_account(self, user_id: str, account_id: str | None = None) -> Any | None:
+        """Resolve the canonical account definition serving a request.
+
+        Same contract as :meth:`resolve_account_id`, but returns the account
+        definition (or ``None`` if the resolved account has no definition,
+        e.g. stub-only setups).
+        """
+        resolved_id = self.resolve_account_id(user_id, account_id)
+        if resolved_id is None:
+            return None
+        return self.get_account_definition(resolved_id)
+
+
+__all__ = [
+    "ACCOUNT_UNAVAILABLE_MSG",
+    "DEFAULT_PROFILE",
+    "EmailAccountAccessError",
+    "EmailAccountResolver",
+    "EmailIdentityError",
+    "require_user_id",
+]

--- a/rex/email_backends/account_router.py
+++ b/rex/email_backends/account_router.py
@@ -43,27 +43,49 @@ def resolve_backend(
         logger.info("No email accounts configured; using stub backend")
         return StubEmailBackend(fixture_path=stub_fixture), None
 
+    backend = build_backend_for_account(
+        account,
+        credential_getter=credential_getter,
+    )
+    if backend is None:
+        return StubEmailBackend(fixture_path=stub_fixture), None
+    return backend, account
+
+
+def build_backend_for_account(
+    account: EmailAccountConfig,
+    credential_getter: object | None = None,
+) -> EmailBackend | None:
+    """Build a real backend for one already-authorized account definition.
+
+    Ownership must be validated by the caller (``rex.email_accounts``) before
+    this is invoked.  The credential lookup uses only the account's own
+    ``credential_ref`` — callers can never supply an arbitrary reference.
+
+    Returns:
+        A connected-capable ``ImapSmtpEmailBackend``, or ``None`` when no
+        usable credential is available for the account.
+    """
     cred_token = _get_credential(account.credential_ref, credential_getter)
     if cred_token is None:
         logger.warning(
-            "No credential found for ref '%s' (account '%s'); " "falling back to stub backend",
+            "No credential found for ref '%s' (account '%s')",
             account.credential_ref,
             account.id,
         )
-        return StubEmailBackend(fixture_path=stub_fixture), None
+        return None
 
     username, password = _parse_credential_token(cred_token, account)
     if not username or not password:
         logger.warning(
-            "Credential for '%s' could not be parsed into username:password; "
-            "falling back to stub backend",
+            "Credential for '%s' could not be parsed into username:password",
             account.credential_ref,
         )
-        return StubEmailBackend(fixture_path=stub_fixture), None
+        return None
 
     from rex.email_backends.imap_smtp import ImapSmtpEmailBackend
 
-    backend = ImapSmtpEmailBackend(
+    return ImapSmtpEmailBackend(
         imap_host=account.imap.host,
         imap_port=account.imap.port,
         smtp_host=account.smtp.host,
@@ -72,7 +94,6 @@ def resolve_backend(
         password=password,
         use_starttls=account.smtp.starttls,
     )
-    return backend, account
 
 
 def _get_credential(
@@ -104,4 +125,4 @@ def _parse_credential_token(
     return account.address, token.strip()
 
 
-__all__ = ["resolve_backend"]
+__all__ = ["build_backend_for_account", "resolve_backend"]

--- a/rex/email_service.py
+++ b/rex/email_service.py
@@ -10,18 +10,39 @@ Design goals:
   2) "triage_unread(...)" returning CLI-friendly dict summaries
 - Optional EventBus publishing if rex.event_bus is available and provided.
 - Backend-aware: accepts an optional ``EmailBackend`` for real IMAP/SMTP.
-- Multi-account: can resolve backend per-account via ``EmailConfig``.
-- ``send()`` method delegates to the active backend.
+- Multi-account: resolves backends per validated user and account via
+  ``rex.email_accounts.EmailAccountResolver`` (issue #303).
+- ``send()`` method delegates to the requesting user's authorized backend.
+
+Per-user isolation (issue #303):
+- Every operation that reads or mutates email data requires an explicit,
+  validated ``user_id``.  Missing, blank, malformed, or traversal-style
+  identities fail closed (``EmailIdentityError``) before any account or
+  credential lookup.
+- Account selection is restricted to the requesting user's authorized
+  accounts; explicit foreign or nonexistent accounts raise the generic
+  ``EmailAccountAccessError`` (indistinguishable to the caller).
+- Backends are cached per ``(user_id, account_id)``; a backend resolved for
+  one user is never reused for another.
+- Stub/mock mode keeps a separate mutable inbox per user so one user's
+  mark-read never alters another user's view.
 """
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+from rex.email_accounts import (
+    DEFAULT_PROFILE,
+    EmailAccountResolver,
+    require_user_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -109,10 +130,15 @@ class EmailService:
 
     Supports two modes:
     - **Stub mode** (default): reads from a local JSON fixture; send is a
-      logged no-op.  Used for offline development and testing.
-    - **Backend mode**: delegates to an ``EmailBackend`` instance for real
-      IMAP/SMTP operations.  Activated by passing a ``backend`` to the
-      constructor or by calling ``set_backend()``.
+      logged no-op.  Used for offline development and testing.  Each user
+      gets an isolated mutable copy of the fixture inbox.
+    - **Backend mode**: resolves an ``EmailBackend`` per validated user and
+      authorized account via ``EmailAccountResolver``.  An explicitly
+      injected backend (constructor ``backend=`` or :meth:`set_backend`)
+      serves only the user it is bound to.
+
+    Every read/mutate/send operation requires a validated ``user_id`` and
+    fails closed on missing or invalid identity.
     """
 
     def __init__(
@@ -123,7 +149,10 @@ class EmailService:
         mock_messages: list[EmailMessage] | None = None,
         mock_data_path: Path | None = None,
         backend: object | None = None,
+        backend_user_id: str = DEFAULT_PROFILE,
         user_email_accounts: dict[str, list[Any]] | None = None,
+        user_default_accounts: dict[str, str] | None = None,
+        account_resolver: EmailAccountResolver | None = None,
     ) -> None:
         if event_bus is None and mock_data_file is not None and hasattr(mock_data_file, "publish"):
             event_bus = mock_data_file  # type: ignore[assignment]
@@ -137,9 +166,23 @@ class EmailService:
         self._event_bus = event_bus
         self._mock_messages = mock_messages  # If provided, overrides file loading
         self._mock_emails: list[EmailSummary] = []
-        self._backend = backend  # Optional EmailBackend instance
+        # Per-user isolated copies of the stub inbox: {user_id: [EmailSummary]}
+        self._user_mock_emails: dict[str, list[EmailSummary]] = {}
+        # Explicitly injected backend, bound to exactly one user.
+        self._backend = backend
+        self._backend_owner = require_user_id(backend_user_id) if backend is not None else None
         # Per-user account map: {user_id: [UserEmailAccount, ...]}
         self._user_email_accounts: dict[str, list[Any]] = user_email_accounts or {}
+        # Per-user default account selection: {user_id: account_id}
+        self._user_default_accounts: dict[str, str] = user_default_accounts or {}
+        # Injected authorization/routing resolver (tests/embedding only; the
+        # production path loads lazily so config changes are picked up).
+        self._account_resolver = account_resolver
+        self._resolver_cache: EmailAccountResolver | None = None
+        self._resolver_stamp: int | None = None
+        # Backends resolved from config, cached per (user_id, account_id).
+        # A backend resolved for one user is never served to another.
+        self._user_backends: dict[tuple[str, str], object] = {}
 
         self.credential_manager = None
         if get_credential_manager is not None:
@@ -152,73 +195,155 @@ class EmailService:
     # Backend management
     # ------------------------------------------------------------------
 
-    def set_backend(self, backend: object) -> None:
-        """Swap the active email backend at runtime.
+    def set_backend(self, backend: object, *, user_id: str = DEFAULT_PROFILE) -> None:
+        """Swap the explicitly injected email backend at runtime.
+
+        The injected backend is bound to *user_id* and serves only that
+        user's operations; other users resolve through the account resolver.
 
         Args:
             backend: An ``EmailBackend`` instance (or ``None`` for stub).
+            user_id: The user this backend belongs to (default: the legacy
+                ``default`` profile).
         """
         self._backend = backend
+        self._backend_owner = require_user_id(user_id) if backend is not None else None
         self.connected = False
 
     @property
     def active_backend(self) -> object | None:
-        """The currently configured backend (may be ``None`` for stub mode)."""
+        """The explicitly injected backend (``None`` in stub/resolver mode)."""
         return self._backend
 
     # ------------------------------------------------------------------
-    # User-scoped account access (US-ME-002)
+    # User-scoped account access (US-ME-002 / issue #303)
     # ------------------------------------------------------------------
 
+    def _get_resolver(self) -> EmailAccountResolver:
+        """Return the account resolver for this service instance.
+
+        Config-backed resolvers are invalidated when the runtime config file
+        changes, so revoking or reassigning a user's accounts takes effect in
+        long-lived processes without a restart.  Authorization is re-checked
+        on every operation, so cached backends never outlive their owner's
+        assignment.
+        """
+        if self._account_resolver is not None:
+            return self._account_resolver
+
+        from rex import email_accounts as _email_accounts
+
+        stamp = _email_accounts.config_stamp()
+        if self._resolver_cache is None or stamp != self._resolver_stamp:
+            if self._user_email_accounts or self._user_default_accounts:
+                # Explicitly injected authorization map: authoritative.
+                base = EmailAccountResolver.load()
+                self._resolver_cache = EmailAccountResolver(
+                    base.email_config,
+                    self._user_email_accounts,
+                    self._user_default_accounts,
+                )
+            else:
+                self._resolver_cache = EmailAccountResolver.load()
+            self._resolver_stamp = stamp
+        return self._resolver_cache
+
     def get_accounts(self, user_id: str) -> list[Any]:
-        """Return the email accounts owned by *user_id*.
+        """Return the email account entries authorized for *user_id*.
 
         Returns an empty list (not an error) when the user has no accounts
         configured.  Never returns accounts belonging to other users.
+
+        Raises:
+            EmailIdentityError: On missing or invalid identity.
         """
-        return list(self._user_email_accounts.get(user_id, []))
+        return self._get_resolver().entries_for_user(user_id)
 
     def _check_account_access(self, user_id: str, account_id: str) -> None:
-        """Raise ``PermissionError`` if *account_id* does not belong to *user_id*.
+        """Raise ``EmailAccountAccessError`` unless *user_id* owns *account_id*.
 
-        The check is only applied when ``user_email_accounts`` has been
-        populated (i.e. when the caller explicitly provided the map).  If the
-        map is empty the check is a no-op so that existing callers without
-        user context continue to work.
+        Unauthorized and nonexistent accounts are indistinguishable.  An
+        empty authorization map means "no access", never "allow all".
         """
-        if not self._user_email_accounts:
-            return  # No scoping configured — allow all (backwards compat)
-        owned_ids = {
-            getattr(a, "account_id", None) for a in self._user_email_accounts.get(user_id, [])
-        }
-        if account_id not in owned_ids:
-            raise PermissionError(
-                f"User {user_id!r} does not have access to account {account_id!r}"
-            )
+        self._get_resolver().check_account_access(user_id, account_id)
+
+    def _get_user_backend(
+        self, user_id: str, account_id: str | None = None
+    ) -> tuple[object | None, Any]:
+        """Resolve the backend serving *user_id*, after ownership validation.
+
+        Credential lookup happens only here, only after the account has been
+        authorized, and only with that account definition's own
+        ``credential_ref``.
+
+        Returns:
+            ``(backend_or_None, account_definition_or_None)``.
+        """
+        validated = require_user_id(user_id)
+        resolver = self._get_resolver()
+        resolved_id = resolver.resolve_account_id(validated, account_id)
+        if resolved_id is None:
+            return None, None
+        definition = resolver.get_account_definition(resolved_id)
+        if definition is None:
+            return None, None
+
+        key = (validated, resolved_id)
+        backend = self._user_backends.get(key)
+        if backend is None:
+            credential_getter = None
+            if self.credential_manager is not None and hasattr(
+                self.credential_manager, "get_token"
+            ):
+                credential_getter = self.credential_manager.get_token
+
+            from rex.email_backends.account_router import build_backend_for_account
+
+            backend = build_backend_for_account(definition, credential_getter=credential_getter)
+            if backend is None:
+                return None, definition
+            try:
+                backend.connect()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to connect email backend for account %r: %s", resolved_id, exc
+                )
+            self._user_backends[key] = backend
+        return backend, definition
 
     # ------------------------------------------------------------------
     # Connection
     # ------------------------------------------------------------------
 
-    def connect(self) -> bool:
+    def connect(self, user_id: str | None = None) -> bool:
         """
         Connect to email service.
 
-        If a backend is set, delegates to ``backend.connect()``.
-        Otherwise falls back to stub behaviour (loads mock data).
+        With an injected backend, delegates to ``backend.connect()``.  When
+        real accounts are configured, *user_id* is required and only that
+        user's authorized backend is connected.  Otherwise falls back to
+        stub behaviour (loads mock data).
         """
         try:
-            if self._backend is None:
-                backend, _account = self._resolve_backend_from_config()
-                if backend is not None:
-                    self._backend = backend
-
             if self._backend is not None:
                 result = self._backend.connect()  # type: ignore[attr-defined]
                 self.connected = bool(result)
                 if self.connected:
                     logger.info("Email service connected via backend")
                 return self.connected
+
+            resolver = self._get_resolver()
+            if resolver.has_configured_accounts():
+                if user_id is None:
+                    logger.warning(
+                        "Email accounts are configured; connect() requires a user identity"
+                    )
+                    return False
+                backend, _definition = self._get_user_backend(user_id)
+                if backend is None:
+                    return False
+                self.connected = True
+                return True
 
             # Stub mode
             if self.credential_manager is not None:
@@ -238,41 +363,6 @@ class EmailService:
             self.connected = False
             return False
 
-    def _resolve_backend_from_config(
-        self, account_id: str | None = None
-    ) -> tuple[object | None, Any]:
-        """Resolve a real backend from runtime config, else return ``(None, None)``.
-
-        Resolution follows the account-router precedence:
-        explicit account > default account > first account > stub fallback.
-        """
-        try:
-            from rex.config_manager import load_config as _load_json_config
-            from rex.email_backends.account_config import load_email_config
-            from rex.email_backends.account_router import resolve_backend
-            from rex.email_backends.stub import StubEmailBackend
-
-            raw_config = _load_json_config()
-            email_config = load_email_config(raw_config)
-
-            credential_getter = None
-            if self.credential_manager is not None and hasattr(
-                self.credential_manager, "get_token"
-            ):
-                credential_getter = self.credential_manager.get_token
-
-            backend, account = resolve_backend(
-                email_config,
-                account_id=account_id,
-                credential_getter=credential_getter,
-            )
-            if isinstance(backend, StubEmailBackend):
-                return None, None
-            return backend, account
-        except Exception as exc:
-            logger.debug("Failed to resolve configured email backend: %s", exc)
-            return None, None
-
     def _publish(self, topic: str, payload: dict[str, Any]) -> None:
         if self._event_bus is None:
             return
@@ -280,6 +370,23 @@ class EmailService:
             self._event_bus.publish(topic, payload)
         except Exception as e:
             logger.debug("EventBus publish failed for %s: %s", topic, e)
+
+    def _publish_user_event(
+        self,
+        topic: str,
+        user_id: str,
+        shared_payload: dict[str, Any],
+        private_payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Publish a safe envelope on the shared topic and the full payload
+        on the owner's user-scoped topic.
+
+        The shared topic must never carry private email fields (subjects,
+        senders, snippets); those go only to ``{topic}.user.{user_id}``.
+        """
+        self._publish(topic, shared_payload)
+        if private_payload is not None:
+            self._publish(f"{topic}.user.{user_id}", private_payload)
 
     def _load_mock_data(self) -> None:
         """Load mock email data from file or legacy mock messages."""
@@ -324,6 +431,14 @@ class EmailService:
 
         self._mock_emails = parsed
         logger.info("Loaded %d mock emails", len(self._mock_emails))
+
+    def _user_inbox(self, user_id: str) -> list[EmailSummary]:
+        """Return *user_id*'s isolated mutable copy of the stub inbox."""
+        inbox = self._user_mock_emails.get(user_id)
+        if inbox is None:
+            inbox = copy.deepcopy(self._mock_emails)
+            self._user_mock_emails[user_id] = inbox
+        return inbox
 
     def _email_summary_from_message(self, msg: EmailMessage) -> EmailSummary:
         return EmailSummary(
@@ -398,56 +513,118 @@ class EmailService:
     # Read operations
     # ------------------------------------------------------------------
 
-    def fetch_unread(self, limit: int = 10, *, user_id: str | None = None) -> list[EmailSummary]:
+    def fetch_unread(
+        self,
+        limit: int = 10,
+        *,
+        user_id: str | None = None,
+        account_id: str | None = None,
+    ) -> list[EmailSummary]:
         """
-        Fetch unread email summaries.
-
-        If a backend is configured, delegates to ``backend.fetch_unread()``
-        and converts envelopes to ``EmailSummary`` objects.  Otherwise uses
-        the in-memory mock data.
+        Fetch unread email summaries for the requesting user.
 
         Args:
-            limit:   Maximum number of emails to return
-            user_id: When provided, only return emails from accounts owned by
-                     this user.  Emails without an ``account_id`` label are
-                     included unless ``user_email_accounts`` is populated.
+            limit:      Maximum number of emails to return.
+            user_id:    Requesting user (required).  Only that user's
+                        authorized accounts are consulted.
+            account_id: Optional explicit account, validated for ownership.
 
         Returns:
-            List of EmailSummary objects
+            List of EmailSummary objects.  Returns ``[]`` when the user has
+            no authorized/usable account (documented not-configured result).
+
+        Raises:
+            EmailIdentityError: On missing or invalid identity.
+            EmailAccountAccessError: When *account_id* is not available to
+                this user (unauthorized or nonexistent).
         """
+        validated = require_user_id(user_id)
+        resolver = self._get_resolver()
+        if account_id:
+            resolver.check_account_access(validated, account_id)
+
+        if self._backend is not None and self._backend_owner == validated:
+            if not self.connected:
+                if not self.connect():
+                    logger.warning("Email service not connected")
+                    return []
+            envelopes = self._backend.fetch_unread(limit=limit)  # type: ignore[attr-defined]
+            result = [self._envelope_to_summary(env) for env in envelopes]
+            self._publish_user_event(
+                "email.unread",
+                validated,
+                {"count": len(result), "user_id": validated, "account_id": account_id},
+                {
+                    "count": len(result),
+                    "user_id": validated,
+                    "account_id": account_id,
+                    "messages": [self._summary_dict(e) for e in result],
+                },
+            )
+            return result
+
+        if resolver.has_configured_accounts():
+            backend, definition = self._get_user_backend(validated, account_id)
+            if backend is None:
+                logger.warning("No usable email account for user %r", validated)
+                return []
+            resolved_id = getattr(definition, "id", None)
+            envelopes = backend.fetch_unread(limit=limit)  # type: ignore[attr-defined]
+            result = [self._envelope_to_summary(env) for env in envelopes]
+            self._publish_user_event(
+                "email.unread",
+                validated,
+                {"count": len(result), "user_id": validated, "account_id": resolved_id},
+                {
+                    "count": len(result),
+                    "user_id": validated,
+                    "account_id": resolved_id,
+                    "messages": [self._summary_dict(e) for e in result],
+                },
+            )
+            return result
+
+        # Stub mode: per-user isolated inbox.
         if not self.connected:
             if not self.connect():
                 logger.warning("Email service not connected")
                 return []
 
-        if self._backend is not None:
-            envelopes = self._backend.fetch_unread(limit=limit)  # type: ignore[attr-defined]
-            result = [self._envelope_to_summary(env) for env in envelopes]
-            self._publish(
-                "email.unread",
-                {"count": len(result), "messages": [self._summary_dict(e) for e in result]},
-            )
-            return result
-
-        unread = [email for email in self._mock_emails if "unread" in (email.labels or [])]
+        inbox = self._user_inbox(validated)
+        unread = [email for email in inbox if "unread" in (email.labels or [])]
         result = unread[: max(0, int(limit))]
-        self._publish(
+        self._publish_user_event(
             "email.unread",
-            {"count": len(result), "messages": [self._summary_dict(e) for e in result]},
+            validated,
+            {"count": len(result), "user_id": validated, "account_id": account_id},
+            {
+                "count": len(result),
+                "user_id": validated,
+                "account_id": account_id,
+                "messages": [self._summary_dict(e) for e in result],
+            },
         )
         return result
 
-    def triage_unread(self, limit: int = 10) -> list[dict[str, Any]]:
+    def triage_unread(
+        self,
+        limit: int = 10,
+        *,
+        user_id: str | None = None,
+        account_id: str | None = None,
+    ) -> list[dict[str, Any]]:
         """
         Legacy-friendly triage output used by older CLI command.
 
-        Returns list of dicts:
+        Requires a validated ``user_id``; triages only that user's unread
+        mail.  Returns list of dicts:
             {
               message_id, sender, subject, received_at (datetime),
               category, summary
             }
         """
-        unread = self.fetch_unread(limit=limit)
+        validated = require_user_id(user_id)
+        unread = self.fetch_unread(limit=limit, user_id=validated, account_id=account_id)
         triaged: list[dict[str, Any]] = []
 
         for email in unread:
@@ -464,10 +641,13 @@ class EmailService:
                 }
             )
 
-        self._publish(
+        self._publish_user_event(
             "email.triaged",
+            validated,
+            {"count": len(triaged), "user_id": validated},
             {
                 "count": len(triaged),
+                "user_id": validated,
                 "triaged": [
                     {"message_id": t["message_id"], "category": t["category"]} for t in triaged
                 ],
@@ -475,24 +655,40 @@ class EmailService:
         )
         return triaged
 
-    def mark_as_read(self, email_id: str) -> bool:
-        """Mark an email as read."""
+    def mark_as_read(self, email_id: str, *, user_id: str | None = None) -> bool:
+        """Mark an email as read within the requesting user's inbox."""
+        validated = require_user_id(user_id)
+
+        if self._backend is not None and self._backend_owner == validated:
+            if not self.connected:
+                logger.warning("Email service not connected")
+                return False
+            result = self._backend.mark_as_read(email_id)  # type: ignore[attr-defined]
+            if result:
+                self._publish("email.read", {"id": email_id, "user_id": validated})
+            return result  # type: ignore[no-any-return]
+
+        resolver = self._get_resolver()
+        if resolver.has_configured_accounts():
+            backend, _definition = self._get_user_backend(validated)
+            if backend is None:
+                logger.warning("No usable email account for user %r", validated)
+                return False
+            result = backend.mark_as_read(email_id)  # type: ignore[attr-defined]
+            if result:
+                self._publish("email.read", {"id": email_id, "user_id": validated})
+            return bool(result)
+
         if not self.connected:
             logger.warning("Email service not connected")
             return False
 
-        if self._backend is not None:
-            result = self._backend.mark_as_read(email_id)  # type: ignore[attr-defined]
-            if result:
-                self._publish("email.read", {"id": email_id})
-            return result  # type: ignore[no-any-return]
-
-        for email in self._mock_emails:
+        for email in self._user_inbox(validated):
             if email.id == email_id:
                 if email.labels and "unread" in email.labels:
                     email.labels.remove("unread")
-                logger.info("Marked email %s as read", email_id)
-                self._publish("email.read", {"id": email_id})
+                logger.info("Marked email %s as read for user %s", email_id, validated)
+                self._publish("email.read", {"id": email_id, "user_id": validated})
                 return True
 
         logger.warning("Email not found: %s", email_id)
@@ -512,33 +708,43 @@ class EmailService:
         account_id: str | None = None,
         user_id: str | None = None,
     ) -> dict[str, Any]:
-        """Send an email via the active backend.
-
-        If no backend is configured or send is not supported, logs the
-        intent and returns a stub result.
+        """Send an email through the requesting user's authorized account.
 
         Args:
             to:         Recipient address(es).
             subject:    Email subject line.
             body:       Plain-text body.
             from_addr:  Sender address override (defaults to account address).
-            account_id: Explicit account to route through (for multi-account).
-            user_id:    Requesting user — enforces account ownership when
-                        ``account_id`` is also supplied.
+            account_id: Explicit account to route through, validated for
+                        ownership.
+            user_id:    Requesting user (required).
 
         Returns:
             A dict with keys ``ok`` (bool), ``message_id`` (str|None), and
-            ``error`` (str|None).
+            ``error`` (str|None).  When real accounts are configured but none
+            is available to this user, ``ok`` is False (fail closed) — never
+            a fallback through another user's account.  In pure stub mode
+            (no accounts configured anywhere) the send is logged and reported
+            as ok.
+
+        Raises:
+            EmailIdentityError: On missing or invalid identity.
+            EmailAccountAccessError: When *account_id* is not available to
+                this user (unauthorized or nonexistent).
         """
-        if user_id is not None and account_id is not None:
-            self._check_account_access(user_id, account_id)
+        validated = require_user_id(user_id)
+        resolver = self._get_resolver()
+        if account_id:
+            resolver.check_account_access(validated, account_id)
+
         to_addrs = [to] if isinstance(to, str) else list(to)
 
-        send_backend = self._backend
+        send_backend = None
         resolved_account = None
-
-        if send_backend is None:
-            send_backend, resolved_account = self._resolve_backend_from_config(account_id)
+        if self._backend is not None and self._backend_owner == validated:
+            send_backend = self._backend
+        else:
+            send_backend, resolved_account = self._get_user_backend(validated, account_id)
 
         if send_backend is not None and hasattr(send_backend, "send"):
             sender = from_addr or getattr(resolved_account, "address", "") or ""
@@ -552,6 +758,16 @@ class EmailService:
                 "ok": result.ok,
                 "message_id": result.message_id,
                 "error": result.error,
+            }
+
+        if resolver.has_configured_accounts():
+            # Real accounts exist but none is available to this user (or its
+            # credentials are missing): fail closed, never fall back.
+            logger.warning("Email send refused: no authorized account for user %r", validated)
+            return {
+                "ok": False,
+                "message_id": None,
+                "error": "No email account is available for this user",
             }
 
         # Stub mode: log and return success.
@@ -627,15 +843,17 @@ class EmailService:
 
         return "general"
 
-    def summarize(self, email_id: str) -> str:
+    def summarize(self, email_id: str, *, user_id: str | None = None) -> str:
         """
         Get a simple summary of an email (stub implementation).
-        Currently returns a formatted snippet.
+        Currently returns a formatted snippet from the requesting user's inbox.
         """
+        validated = require_user_id(user_id)
+
         if not self.connected:
             return "Email service not connected"
 
-        for email in self._mock_emails:
+        for email in self._user_inbox(validated):
             if email.id == email_id:
                 return f"From: {email.from_addr}\nSubject: {email.subject}\n\n{email.snippet}"
 
@@ -660,7 +878,7 @@ class EmailService:
         }
 
     def get_all_emails(self) -> list[EmailSummary]:
-        """Get all emails (stub/testing)."""
+        """Get all emails from the loaded fixture (stub/testing)."""
         return self._mock_emails.copy()
 
     # ------------------------------------------------------------------
@@ -686,24 +904,31 @@ _email_service: EmailService | None = None
 
 
 def _create_configured_email_service() -> EmailService:
-    """Create an EmailService backed by real IMAP credentials.
+    """Create an EmailService wired to the per-user account resolver.
+
+    Backends are resolved lazily per validated user and authorized account;
+    no backend or credential is touched at construction time.
 
     Raises:
-        IntegrationNotConfiguredError: when no IMAP/SMTP credentials are found.
+        IntegrationNotConfiguredError: when no email accounts are configured.
     """
-    service = EmailService()
-    backend, _account = service._resolve_backend_from_config()
-    if backend is None:
+    resolver = EmailAccountResolver.load()
+    if not resolver.has_configured_accounts():
         raise IntegrationNotConfiguredError("Email: not configured")
-    service.set_backend(backend)
-    return service
+    # No resolver is injected: the service loads it lazily and refreshes it
+    # when the config file changes, so account revocations take effect in
+    # long-lived processes without a restart.
+    return EmailService()
 
 
 def get_email_service() -> EmailService:
     """Get the global email service instance.
 
+    The returned service enforces per-user account ownership internally;
+    every operation requires a validated ``user_id``.
+
     Raises:
-        IntegrationNotConfiguredError: when no IMAP/SMTP credentials are configured.
+        IntegrationNotConfiguredError: when no email accounts are configured.
     """
     global _email_service
     if _email_service is None:

--- a/rex/integrations.py
+++ b/rex/integrations.py
@@ -27,38 +27,60 @@ def setup_email_job() -> ScheduledJob:
 
     # Register email check callback
     def check_email(job: ScheduledJob) -> None:
-        """Check for unread emails and publish event."""
+        """Check unread email per configured owner and publish scoped events.
+
+        Each owner is processed in an isolated context; private email fields
+        are published only on the owner-scoped topic (see
+        ``rex.integrations._setup.setup_email_job``, the canonical copy).
+        """
         logger.info("Running scheduled email check")
-        email_service = get_email_service()
+        try:
+            from rex.email_accounts import EmailAccountResolver
+
+            owners = EmailAccountResolver.load().configured_user_ids()
+        except Exception as e:
+            logger.error(f"Error resolving email owners: {e}", exc_info=True)
+            return
+        if not owners:
+            logger.debug("No email account owners configured; skipping scheduled email check")
+            return
 
         try:
-            if not email_service.connected:
-                email_service.connect()
-
-            # Fetch unread emails
-            unread_emails = email_service.fetch_unread(limit=10)
-
-            if unread_emails:
-                # Categorize emails
-                for email in unread_emails:
-                    email.category = email_service.categorize(email)
-
-                # Publish event
-                event = Event(
-                    event_type="email.unread",
-                    payload={
-                        "count": len(unread_emails),
-                        "emails": [email.model_dump() for email in unread_emails],
-                    },
-                )
-                event_bus.publish(event)
-
-                logger.info(f"Published email.unread event with {len(unread_emails)} emails")
-            else:
-                logger.debug("No unread emails found")
-
+            email_service = get_email_service()
         except Exception as e:
-            logger.error(f"Error checking emails: {e}", exc_info=True)
+            logger.debug(f"Email service unavailable for scheduled check: {e}")
+            return
+
+        for owner in owners:
+            try:
+                unread_emails = email_service.fetch_unread(limit=10, user_id=owner)
+                if unread_emails:
+                    for email in unread_emails:
+                        email.category = email_service.categorize(email)
+                    event_bus.publish(
+                        Event(
+                            event_type=f"email.unread.user.{owner}",
+                            payload={
+                                "count": len(unread_emails),
+                                "user_id": owner,
+                                "emails": [email.model_dump() for email in unread_emails],
+                            },
+                        )
+                    )
+                    event_bus.publish(
+                        Event(
+                            event_type="email.unread",
+                            payload={"count": len(unread_emails), "user_id": owner},
+                        )
+                    )
+                    logger.info(
+                        f"Published email.unread event with {len(unread_emails)} emails "
+                        f"for user {owner}"
+                    )
+                else:
+                    logger.debug(f"No unread emails found for user {owner}")
+            except Exception as e:
+                logger.error(f"Error checking emails for user {owner}: {e}", exc_info=True)
 
     scheduler.register_callback("check_email", check_email)
 

--- a/rex/integrations/_setup.py
+++ b/rex/integrations/_setup.py
@@ -23,29 +23,61 @@ def setup_email_job() -> ScheduledJob:
     event_bus = get_event_bus()
 
     def check_email(job: ScheduledJob) -> None:
-        """Check for unread emails and publish event."""
+        """Check unread email per configured owner and publish scoped events.
+
+        Each owner is processed in an isolated context: one owner's failure
+        never falls through to another owner's account.  Private email
+        fields are published only on the owner-scoped topic; the shared
+        ``email.unread`` topic carries a safe envelope (count/user/account).
+        """
         logger.info("Running scheduled email check")
-        email_service = get_email_service()
         try:
-            if not email_service.connected:
-                email_service.connect()
-            unread_emails = email_service.fetch_unread(limit=10)
-            if unread_emails:
-                for email in unread_emails:
-                    email.category = email_service.categorize(email)
-                event = Event(
-                    event_type="email.unread",
-                    payload={
-                        "count": len(unread_emails),
-                        "emails": [email.model_dump() for email in unread_emails],
-                    },
-                )
-                event_bus.publish(event)
-                logger.info(f"Published email.unread event with {len(unread_emails)} emails")
-            else:
-                logger.debug("No unread emails found")
+            from rex.email_accounts import EmailAccountResolver
+
+            owners = EmailAccountResolver.load().configured_user_ids()
         except Exception as e:
-            logger.error(f"Error checking emails: {e}", exc_info=True)
+            logger.error(f"Error resolving email owners: {e}", exc_info=True)
+            return
+        if not owners:
+            logger.debug("No email account owners configured; skipping scheduled email check")
+            return
+
+        try:
+            email_service = get_email_service()
+        except Exception as e:
+            logger.debug(f"Email service unavailable for scheduled check: {e}")
+            return
+
+        for owner in owners:
+            try:
+                unread_emails = email_service.fetch_unread(limit=10, user_id=owner)
+                if unread_emails:
+                    for email in unread_emails:
+                        email.category = email_service.categorize(email)
+                    event_bus.publish(
+                        Event(
+                            event_type=f"email.unread.user.{owner}",
+                            payload={
+                                "count": len(unread_emails),
+                                "user_id": owner,
+                                "emails": [email.model_dump() for email in unread_emails],
+                            },
+                        )
+                    )
+                    event_bus.publish(
+                        Event(
+                            event_type="email.unread",
+                            payload={"count": len(unread_emails), "user_id": owner},
+                        )
+                    )
+                    logger.info(
+                        f"Published email.unread event with {len(unread_emails)} emails "
+                        f"for user {owner}"
+                    )
+                else:
+                    logger.debug(f"No unread emails found for user {owner}")
+            except Exception as e:
+                logger.error(f"Error checking emails for user {owner}: {e}", exc_info=True)
 
     scheduler.register_callback("check_email", check_email)
     job = scheduler.add_job(

--- a/rex/integrations/email_service.py
+++ b/rex/integrations/email_service.py
@@ -101,10 +101,17 @@ class EmailService:
     Args:
         email_provider: One of ``"none"``, ``"gmail"``, or ``"outlook"``.
             Defaults to ``"none"`` (stub mode).
+        access_token: OAuth access token for the live provider.  When set,
+            it is used instead of the legacy ``GMAIL_ACCESS_TOKEN``
+            environment variable.  Callers acting for a named user must
+            resolve and pass that user's own token (see
+            ``rex.email_accounts``); the environment fallback is
+            legacy-``default``-profile behaviour only.
     """
 
-    def __init__(self, email_provider: str = "none") -> None:
+    def __init__(self, email_provider: str = "none", access_token: str | None = None) -> None:
         self._provider = email_provider.lower()
+        self._access_token = access_token
         logger.debug("EmailService initialised with provider=%s", self._provider)
 
     # ------------------------------------------------------------------
@@ -204,7 +211,7 @@ class EmailService:
     # ------------------------------------------------------------------
 
     def _gmail_headers(self) -> dict[str, str]:
-        token = os.environ.get("GMAIL_ACCESS_TOKEN", "")
+        token = self._access_token or os.environ.get("GMAIL_ACCESS_TOKEN", "")
         return {"Authorization": f"Bearer {token}", "Accept": "application/json"}
 
     def _gmail_list_inbox(self, limit: int) -> list[EmailMessage]:
@@ -378,7 +385,80 @@ class EmailService:
 
 
 # ---------------------------------------------------------------------------
+# Per-user construction (issue #303)
+# ---------------------------------------------------------------------------
+
+
+def create_email_service_for_user(
+    user_id: str, raw_config: dict | None = None
+) -> tuple[EmailService | None, str]:
+    """Build the inbox EmailService for one validated user, failing closed.
+
+    Provider selection is per-user via ``rex.email_accounts``:
+
+    - A ``gmail``-backend account assigned to the user is served with that
+      user's own token (read from the environment variable named by the
+      entry's ``credentials_key``).
+    - The legacy global ``email.provider`` + ``GMAIL_ACCESS_TOKEN`` path is
+      available only to the explicit ``default`` profile.  Named users never
+      inherit the global credentials.
+
+    Returns:
+        ``(service_or_None, provider)`` where *provider* is one of
+        ``"none"``, ``"gmail"``, or ``"outlook"``.  ``service`` is ``None``
+        when the user has no usable provider (or the provider is
+        unsupported).
+
+    Raises:
+        PermissionError: On missing or invalid *user_id* (fail closed,
+            before any credential is read).
+    """
+    from rex.email_accounts import DEFAULT_PROFILE, EmailAccountResolver, require_user_id
+
+    validated = require_user_id(user_id)
+
+    if raw_config is None:
+        try:
+            from rex.config_manager import load_config
+
+            raw_config = load_config()
+        except Exception:
+            raw_config = {}
+
+    resolver = EmailAccountResolver.from_raw_config(raw_config)
+    entry = resolver.provider_entry_for_user(validated)
+    if entry is not None:
+        backend = getattr(entry, "backend", "")
+        if backend == "outlook":
+            return None, "outlook"
+        credentials_key = getattr(entry, "credentials_key", "") or ""
+        token = os.environ.get(credentials_key, "") if credentials_key else ""
+        if not token:
+            logger.warning(
+                "Gmail account %r for user %r has no token under credentials key %r",
+                getattr(entry, "account_id", ""),
+                validated,
+                credentials_key,
+            )
+            return None, "none"
+        return EmailService(email_provider="gmail", access_token=token), "gmail"
+
+    if validated == DEFAULT_PROFILE:
+        email_section = raw_config.get("email")
+        provider = ""
+        if isinstance(email_section, dict):
+            provider = str(email_section.get("provider") or "none").lower()
+        if provider == "outlook":
+            return None, "outlook"
+        if provider == "gmail":
+            # Legacy default-profile behaviour: global env token.
+            return EmailService(email_provider="gmail"), "gmail"
+
+    return None, "none"
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
-__all__ = ["EmailService"]
+__all__ = ["EmailService", "create_email_service_for_user"]

--- a/rex/local_tool_executor.py
+++ b/rex/local_tool_executor.py
@@ -121,17 +121,29 @@ def _handle_web_search(args: dict[str, Any]) -> str:
 
 
 def _handle_send_email(args: dict[str, Any]) -> str:
-    """Send an email via EmailService.  Accepts {to, subject, body}."""
+    """Send an email via EmailService.  Accepts {to, subject, body, _user_id}.
+
+    Requires a validated requesting user (``_user_id`` or ``user_id`` in
+    *args*); fails closed before any account or credential resolution.
+    """
     to: str = str(args.get("to") or "").strip()
     subject: str = str(args.get("subject") or "(no subject)").strip()
     body: str = str(args.get("body") or "").strip()
+    user_id = args.get("_user_id") or args.get("user_id")
 
     if not to:
         return "[send_email error: 'to' address is required]"
 
+    from rex.email_accounts import require_user_id
+
+    try:
+        validated_user = require_user_id(user_id)
+    except PermissionError:
+        return "[send_email error: a valid user identity is required]"
+
     try:
         svc = EmailService()
-        result = svc.send(to=to, subject=subject, body=body)
+        result = svc.send(to=to, subject=subject, body=body, user_id=validated_user)
     except Exception as exc:
         logger.warning("send_email failed: %s", exc)
         return f"[send_email error: {exc}]"

--- a/rex/notification.py
+++ b/rex/notification.py
@@ -411,25 +411,38 @@ class Notifier:
         """Send notification via email.
 
         Always dispatches through ``EmailService.send()`` so the real SMTP
-        backend is used when configured.  When no recipient is provided in
-        notification metadata the call is skipped with a warning.
+        backend is used when configured.  When no recipient or owner is
+        provided in notification metadata the call is skipped with a warning
+        — delivery never falls back to another user's account.
 
         On send failure the error is logged and re-raised so the caller can
         record the notification as failed rather than silently dropping it.
 
         Metadata keys:
-            ``to_email``        — recipient address (required for delivery).
-            ``email_account_id`` — route through a specific account (optional).
+            ``to_email``         — recipient address (required for delivery).
+            ``email_user_id``    — owning user whose account sends the email
+                                   (required for delivery; fail closed).
+            ``email_account_id`` — route through a specific account owned by
+                                   that user (optional).
         """
         try:
             service = get_email_service()
 
             to_email = notification.metadata.get("to_email")
             account_id = notification.metadata.get("email_account_id")
+            user_id = notification.metadata.get("email_user_id")
 
             if not to_email:
                 logger.warning(
                     "[EMAIL] No recipient address configured for notification %r; skipping",
+                    notification.title,
+                )
+                return
+
+            if not user_id:
+                logger.warning(
+                    "[EMAIL] No owning user (email_user_id) for notification %r; "
+                    "skipping (email delivery requires an explicit owner)",
                     notification.title,
                 )
                 return
@@ -439,6 +452,7 @@ class Notifier:
                 subject=notification.title,
                 body=notification.body,
                 account_id=account_id,
+                user_id=user_id,
             )
             if result.get("ok"):
                 logger.info(
@@ -547,9 +561,10 @@ class Notifier:
             if not queue.notifications:
                 continue
 
-            # Create digest summary — propagate to_email and email_account_id
-            # from the first queued notification that carries them so the
-            # digest delivery goes through EmailService correctly.
+            # Create digest summary — propagate to_email, email_account_id,
+            # and the owning email_user_id from the first queued notification
+            # that carries a recipient so the digest delivery goes through
+            # EmailService as the correct owner.
             summary = self._create_digest_summary(queue.notifications)
             digest_meta: dict = {}
             for queued in queue.notifications:
@@ -557,6 +572,8 @@ class Notifier:
                     digest_meta["to_email"] = queued.metadata["to_email"]
                     if queued.metadata.get("email_account_id"):
                         digest_meta["email_account_id"] = queued.metadata["email_account_id"]
+                    if queued.metadata.get("email_user_id"):
+                        digest_meta["email_user_id"] = queued.metadata["email_user_id"]
                     break
             digest_notification = NotificationRequest(
                 priority="normal",
@@ -618,8 +635,13 @@ class Notifier:
 
             bus = EventBridge()
 
-            # Subscribe to email events
-            bus.subscribe("email.unread", self._on_email_unread)
+            # Subscribe to user-scoped email events.  The shared
+            # "email.unread" topic carries only a safe envelope (no private
+            # fields); full payloads are published per owner on
+            # "email.unread.user.<user_id>", so a wildcard subscription with
+            # a prefix filter is used here (this is a trusted system
+            # component, not a user surface).
+            bus.subscribe("*", self._on_any_event)
 
             # Subscribe to calendar events
             bus.subscribe("calendar.update", self._on_calendar_update)
@@ -628,11 +650,18 @@ class Notifier:
         except Exception as e:
             logger.warning(f"Failed to subscribe to events: {e}")
 
+    def _on_any_event(self, event) -> None:
+        """Route user-scoped email events to the email handler."""
+        event_type = getattr(event, "event_type", "")
+        if isinstance(event_type, str) and event_type.startswith("email.unread.user."):
+            self._on_email_unread(event)
+
     def _on_email_unread(self, event) -> None:
-        """Handle email.unread events."""
+        """Handle user-scoped email.unread events."""
         try:
             payload = event.payload if hasattr(event, "payload") else event
-            emails = payload.get("emails", [])
+            emails = payload.get("emails", []) or payload.get("messages", [])
+            user_id = payload.get("user_id")
 
             # Check for high-importance emails
             for email in emails:
@@ -644,7 +673,7 @@ class Notifier:
                         body=f"From: {email.get('from_addr', 'Unknown')}\n"
                         f"Subject: {email.get('subject', 'No subject')}",
                         channel_preferences=["sms", "email", "dashboard"],
-                        metadata={"email_id": email.get("id")},
+                        metadata={"email_id": email.get("id"), "user_id": user_id},
                     )
                     self.send(notification)
         except Exception as e:

--- a/rex/openclaw/tools/email_tool.py
+++ b/rex/openclaw/tools/email_tool.py
@@ -45,34 +45,61 @@ def send_email(
     subject: str = "",
     body: str = "",
     context: dict[str, Any] | None = None,
+    account_id: str | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """Send an email via Rex's EmailService.
+    """Send an email via Rex's EmailService as the dispatching user.
 
-    Delegates to :func:`rex.email_service.get_email_service().send`.  In
-    stub mode (no backend configured) the email is logged and a success
-    response is returned without actually sending.
+    Delegates to :func:`rex.email_service.get_email_service().send`.  The
+    dispatcher-injected ``_user_id`` is required and validated **before** any
+    backend or credential resolution; missing or invalid identity fails
+    closed.  An optional ``account_id`` routes through a specific account
+    only after ownership validation — a named user can never fall back to
+    the global default or first configured account.
 
     .. note::
         This tool is policy-gated (MEDIUM risk).  Callers are responsible
         for obtaining policy approval before invoking this function.
 
     Args:
-        to:      Recipient address or list of addresses.
-        subject: Email subject line.
-        body:    Plain-text message body.
-        context: Optional ambient context dict (unused; reserved for future
-            timezone / locale injection).
-        **kwargs: Absorbs dispatcher-injected keys such as ``transcript``
+        to:         Recipient address or list of addresses.
+        subject:    Email subject line.
+        body:       Plain-text message body.
+        context:    Optional ambient context dict (unused; reserved for
+            future timezone / locale injection).
+        account_id: Optional explicit account to send from (must belong to
+            the requesting user).
+        **kwargs:   Absorbs dispatcher-injected keys such as ``transcript``
             and ``_user_id`` without raising TypeError.
 
     Returns:
         A dict with keys ``ok`` (bool), ``message_id`` (str|None), and
         ``error`` (str|None).
     """
-    user_id: str | None = kwargs.get("_user_id")
+    from rex.email_accounts import require_user_id
+
+    try:
+        user_id = require_user_id(kwargs.get("_user_id"))
+    except PermissionError as exc:
+        logger.warning("send_email tool refused: %s", exc)
+        return {
+            "ok": False,
+            "message_id": None,
+            "error": "send_email requires a valid user identity",
+        }
+
     service = _get_email_service()
-    send_kwargs: dict[str, Any] = {"to": to, "subject": subject, "body": body}
-    if user_id is not None:
-        send_kwargs["user_id"] = user_id
-    return service.send(**send_kwargs)
+    # Audit metadata: requesting user and selected account only — never
+    # credentials or message bodies.
+    logger.info("send_email tool: user=%s account=%s", user_id, account_id or "(default)")
+    try:
+        return service.send(
+            to=to,
+            subject=subject,
+            body=body,
+            account_id=account_id,
+            user_id=user_id,
+        )
+    except PermissionError as exc:
+        logger.warning("send_email tool refused for user=%s: %s", user_id, exc)
+        return {"ok": False, "message_id": None, "error": str(exc)}

--- a/rex/routes/integrations.py
+++ b/rex/routes/integrations.py
@@ -171,19 +171,49 @@ def create_blueprint() -> Blueprint:
 
     @bp.route("/api/email/inbox", methods=["GET"])
     def _email_inbox() -> Any:
-        """Return inbox messages from the configured email provider."""
+        """Return inbox messages for the resolved requesting user only.
+
+        Identity comes from an explicit ``?user=`` query parameter or the
+        standard identity chain; without a valid user the request fails
+        closed (no global-credential fallback for named users).
+        """
         from flask import jsonify, request
 
-        from rex.config import load_config
-        from rex.integrations.email_service import EmailService
+        from rex.identity import resolve_active_user
+        from rex.integrations.email_service import create_email_service_for_user
+
+        no_user_error = (
+            "No active user for email. Set one with 'rex identify --user <id>' "
+            "or pass an explicit ?user= parameter."
+        )
 
         try:
-            cfg = load_config()
-        except Exception:
-            return jsonify({"ok": True, "messages": [], "configured": False}), 200
+            from rex.config_manager import load_config as _load_raw_config
 
-        provider = getattr(cfg, "email_provider", "none") or "none"
-        if str(provider).lower() == "outlook":
+            raw_config = _load_raw_config()
+        except Exception:
+            raw_config = {}
+
+        explicit = str(request.args.get("user") or "").strip() or None
+        try:
+            user_id = resolve_active_user(explicit, config=raw_config)
+        except ValueError:
+            user_id = None
+        if not user_id:
+            return (
+                jsonify({"ok": False, "messages": [], "configured": False, "error": no_user_error}),
+                403,
+            )
+
+        try:
+            svc, provider = create_email_service_for_user(user_id, raw_config)
+        except PermissionError:
+            return (
+                jsonify({"ok": False, "messages": [], "configured": False, "error": no_user_error}),
+                403,
+            )
+
+        if provider == "outlook":
             return (
                 jsonify(
                     {
@@ -200,7 +230,8 @@ def create_blueprint() -> Blueprint:
                 501,
             )
 
-        svc = EmailService(email_provider=provider)
+        if svc is None:
+            return jsonify({"ok": True, "messages": [], "configured": False}), 200
 
         try:
             limit = int(request.args.get("limit", 50))
@@ -208,7 +239,7 @@ def create_blueprint() -> Blueprint:
             limit = 50
 
         messages = svc.list_inbox(limit=limit)
-        configured = provider != "none"
+        configured = True
 
         def _msg_to_dict(m: Any) -> dict:
             return {

--- a/rex/services.py
+++ b/rex/services.py
@@ -65,7 +65,7 @@ def initialize_services(
     )
 
     # Register scheduler handlers
-    scheduler.register_handler("email_triage", lambda job: email.triage_unread())  # type: ignore[arg-type]
+    scheduler.register_handler("email_triage", lambda job: _run_email_triage(email))
     scheduler.register_handler("calendar_sync", lambda job: calendar.refresh_upcoming())  # type: ignore[arg-type]
     scheduler.register_handler("flush_digests", lambda job: notifier.flush_digests())  # type: ignore[arg-type]
     scheduler.register_handler(
@@ -93,6 +93,42 @@ def reset_services() -> None:
     """Reset cached services (primarily for tests)."""
     global _SERVICES
     _SERVICES = None
+
+
+def _email_triage_owners() -> list[str]:
+    """Return the owners scheduled email triage runs for.
+
+    Owners are users with explicit email account assignments (plus the
+    ``default`` profile for legacy unassigned accounts).  When nothing is
+    configured, the legacy job runs only as the distinct ``default`` profile
+    — stub-only, never another user's real mail.
+    """
+    try:
+        from rex.email_accounts import DEFAULT_PROFILE, EmailAccountResolver
+
+        owners = EmailAccountResolver.load().configured_user_ids()
+        return owners or [DEFAULT_PROFILE]
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).warning("Failed to resolve email triage owners: %s", exc)
+        return []
+
+
+def _run_email_triage(email: EmailService) -> None:
+    """Run scheduled email triage per owner, in isolated owner contexts.
+
+    One owner's failure is logged and never falls through to (or exposes)
+    another owner's account.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    for owner in _email_triage_owners():
+        try:
+            email.triage_unread(user_id=owner)
+        except Exception as exc:
+            logger.warning("Scheduled email triage failed for user %r: %s", owner, exc)
 
 
 def _check_escalations(notifier: Notifier, escalation_manager: EscalationManager) -> None:

--- a/tests/test_cli_email_accounts.py
+++ b/tests/test_cli_email_accounts.py
@@ -1,15 +1,47 @@
-"""Tests for email account management CLI commands (BL-011 gap fill).
+"""Tests for email account management CLI commands.
 
-Covers: rex email accounts list, set-active, send, test-connection.
+Covers: rex email accounts list, set-active, send, test-connection, unread —
+all user-scoped (issue #303).  Every subcommand resolves one validated user,
+fails closed without identity, and reveals only that user's accounts.
 """
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from rex.cli import cmd_email
+from rex.email_accounts import EmailAccountResolver
+from rex.email_backends.account_config import EmailConfig
+
+
+def _make_resolver(accounts: list[dict], users: dict, defaults: dict | None = None):
+    """Build a real EmailAccountResolver from plain dicts."""
+    from rex.config import _parse_user_email_accounts
+
+    email_config = EmailConfig.model_validate({"accounts": accounts})
+    user_accounts = _parse_user_email_accounts(users, accounts)
+    return EmailAccountResolver(email_config, user_accounts, defaults or {})
+
+
+def _account(account_id: str, stem: str) -> dict:
+    return {
+        "id": account_id,
+        "label": f"{account_id} label",
+        "address": f"{account_id}@{stem}.example.com",
+        "imap": {"host": f"imap.{stem}.example.com"},
+        "smtp": {"host": f"smtp.{stem}.example.com"},
+        "credential_ref": f"email:{account_id}",
+    }
+
+
+TWO_USER_ACCOUNTS = [_account("alice-work", "alice"), _account("bob-personal", "bob")]
+TWO_USER_USERS = {
+    "alice": {"email_accounts": [{"account_id": "alice-work"}]},
+    "bob": {"email_accounts": [{"account_id": "bob-personal"}]},
+}
 
 
 @pytest.fixture
@@ -23,119 +55,196 @@ def mock_email_service():
 
 
 @pytest.fixture
-def _no_email_config():
-    """Patch _load_email_config_safe to return None (no config)."""
-    with patch("rex.cli._load_email_config_safe", return_value=None):
+def _no_email_resolver():
+    """Patch _load_email_resolver_safe to return None (no config)."""
+    with patch("rex.cli._load_email_resolver_safe", return_value=None):
         yield
 
 
 @pytest.fixture
-def _stub_email_config():
-    """Patch _load_email_config_safe to return a mock config with accounts."""
-    config = MagicMock()
-    acct = MagicMock()
-    acct.id = "personal"
-    acct.label = "Personal"
-    acct.address = "user@example.com"
-    acct.imap.host = "imap.example.com"
-    acct.imap.port = 993
-    acct.imap.ssl = True
-    acct.smtp.host = "smtp.example.com"
-    acct.smtp.port = 587
-    acct.smtp.starttls = True
-    acct.credential_ref = "email:personal"
-    config.accounts = [acct]
-    config.default_account_id = "personal"
-    config.list_account_ids.return_value = ["personal"]
-    config.get_account.return_value = acct
-    with patch("rex.cli._load_email_config_safe", return_value=config):
-        yield config
+def _two_user_resolver():
+    """Patch _load_email_resolver_safe with a two-user resolver."""
+    resolver = _make_resolver(TWO_USER_ACCOUNTS, TWO_USER_USERS)
+    with patch("rex.cli._load_email_resolver_safe", return_value=resolver):
+        yield resolver
 
 
-class TestEmailAccountsList:
-    def test_no_accounts_configured(self, mock_email_service, _no_email_config, capsys):
-        args = MagicMock(email_command="accounts", accounts_command="list", user=None)
-        result = cmd_email(args)
-        assert result == 0
+def _args(**kwargs) -> MagicMock:
+    kwargs.setdefault("user", "alice")
+    return MagicMock(**kwargs)
+
+
+class TestEmailRequiresUser:
+    def test_missing_identity_fails_closed(self, mock_email_service, capsys):
+        with patch("rex.cli._resolve_cli_user", return_value=None):
+            args = _args(email_command="unread", user=None)
+            result = cmd_email(args)
+        assert result == 1
         out = capsys.readouterr().out
-        assert "No email accounts configured" in out
+        assert "No active user for email" in out
+        assert "rex identify" in out
 
-    def test_list_with_accounts(self, mock_email_service, _stub_email_config, capsys):
-        args = MagicMock(email_command="accounts", accounts_command="list", user=None)
-        result = cmd_email(args)
-        assert result == 0
-        out = capsys.readouterr().out
-        assert "personal" in out
-        assert "user@example.com" in out
-
-
-class TestEmailAccountsSetActive:
-    def test_set_active_no_config(self, mock_email_service, _no_email_config, capsys):
-        args = MagicMock(
-            email_command="accounts",
-            accounts_command="set-active",
-            account_id="work",
-            user=None,
-        )
+    def test_invalid_identity_fails_closed(self, mock_email_service, capsys):
+        args = _args(email_command="unread", user="../evil")
         result = cmd_email(args)
         assert result == 1
         out = capsys.readouterr().out
         assert "Error" in out
 
-    def test_set_active_invalid_id(self, mock_email_service, _stub_email_config, capsys):
-        args = MagicMock(
+
+class TestEmailAccountsList:
+    def test_no_accounts_configured(self, mock_email_service, _no_email_resolver, capsys):
+        args = _args(email_command="accounts", accounts_command="list")
+        result = cmd_email(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No email accounts configured for user 'alice'" in out
+
+    def test_list_shows_only_own_accounts(self, mock_email_service, _two_user_resolver, capsys):
+        args = _args(email_command="accounts", accounts_command="list", user="alice")
+        result = cmd_email(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "alice-work" in out
+        assert "alice-work@alice.example.com" in out
+        # Bob's account, address, and label are never revealed to Alice.
+        assert "bob-personal" not in out
+        assert "bob.example.com" not in out
+        assert "bob-personal label" not in out
+
+    def test_user_with_no_assignments_sees_nothing(
+        self, mock_email_service, _two_user_resolver, capsys
+    ):
+        args = _args(email_command="accounts", accounts_command="list", user="charlie")
+        result = cmd_email(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No email accounts configured for user 'charlie'" in out
+        assert "alice-work" not in out
+        assert "bob-personal" not in out
+
+
+class TestEmailAccountsSetActive:
+    def test_set_active_no_config(self, mock_email_service, _no_email_resolver, capsys):
+        args = _args(email_command="accounts", accounts_command="set-active", account_id="work")
+        result = cmd_email(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "Error" in out
+
+    def test_set_active_foreign_account_rejected(
+        self, mock_email_service, _two_user_resolver, capsys
+    ):
+        args = _args(
             email_command="accounts",
             accounts_command="set-active",
-            account_id="nonexistent",
-            user=None,
+            account_id="bob-personal",
+            user="alice",
         )
         result = cmd_email(args)
         assert result == 1
         out = capsys.readouterr().out
-        assert "not found" in out
+        assert "not available for user 'alice'" in out
+        # Only Alice's own accounts may be suggested.
+        assert "bob-personal" not in out.replace("Account 'bob-personal'", "")
+
+    def test_set_active_nonexistent_matches_foreign(
+        self, mock_email_service, _two_user_resolver, capsys
+    ):
+        args = _args(
+            email_command="accounts",
+            accounts_command="set-active",
+            account_id="no-such",
+            user="alice",
+        )
+        result = cmd_email(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "not available for user 'alice'" in out
+
+    def test_set_active_updates_only_selected_users_default(
+        self, mock_email_service, _two_user_resolver, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "rex_config.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps({"users": {"bob": {"default_email_account_id": "bob-personal"}}}),
+            encoding="utf-8",
+        )
+
+        args = _args(
+            email_command="accounts",
+            accounts_command="set-active",
+            account_id="alice-work",
+            user="alice",
+        )
+        result = cmd_email(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "for user 'alice'" in out
+
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert written["users"]["alice"]["default_email_account_id"] == "alice-work"
+        # Bob's default and the legacy global default are untouched.
+        assert written["users"]["bob"]["default_email_account_id"] == "bob-personal"
+        assert "email" not in written or "default_account_id" not in written.get("email", {})
 
 
 class TestEmailSend:
     def test_send_missing_args(self, mock_email_service, capsys):
-        args = MagicMock(
-            email_command="send",
-            to=None,
-            subject=None,
-            body=None,
-            account_id=None,
-            user=None,
-        )
+        args = _args(email_command="send", to=None, subject=None, body=None, account_id=None)
         result = cmd_email(args)
         assert result == 1
         out = capsys.readouterr().out
         assert "required" in out
 
-    def test_send_success(self, mock_email_service, capsys):
+    def test_send_passes_resolved_user(self, mock_email_service, capsys):
         mock_email_service.connected = True
         mock_email_service.send.return_value = {"ok": True, "message_id": "test-123"}
-        args = MagicMock(
+        args = _args(
             email_command="send",
             to="recipient@example.com",
             subject="Test",
             body="Hello",
             account_id=None,
-            user=None,
+            user="alice",
         )
         result = cmd_email(args)
         assert result == 0
         out = capsys.readouterr().out
         assert "sent successfully" in out
+        kwargs = mock_email_service.send.call_args.kwargs
+        assert kwargs["user_id"] == "alice"
+        assert kwargs["account_id"] is None
+
+    def test_send_foreign_account_generic_error(self, mock_email_service, capsys):
+        mock_email_service.connected = True
+        mock_email_service.send.side_effect = PermissionError(
+            "Email account 'bob-personal' is not available for user 'alice'"
+        )
+        args = _args(
+            email_command="send",
+            to="x@example.com",
+            subject="s",
+            body="b",
+            account_id="bob-personal",
+            user="alice",
+        )
+        result = cmd_email(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "not available" in out
 
     def test_send_connection_failure(self, mock_email_service, capsys):
         mock_email_service.connected = False
         mock_email_service.connect.return_value = False
-        args = MagicMock(
+        args = _args(
             email_command="send",
             to="recipient@example.com",
             subject="Test",
             body="Hello",
             account_id=None,
-            user=None,
         )
         result = cmd_email(args)
         assert result == 1
@@ -143,14 +252,76 @@ class TestEmailSend:
         assert "Failed to connect" in out
 
 
+class TestEmailUnread:
+    def test_unread_passes_resolved_user(self, mock_email_service, capsys):
+        mock_email_service.connected = True
+        mock_email_service.fetch_unread.return_value = []
+        args = _args(email_command="unread", limit=5, verbose=False, user="alice")
+        result = cmd_email(args)
+        assert result == 0
+        kwargs = mock_email_service.fetch_unread.call_args.kwargs
+        assert kwargs["user_id"] == "alice"
+
+    def test_unread_connects_as_resolved_user(self, mock_email_service, capsys):
+        mock_email_service.connected = False
+        mock_email_service.connect.return_value = True
+        mock_email_service.fetch_unread.return_value = []
+        args = _args(email_command="unread", limit=5, verbose=False, user="alice")
+        result = cmd_email(args)
+        assert result == 0
+        mock_email_service.connect.assert_called_once_with("alice")
+
+
 class TestEmailTestConnection:
-    def test_no_accounts_stub(self, mock_email_service, _no_email_config, capsys):
-        args = MagicMock(
-            email_command="test-connection",
-            account_id=None,
-            user=None,
-        )
+    def test_no_accounts_stub(self, mock_email_service, _no_email_resolver, capsys):
+        args = _args(email_command="test-connection", account_id=None)
         result = cmd_email(args)
         assert result == 0
         out = capsys.readouterr().out
         assert "stub" in out.lower()
+
+    def test_foreign_account_not_revealed(self, mock_email_service, _two_user_resolver, capsys):
+        args = _args(email_command="test-connection", account_id="bob-personal", user="alice")
+        result = cmd_email(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "Available for user 'alice': alice-work" in out
+        # Bob's address/host details are never revealed.
+        assert "bob.example.com" not in out
+
+    def test_user_without_accounts_gets_generic_result(
+        self, mock_email_service, _two_user_resolver, capsys
+    ):
+        args = _args(email_command="test-connection", account_id=None, user="charlie")
+        result = cmd_email(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "No email accounts configured for user 'charlie'" in out
+        assert "alice-work" not in out
+
+    def test_own_account_is_tested_with_own_credential_ref(
+        self, mock_email_service, _two_user_resolver, capsys
+    ):
+        lookups: list[str] = []
+
+        class FakeCM:
+            def get_token(self, ref):
+                lookups.append(ref)
+                return "user:pass"
+
+        fake_backend = MagicMock()
+        fake_backend.connect.return_value = True
+
+        with patch("rex.credentials.get_credential_manager", return_value=FakeCM()):
+            with patch(
+                "rex.email_backends.account_router.build_backend_for_account",
+                return_value=fake_backend,
+            ) as build:
+                args = _args(email_command="test-connection", account_id=None, user="alice")
+                result = cmd_email(args)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "alice-work" in out
+        assert lookups == ["email:alice-work"]
+        assert build.call_args.args[0].id == "alice-work"

--- a/tests/test_cli_scheduler.py
+++ b/tests/test_cli_scheduler.py
@@ -62,7 +62,7 @@ def test_cli_email_unread(capsys, monkeypatch):
 
     reset_services()
     monkeypatch.setattr("rex.cli.get_email_service", lambda: EmailService())
-    args = Namespace(email_command="unread")
+    args = Namespace(email_command="unread", user="default")
     assert cmd_email(args) == 0
     output = capsys.readouterr().out
     assert "Unread Email Summary" in output

--- a/tests/test_cli_scheduler_email_calendar.py
+++ b/tests/test_cli_scheduler_email_calendar.py
@@ -166,7 +166,7 @@ class TestEmailCLI:
         mock_email_service.connect.return_value = True
         mock_email_service.fetch_unread.return_value = []
 
-        args = MagicMock(email_command="unread", limit=10, verbose=False, user=None)
+        args = MagicMock(email_command="unread", limit=10, verbose=False, user="default")
         result = cmd_email(args)
 
         assert result == 0
@@ -190,7 +190,7 @@ class TestEmailCLI:
         mock_email_service.fetch_unread.return_value = [email1]
         mock_email_service.categorize.return_value = "important"
 
-        args = MagicMock(email_command="unread", limit=10, verbose=False, user=None)
+        args = MagicMock(email_command="unread", limit=10, verbose=False, user="default")
         result = cmd_email(args)
 
         assert result == 0
@@ -217,7 +217,7 @@ class TestEmailCLI:
         mock_email_service.fetch_unread.return_value = [email]
         mock_email_service.categorize.return_value = "general"
 
-        args = MagicMock(email_command="unread", limit=10, verbose=True, user=None)
+        args = MagicMock(email_command="unread", limit=10, verbose=True, user="default")
         result = cmd_email(args)
 
         assert result == 0
@@ -229,7 +229,7 @@ class TestEmailCLI:
         """Test email command when connection fails."""
         mock_email_service.connect.return_value = False
 
-        args = MagicMock(email_command="unread", limit=10, verbose=False, user=None)
+        args = MagicMock(email_command="unread", limit=10, verbose=False, user="default")
         result = cmd_email(args)
 
         assert result == 1
@@ -241,14 +241,14 @@ class TestEmailCLI:
         mock_email_service.connect.return_value = True
         mock_email_service.fetch_unread.return_value = []
 
-        args = MagicMock(email_command="unread", limit=5, verbose=False, user=None)
+        args = MagicMock(email_command="unread", limit=5, verbose=False, user="default")
         cmd_email(args)
 
-        mock_email_service.fetch_unread.assert_called_once_with(limit=5)
+        mock_email_service.fetch_unread.assert_called_once_with(limit=5, user_id="default")
 
     def test_email_unknown_command(self, mock_email_service, capsys):
         """Test unknown email subcommand."""
-        args = MagicMock(email_command="unknown", user=None)
+        args = MagicMock(email_command="unknown", user="default")
         result = cmd_email(args)
 
         assert result == 1

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -120,7 +120,7 @@ def test_email_triage_publishes_events() -> None:
     )
 
     service = EmailService(bus, mock_messages=[message])  # type: ignore[call-arg]
-    triaged = service.triage_unread()  # type: ignore[attr-defined]
+    triaged = service.triage_unread(user_id="default")  # type: ignore[attr-defined]
 
     assert triaged[0]["category"] == "finance"
     assert events, "Expected at least one published event"
@@ -244,7 +244,7 @@ def test_connect_loads_mock_data(email_service: EmailService) -> None:
 )
 def test_fetch_unread(email_service: EmailService) -> None:
     email_service.connect()  # type: ignore[attr-defined]
-    unread = email_service.fetch_unread()  # type: ignore[attr-defined]
+    unread = email_service.fetch_unread(user_id="default")  # type: ignore[attr-defined]
 
     assert len(unread) == 2
     assert all("unread" in email.labels for email in unread)
@@ -256,7 +256,7 @@ def test_fetch_unread(email_service: EmailService) -> None:
 )
 def test_fetch_unread_with_limit(email_service: EmailService) -> None:
     email_service.connect()  # type: ignore[attr-defined]
-    unread = email_service.fetch_unread(limit=1)  # type: ignore[attr-defined]
+    unread = email_service.fetch_unread(limit=1, user_id="default")  # type: ignore[attr-defined]
     assert len(unread) == 1
 
 
@@ -266,7 +266,7 @@ def test_fetch_unread_with_limit(email_service: EmailService) -> None:
 )
 def test_fetch_unread_not_connected() -> None:
     service = EmailService(mock_data_file=Path("/nonexistent"))  # type: ignore[call-arg]
-    unread = service.fetch_unread()  # type: ignore[attr-defined]
+    unread = service.fetch_unread(user_id="default")  # type: ignore[attr-defined]
     assert unread == []
 
 
@@ -276,13 +276,13 @@ def test_fetch_unread_not_connected() -> None:
 )
 def test_mark_as_read(email_service: EmailService) -> None:
     email_service.connect()  # type: ignore[attr-defined]
-    unread = email_service.fetch_unread()  # type: ignore[attr-defined]
+    unread = email_service.fetch_unread(user_id="default")  # type: ignore[attr-defined]
     email_id = unread[0].id
 
-    result = email_service.mark_as_read(email_id)  # type: ignore[attr-defined]
+    result = email_service.mark_as_read(email_id, user_id="default")  # type: ignore[attr-defined]
     assert result is True
 
-    unread_after = email_service.fetch_unread()  # type: ignore[attr-defined]
+    unread_after = email_service.fetch_unread(user_id="default")  # type: ignore[attr-defined]
     assert len(unread_after) == len(unread) - 1
     assert email_id not in [e.id for e in unread_after]
 
@@ -293,7 +293,7 @@ def test_mark_as_read(email_service: EmailService) -> None:
 )
 def test_mark_as_read_nonexistent(email_service: EmailService) -> None:
     email_service.connect()  # type: ignore[attr-defined]
-    assert email_service.mark_as_read("nonexistent-id") is False  # type: ignore[attr-defined]
+    assert email_service.mark_as_read("nonexistent-id", user_id="default") is False  # type: ignore[attr-defined]
 
 
 @pytest.mark.skipif(
@@ -302,7 +302,7 @@ def test_mark_as_read_nonexistent(email_service: EmailService) -> None:
 )
 def test_mark_as_read_not_connected() -> None:
     service = EmailService(mock_data_file=Path("/nonexistent"))  # type: ignore[call-arg]
-    assert service.mark_as_read("email-1") is False  # type: ignore[attr-defined]
+    assert service.mark_as_read("email-1", user_id="default") is False  # type: ignore[attr-defined]
 
 
 @pytest.mark.skipif(
@@ -420,7 +420,7 @@ def test_categorize_general(email_service: EmailService) -> None:
 )
 def test_summarize(email_service: EmailService) -> None:
     email_service.connect()  # type: ignore[attr-defined]
-    summary = email_service.summarize("email-1")  # type: ignore[attr-defined]
+    summary = email_service.summarize("email-1", user_id="default")  # type: ignore[attr-defined]
 
     assert "boss@company.com" in summary
     assert "URGENT: Project deadline" in summary
@@ -433,7 +433,7 @@ def test_summarize(email_service: EmailService) -> None:
 )
 def test_summarize_nonexistent(email_service: EmailService) -> None:
     email_service.connect()  # type: ignore[attr-defined]
-    summary = email_service.summarize("nonexistent")  # type: ignore[attr-defined]
+    summary = email_service.summarize("nonexistent", user_id="default")  # type: ignore[attr-defined]
     assert "not found" in summary.lower()
 
 
@@ -443,7 +443,7 @@ def test_summarize_nonexistent(email_service: EmailService) -> None:
 )
 def test_summarize_not_connected() -> None:
     service = EmailService(mock_data_file=Path("/nonexistent"))  # type: ignore[call-arg]
-    summary = service.summarize("email-1")  # type: ignore[attr-defined]
+    summary = service.summarize("email-1", user_id="default")  # type: ignore[attr-defined]
     assert "not connected" in summary.lower()
 
 

--- a/tests/test_email_service_backend.py
+++ b/tests/test_email_service_backend.py
@@ -44,7 +44,7 @@ class TestEmailServiceBackend:
         svc = EmailService(mock_data_file=mock_emails_file)
         assert svc.active_backend is None
         assert svc.connect() is True
-        unread = svc.fetch_unread()
+        unread = svc.fetch_unread(user_id="default")
         assert len(unread) == 1
 
     def test_set_backend(self, mock_emails_file):
@@ -77,7 +77,7 @@ class TestEmailServiceBackend:
 
         svc = EmailService(mock_data_file=mock_emails_file, backend=mock_backend)
         svc.connect()
-        result = svc.fetch_unread()
+        result = svc.fetch_unread(user_id="default")
 
         assert len(result) == 1
         assert isinstance(result[0], EmailSummary)
@@ -91,7 +91,7 @@ class TestEmailServiceBackend:
 
         svc = EmailService(mock_data_file=mock_emails_file, backend=mock_backend)
         svc.connect()
-        assert svc.mark_as_read("msg-1") is True
+        assert svc.mark_as_read("msg-1", user_id="default") is True
         mock_backend.mark_as_read.assert_called_once_with("msg-1")
 
     def test_send_with_backend(self, mock_emails_file):
@@ -105,6 +105,7 @@ class TestEmailServiceBackend:
             to="recipient@y.com",
             subject="Test Send",
             body="Hello via backend",
+            user_id="default",
         )
         assert result["ok"] is True
         assert result["message_id"] == "sent-1"
@@ -118,6 +119,7 @@ class TestEmailServiceBackend:
             to="recipient@y.com",
             subject="Stub Send",
             body="Logged only",
+            user_id="default",
         )
         assert result["ok"] is True
         assert result["error"] is None
@@ -133,6 +135,7 @@ class TestEmailServiceBackend:
             to=["a@b.com", "c@d.com"],
             subject="Multi",
             body="Multi-recipient",
+            user_id="default",
         )
         assert result["ok"] is True
         call_kwargs = mock_backend.send.call_args[1]
@@ -145,7 +148,7 @@ class TestEmailServiceBackend:
 
         svc = EmailService(mock_data_file=mock_emails_file, backend=mock_backend)
         svc.connect()
-        result = svc.send(to="x@y.com", subject="Fail", body="Oops")
+        result = svc.send(to="x@y.com", subject="Fail", body="Oops", user_id="default")
         assert result["ok"] is False
         assert "relay denied" in result["error"]
 
@@ -157,13 +160,13 @@ class TestEmailServiceStubBackend:
         backend = StubEmailBackend(fixture_path=mock_emails_file)
         svc = EmailService(backend=backend)
         assert svc.connect() is True
-        unread = svc.fetch_unread()
+        unread = svc.fetch_unread(user_id="default")
         assert len(unread) == 1
 
     def test_stub_send_through_service(self, mock_emails_file):
         backend = StubEmailBackend(fixture_path=mock_emails_file)
         svc = EmailService(backend=backend)
         svc.connect()
-        result = svc.send(to="x@y.com", subject="Hi", body="Hello")
+        result = svc.send(to="x@y.com", subject="Hi", body="Hello", user_id="default")
         assert result["ok"] is True
         assert len(backend.sent_messages) == 1

--- a/tests/test_email_user_isolation.py
+++ b/tests/test_email_user_isolation.py
@@ -37,7 +37,7 @@ ALICE_CRED_REF = "email:alice-work"
 BOB_CRED_REF = "email:bob-personal"
 
 # Marker substrings used to detect credential leakage in any output.
-SECRET_MARKER = "s3cr3t-p4ss"
+SECRET_MARKER = "s3cr3t-p4ss"  # pragma: allowlist secret
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_email_user_isolation.py
+++ b/tests/test_email_user_isolation.py
@@ -1,0 +1,888 @@
+"""Per-user email account and credential isolation tests (issue #303).
+
+These tests reproduce and lock down the cross-user email defects:
+
+1. A named user must never route reads or sends through another user's
+   configured account or credentials (no global default / first-account
+   fallback for named users).
+2. A backend resolved or connected for User A must never be reused for
+   User B in the same process.
+3. Identity is required and validated before any credential lookup; missing,
+   blank, malformed, and traversal-style identities fail closed.
+4. The ``user_email_accounts`` map is the authoritative authorization map;
+   an empty map means "no access", never "allow all".
+5. Legacy global ``email.accounts`` entries belong only to the explicit
+   ``default`` profile.
+6. Stub/mock mode isolates mutable state between users.
+7. No credential value ever appears in results, events, or error messages.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from rex.email_service import EmailService
+
+ALICE = "alice"
+BOB = "bob"
+
+ALICE_HOST = "imap.alice.example.com"
+BOB_HOST = "imap.bob.example.com"
+
+ALICE_CRED_REF = "email:alice-work"
+BOB_CRED_REF = "email:bob-personal"
+
+# Marker substrings used to detect credential leakage in any output.
+SECRET_MARKER = "s3cr3t-p4ss"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+def _account_def(account_id: str, host_stem: str, cred_ref: str) -> dict[str, Any]:
+    return {
+        "id": account_id,
+        "label": f"{account_id} label",
+        "address": f"{account_id}@{host_stem}.example.com",
+        "imap": {"host": f"imap.{host_stem}.example.com", "port": 993, "ssl": True},
+        "smtp": {"host": f"smtp.{host_stem}.example.com", "port": 587, "starttls": True},
+        "credential_ref": cred_ref,
+    }
+
+
+def _two_user_raw_config() -> dict[str, Any]:
+    """Two named users, each owning exactly one configured account."""
+    return {
+        "email": {
+            "default_account_id": "alice-work",
+            "accounts": [
+                _account_def("alice-work", "alice", ALICE_CRED_REF),
+                _account_def("bob-personal", "bob", BOB_CRED_REF),
+            ],
+        },
+        "users": {
+            ALICE: {
+                "email_accounts": [
+                    {
+                        "account_id": "alice-work",
+                        "backend": "imap",
+                        "credentials_key": ALICE_CRED_REF,
+                    }
+                ]
+            },
+            BOB: {
+                "email_accounts": [
+                    {
+                        "account_id": "bob-personal",
+                        "backend": "imap",
+                        "credentials_key": BOB_CRED_REF,
+                    }
+                ]
+            },
+        },
+    }
+
+
+def _legacy_only_raw_config() -> dict[str, Any]:
+    """Legacy global accounts with no ``users`` block at all."""
+    return {
+        "email": {
+            "default_account_id": "legacy-main",
+            "accounts": [_account_def("legacy-main", "legacy", "email:legacy-main")],
+        },
+    }
+
+
+class FakeCredentialManager:
+    """Records every credential-ref lookup and returns a marked secret."""
+
+    def __init__(self) -> None:
+        self.lookups: list[str] = []
+
+    def get_token(self, ref: str, **_: Any) -> str:
+        self.lookups.append(ref)
+        return f"user-{ref}:{SECRET_MARKER}-{ref}"
+
+    def get_credential(self, name: str) -> None:
+        return None
+
+
+class FakeImapBackend:
+    """Stand-in for ImapSmtpEmailBackend: no network, distinct mail per host."""
+
+    instances: list[FakeImapBackend] = []
+
+    def __init__(
+        self,
+        *,
+        imap_host: str,
+        imap_port: int = 993,
+        smtp_host: str = "",
+        smtp_port: int = 587,
+        username: str = "",
+        password: str = "",
+        use_starttls: bool = True,
+    ) -> None:
+        self.imap_host = imap_host
+        self.smtp_host = smtp_host
+        self.username = username
+        self.password = password
+        self.sent: list[dict[str, Any]] = []
+        self.connected = False
+        FakeImapBackend.instances.append(self)
+
+    def connect(self) -> bool:
+        self.connected = True
+        return True
+
+    def disconnect(self) -> None:
+        self.connected = False
+
+    def fetch_unread(self, limit: int = 10) -> list[Any]:
+        return [
+            SimpleNamespace(
+                message_id=f"msg-{self.imap_host}-1",
+                from_addr=f"sender@{self.imap_host}",
+                subject=f"mail-via-{self.imap_host}",
+                snippet="hello",
+                received_at=datetime(2026, 7, 1, tzinfo=UTC),
+                to_addrs=["me@example.com"],
+                labels=["unread"],
+            )
+        ][:limit]
+
+    def mark_as_read(self, message_id: str) -> bool:
+        return True
+
+    def send(self, *, from_addr: str, to_addrs: list[str], subject: str, body: str) -> Any:
+        self.sent.append(
+            {"from_addr": from_addr, "to_addrs": to_addrs, "subject": subject, "body": body}
+        )
+        return SimpleNamespace(ok=True, message_id=f"mid-{self.smtp_host}", error=None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_backend_registry():
+    FakeImapBackend.instances = []
+    yield
+    FakeImapBackend.instances = []
+
+
+@pytest.fixture()
+def fake_creds() -> FakeCredentialManager:
+    return FakeCredentialManager()
+
+
+def _patch_env(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_config: dict[str, Any],
+) -> None:
+    """Point config loading at *raw_config* and neutralize the real backend."""
+    import rex.config_manager as config_manager
+    import rex.email_backends.imap_smtp as imap_smtp
+
+    monkeypatch.setattr(config_manager, "load_config", lambda *a, **k: raw_config)
+    monkeypatch.setattr(imap_smtp, "ImapSmtpEmailBackend", FakeImapBackend)
+
+
+def _make_service(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_config: dict[str, Any],
+    fake_creds: FakeCredentialManager,
+) -> EmailService:
+    _patch_env(monkeypatch, raw_config)
+    svc = EmailService()
+    svc.credential_manager = fake_creds
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Defect reproduction #1: named user routed through another user's account
+# ---------------------------------------------------------------------------
+
+
+class TestNoForeignAccountRouting:
+    def test_send_for_unassigned_user_never_uses_global_default_account(
+        self, monkeypatch, fake_creds
+    ):
+        """A user with no assigned accounts must not send via the global default."""
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        result = svc.send(
+            to="someone@example.com",
+            subject="hi",
+            body="hello",
+            user_id="james",
+        )
+
+        assert result.get("ok") is not True
+        assert ALICE_CRED_REF not in fake_creds.lookups
+        assert BOB_CRED_REF not in fake_creds.lookups
+        # Nothing was handed to any backend.
+        assert all(not b.sent for b in FakeImapBackend.instances)
+
+    def test_send_without_account_id_uses_requesters_own_account(self, monkeypatch, fake_creds):
+        """Bob's account (not the global default alice-work) serves Bob's send."""
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        result = svc.send(
+            to="someone@example.com",
+            subject="hi",
+            body="hello",
+            user_id=BOB,
+        )
+
+        assert result.get("ok") is True
+        assert ALICE_CRED_REF not in fake_creds.lookups
+        assert BOB_CRED_REF in fake_creds.lookups
+        sent_hosts = [b.smtp_host for b in FakeImapBackend.instances if b.sent]
+        assert sent_hosts == ["smtp.bob.example.com"]
+
+    def test_send_explicit_foreign_account_rejected_before_credential_lookup(
+        self, monkeypatch, fake_creds
+    ):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        with pytest.raises(PermissionError):
+            svc.send(
+                to="x@example.com",
+                subject="s",
+                body="b",
+                user_id=BOB,
+                account_id="alice-work",
+            )
+        assert fake_creds.lookups == []
+
+    def test_fetch_unread_explicit_foreign_account_rejected(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        with pytest.raises(PermissionError):
+            svc.fetch_unread(user_id=BOB, account_id="alice-work")
+        assert fake_creds.lookups == []
+
+    def test_foreign_and_nonexistent_accounts_are_indistinguishable(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        with pytest.raises(PermissionError) as foreign:
+            svc.send(to="x@e.com", subject="s", body="b", user_id=BOB, account_id="alice-work")
+        with pytest.raises(PermissionError) as missing:
+            svc.send(to="x@e.com", subject="s", body="b", user_id=BOB, account_id="no-such-acct")
+
+        # Same message shape modulo the requested id; neither leaks existence.
+        msg_foreign = str(foreign.value).replace("alice-work", "<id>")
+        msg_missing = str(missing.value).replace("no-such-acct", "<id>")
+        assert msg_foreign == msg_missing
+
+
+# ---------------------------------------------------------------------------
+# Defect reproduction #2: backend resolved for User A reused for User B
+# ---------------------------------------------------------------------------
+
+
+class TestNoCrossUserBackendReuse:
+    def test_backend_resolved_for_alice_not_reused_for_bob(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        alice_msgs = svc.fetch_unread(user_id=ALICE)
+        bob_msgs = svc.fetch_unread(user_id=BOB)
+
+        assert [m.subject for m in alice_msgs] == [f"mail-via-{ALICE_HOST}"]
+        assert [m.subject for m in bob_msgs] == [f"mail-via-{BOB_HOST}"]
+
+    def test_backend_credentials_looked_up_per_owner_only(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        svc.fetch_unread(user_id=ALICE)
+        lookups_after_alice = list(fake_creds.lookups)
+        svc.fetch_unread(user_id=BOB)
+
+        assert lookups_after_alice == [ALICE_CRED_REF]
+        assert BOB_CRED_REF in fake_creds.lookups
+        # Alice's credential was never re-fetched on Bob's behalf beyond her own call.
+        assert fake_creds.lookups.count(ALICE_CRED_REF) == 1
+
+    def test_backend_instance_reused_for_same_user_and_account(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        svc.fetch_unread(user_id=ALICE)
+        svc.fetch_unread(user_id=ALICE)
+
+        alice_backends = [b for b in FakeImapBackend.instances if b.imap_host == ALICE_HOST]
+        assert len(alice_backends) == 1
+
+
+# ---------------------------------------------------------------------------
+# Identity is required and validated before credential lookup
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityFailClosed:
+    @pytest.mark.parametrize("bad_user", [None, "", "   ", "..", "../evil", "a/b", "a\\b"])
+    def test_fetch_unread_invalid_identity_fails_closed(self, monkeypatch, fake_creds, bad_user):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        with pytest.raises((PermissionError, ValueError)):
+            svc.fetch_unread(user_id=bad_user)
+        assert fake_creds.lookups == []
+
+    @pytest.mark.parametrize("bad_user", [None, "", "..", "../evil"])
+    def test_send_invalid_identity_fails_closed(self, monkeypatch, fake_creds, bad_user):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        with pytest.raises((PermissionError, ValueError)):
+            svc.send(to="x@e.com", subject="s", body="b", user_id=bad_user)
+        assert fake_creds.lookups == []
+
+    def test_mark_as_read_requires_identity(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        with pytest.raises((PermissionError, ValueError, TypeError)):
+            svc.mark_as_read("msg-1")
+
+    def test_triage_unread_requires_identity(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        with pytest.raises((PermissionError, ValueError, TypeError)):
+            svc.triage_unread()
+
+
+# ---------------------------------------------------------------------------
+# Authorization map semantics
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorizationMap:
+    def test_empty_user_map_is_deny_not_allow_all(self):
+        """No configured scoping means no account access — never allow-all."""
+        svc = EmailService()
+
+        with pytest.raises(PermissionError):
+            svc._check_account_access(ALICE, "any-account")
+
+    def test_get_accounts_requires_valid_identity(self):
+        svc = EmailService()
+
+        with pytest.raises((PermissionError, ValueError)):
+            svc.get_accounts("../evil")
+
+
+# ---------------------------------------------------------------------------
+# Legacy global accounts belong only to the explicit `default` profile
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyAccountPolicy:
+    def test_default_profile_keeps_legacy_account(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _legacy_only_raw_config(), fake_creds)
+
+        msgs = svc.fetch_unread(user_id="default")
+
+        assert [m.subject for m in msgs] == ["mail-via-imap.legacy.example.com"]
+        assert fake_creds.lookups == ["email:legacy-main"]
+
+    def test_named_user_does_not_inherit_legacy_accounts(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _legacy_only_raw_config(), fake_creds)
+
+        msgs = svc.fetch_unread(user_id="james")
+
+        assert msgs == []
+        assert fake_creds.lookups == []
+
+    def test_named_user_cannot_send_via_legacy_account(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _legacy_only_raw_config(), fake_creds)
+
+        result = svc.send(to="x@e.com", subject="s", body="b", user_id="james")
+
+        assert result.get("ok") is not True
+        assert fake_creds.lookups == []
+
+    def test_unassigned_legacy_account_stays_with_default_when_users_block_exists(
+        self, monkeypatch, fake_creds
+    ):
+        """A users block for alice must not stop `default` from owning legacy accounts."""
+        raw = _two_user_raw_config()
+        raw["email"]["accounts"].append(_account_def("legacy-extra", "extra", "email:extra"))
+
+        svc = _make_service(monkeypatch, raw, fake_creds)
+
+        msgs = svc.fetch_unread(user_id="default", account_id="legacy-extra")
+        assert [m.subject for m in msgs] == ["mail-via-imap.extra.example.com"]
+
+        with pytest.raises(PermissionError):
+            svc.fetch_unread(user_id=ALICE, account_id="legacy-extra")
+
+
+# ---------------------------------------------------------------------------
+# Stub/mock mode isolation between users
+# ---------------------------------------------------------------------------
+
+
+class TestStubModeIsolation:
+    @pytest.fixture()
+    def stub_service(self, tmp_path, monkeypatch) -> EmailService:
+        _patch_env(monkeypatch, {})  # no accounts configured at all
+        mock_file = tmp_path / "mock_emails.json"
+        mock_file.write_text(
+            """
+            [
+              {"id": "m1", "from_addr": "a@example.com", "subject": "One",
+               "snippet": "one", "received_at": "2026-07-01T00:00:00+00:00",
+               "labels": ["unread"]},
+              {"id": "m2", "from_addr": "b@example.com", "subject": "Two",
+               "snippet": "two", "received_at": "2026-07-01T01:00:00+00:00",
+               "labels": ["unread"]}
+            ]
+            """,
+            encoding="utf-8",
+        )
+        return EmailService(mock_data_file=mock_file)
+
+    def test_mark_read_by_one_user_does_not_affect_another(self, stub_service):
+        alice_before = stub_service.fetch_unread(user_id=ALICE)
+        assert {m.id for m in alice_before} == {"m1", "m2"}
+
+        assert stub_service.mark_as_read("m1", user_id=ALICE) is True
+
+        alice_after = stub_service.fetch_unread(user_id=ALICE)
+        bob_view = stub_service.fetch_unread(user_id=BOB)
+
+        assert {m.id for m in alice_after} == {"m2"}
+        assert {m.id for m in bob_view} == {"m1", "m2"}
+
+    def test_summarize_requires_identity(self, stub_service):
+        with pytest.raises((PermissionError, ValueError, TypeError)):
+            stub_service.summarize("m1")
+
+
+# ---------------------------------------------------------------------------
+# No credential values in results, events, or errors
+# ---------------------------------------------------------------------------
+
+
+class TestNoSecretLeakage:
+    def test_secrets_never_appear_in_results_events_or_errors(self, monkeypatch, fake_creds):
+        published: list[tuple[str, dict[str, Any]]] = []
+
+        class Bus:
+            def publish(self, topic, payload):
+                published.append((topic, payload))
+
+        _patch_env(monkeypatch, _two_user_raw_config())
+        svc = EmailService(event_bus=Bus())
+        svc.credential_manager = fake_creds
+
+        svc.fetch_unread(user_id=ALICE)
+        result = svc.send(to="x@e.com", subject="s", body="b", user_id=ALICE)
+        try:
+            svc.send(to="x@e.com", subject="s", body="b", user_id=ALICE, account_id="bob-personal")
+        except PermissionError as exc:
+            error_text = str(exc)
+        else:
+            error_text = ""
+
+        blob = repr(published) + repr(result) + error_text
+        assert SECRET_MARKER not in blob
+        assert ALICE_CRED_REF in repr(fake_creds.lookups)  # sanity: lookups happened
+
+
+# ---------------------------------------------------------------------------
+# Per-user defaults
+# ---------------------------------------------------------------------------
+
+
+class TestConnectOwnership:
+    def test_connect_requires_user_when_accounts_configured(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        assert svc.connect() is False
+        assert fake_creds.lookups == []
+
+    def test_connect_resolves_only_own_account(self, monkeypatch, fake_creds):
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+
+        assert svc.connect("james") is False  # no account for james
+        assert fake_creds.lookups == []
+
+        assert svc.connect(BOB) is True
+        assert fake_creds.lookups == [BOB_CRED_REF]
+
+
+class TestCredentialRefIntegrity:
+    def test_only_the_definition_credential_ref_is_used(self, monkeypatch, fake_creds):
+        """A tampered entry credentials_key can never redirect credential lookup."""
+        raw = _two_user_raw_config()
+        # Malicious/typo'd config: alice's authorization entry names Bob's ref.
+        raw["users"][ALICE]["email_accounts"][0]["credentials_key"] = BOB_CRED_REF
+
+        svc = _make_service(monkeypatch, raw, fake_creds)
+        svc.fetch_unread(user_id=ALICE)
+
+        # Credential lookup uses only the authorized account definition's ref.
+        assert fake_creds.lookups == [ALICE_CRED_REF]
+
+    def test_no_api_accepts_a_credential_reference(self, monkeypatch, fake_creds):
+        """send() has no parameter through which a caller can name a credential."""
+        import inspect
+
+        from rex.email_service import EmailService as Svc
+
+        for method in (Svc.send, Svc.fetch_unread, Svc.triage_unread, Svc.mark_as_read):
+            params = set(inspect.signature(method).parameters)
+            assert not params & {"credential_ref", "credentials_key", "credential"}
+
+
+class TestEventScoping:
+    def test_private_fields_only_on_user_scoped_topic(self, monkeypatch, fake_creds):
+        published: list[tuple[str, dict[str, Any]]] = []
+
+        class Bus:
+            def publish(self, topic, payload):
+                published.append((topic, payload))
+
+        _patch_env(monkeypatch, _two_user_raw_config())
+        svc = EmailService(event_bus=Bus())
+        svc.credential_manager = fake_creds
+
+        svc.fetch_unread(user_id=ALICE)
+
+        shared = [p for t, p in published if t == "email.unread"]
+        private = [p for t, p in published if t == f"email.unread.user.{ALICE}"]
+        assert shared and private
+
+        # The shared topic carries only the safe envelope.
+        assert "messages" not in shared[0]
+        assert "emails" not in shared[0]
+        assert shared[0]["user_id"] == ALICE
+        # Private payload goes only to the owner-scoped topic.
+        assert private[0]["messages"]
+        # No payload for Alice's mail was published on Bob's topic.
+        assert all(t != f"email.unread.user.{BOB}" for t, _ in published)
+
+    def test_triage_events_are_user_scoped(self, monkeypatch, fake_creds):
+        published: list[tuple[str, dict[str, Any]]] = []
+
+        class Bus:
+            def publish(self, topic, payload):
+                published.append((topic, payload))
+
+        _patch_env(monkeypatch, _two_user_raw_config())
+        svc = EmailService(event_bus=Bus())
+        svc.credential_manager = fake_creds
+
+        svc.triage_unread(user_id=BOB)
+
+        shared = [p for t, p in published if t == "email.triaged"]
+        assert shared and "triaged" not in shared[0]
+        assert shared[0]["user_id"] == BOB
+        private = [p for t, p in published if t == f"email.triaged.user.{BOB}"]
+        assert private and private[0]["triaged"]
+
+
+class TestScheduledTriage:
+    def test_triage_runs_per_stored_owner(self, monkeypatch):
+        import rex.config_manager as config_manager
+        from rex.services import _run_email_triage
+
+        monkeypatch.setattr(config_manager, "load_config", lambda *a, **k: _two_user_raw_config())
+
+        calls: list[str] = []
+
+        class FakeEmail:
+            def triage_unread(self, limit: int = 10, *, user_id=None, account_id=None):
+                calls.append(user_id)
+                return []
+
+        _run_email_triage(FakeEmail())
+        assert calls == [ALICE, BOB]
+
+    def test_one_owner_failure_does_not_affect_others(self, monkeypatch):
+        import rex.config_manager as config_manager
+        from rex.services import _run_email_triage
+
+        monkeypatch.setattr(config_manager, "load_config", lambda *a, **k: _two_user_raw_config())
+
+        calls: list[str] = []
+
+        class FakeEmail:
+            def triage_unread(self, limit: int = 10, *, user_id=None, account_id=None):
+                calls.append(user_id)
+                if user_id == ALICE:
+                    raise RuntimeError("alice IMAP down")
+                return []
+
+        _run_email_triage(FakeEmail())  # must not raise
+        assert calls == [ALICE, BOB]
+
+    def test_legacy_job_without_owners_runs_default_only(self, monkeypatch):
+        import rex.config_manager as config_manager
+        from rex.services import _run_email_triage
+
+        monkeypatch.setattr(config_manager, "load_config", lambda *a, **k: {})
+
+        calls: list[str] = []
+
+        class FakeEmail:
+            def triage_unread(self, limit: int = 10, *, user_id=None, account_id=None):
+                calls.append(user_id)
+                return []
+
+        _run_email_triage(FakeEmail())
+        assert calls == ["default"]
+
+
+class TestOpenClawEmailTool:
+    def test_fails_closed_without_user_id(self, monkeypatch):
+        from unittest.mock import patch
+
+        from rex.openclaw.tools.email_tool import send_email
+
+        with patch("rex.openclaw.tools.email_tool._get_email_service") as get_svc:
+            result = send_email("x@example.com", "s", "b")
+
+        assert result["ok"] is False
+        get_svc.assert_not_called()
+
+    def test_fails_closed_on_invalid_user_id(self):
+        from unittest.mock import patch
+
+        from rex.openclaw.tools.email_tool import send_email
+
+        with patch("rex.openclaw.tools.email_tool._get_email_service") as get_svc:
+            result = send_email("x@example.com", "s", "b", _user_id="../evil")
+
+        assert result["ok"] is False
+        get_svc.assert_not_called()
+
+    def test_cannot_send_through_foreign_account(self, monkeypatch, fake_creds):
+        from unittest.mock import patch
+
+        from rex.openclaw.tools.email_tool import send_email
+
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+        with patch("rex.openclaw.tools.email_tool._get_email_service", return_value=svc):
+            result = send_email("x@example.com", "s", "b", _user_id=BOB, account_id="alice-work")
+
+        assert result["ok"] is False
+        assert fake_creds.lookups == []
+        assert SECRET_MARKER not in str(result)
+
+
+class TestGmailPerUserToken:
+    def test_named_user_never_inherits_global_gmail_token(self, monkeypatch):
+        from rex.integrations.email_service import create_email_service_for_user
+
+        monkeypatch.setenv("GMAIL_ACCESS_TOKEN", "global-secret-token")
+        raw = {"email": {"provider": "gmail"}}
+
+        svc, provider = create_email_service_for_user("james", raw)
+        assert svc is None
+        assert provider == "none"
+
+    def test_default_profile_keeps_legacy_gmail_env(self, monkeypatch):
+        from rex.integrations.email_service import create_email_service_for_user
+
+        monkeypatch.setenv("GMAIL_ACCESS_TOKEN", "global-secret-token")
+        raw = {"email": {"provider": "gmail"}}
+
+        svc, provider = create_email_service_for_user("default", raw)
+        assert provider == "gmail"
+        assert svc is not None
+        assert svc._gmail_headers()["Authorization"] == "Bearer global-secret-token"
+
+    def test_named_user_uses_own_token(self, monkeypatch):
+        from rex.integrations.email_service import create_email_service_for_user
+
+        monkeypatch.setenv("GMAIL_ACCESS_TOKEN", "global-secret-token")
+        monkeypatch.setenv("EMAIL_ALICE_GMAIL", "alice-own-token")
+        raw = {
+            "users": {
+                ALICE: {
+                    "email_accounts": [
+                        {
+                            "account_id": "alice-gmail",
+                            "backend": "gmail",
+                            "credentials_key": "EMAIL_ALICE_GMAIL",
+                        }
+                    ]
+                }
+            }
+        }
+
+        svc, provider = create_email_service_for_user(ALICE, raw)
+        assert provider == "gmail"
+        assert svc is not None
+        assert svc._gmail_headers()["Authorization"] == "Bearer alice-own-token"
+
+    def test_named_user_without_token_fails_closed(self, monkeypatch):
+        from rex.integrations.email_service import create_email_service_for_user
+
+        monkeypatch.setenv("GMAIL_ACCESS_TOKEN", "global-secret-token")
+        monkeypatch.delenv("EMAIL_ALICE_GMAIL", raising=False)
+        raw = {
+            "users": {
+                ALICE: {
+                    "email_accounts": [
+                        {
+                            "account_id": "alice-gmail",
+                            "backend": "gmail",
+                            "credentials_key": "EMAIL_ALICE_GMAIL",
+                        }
+                    ]
+                }
+            }
+        }
+
+        svc, provider = create_email_service_for_user(ALICE, raw)
+        assert svc is None
+        assert provider == "none"
+
+    def test_invalid_identity_fails_before_token_read(self):
+        import pytest as _pytest
+
+        from rex.integrations.email_service import create_email_service_for_user
+
+        with _pytest.raises(PermissionError):
+            create_email_service_for_user("../evil", {})
+
+
+class TestElectronBridgeIdentity:
+    def test_explicit_user_payload_wins(self):
+        from bridge import rex_email_bridge
+
+        assert rex_email_bridge._resolve_user({"user": ALICE}) == ALICE
+
+    def test_invalid_explicit_user_fails_closed(self):
+        from bridge import rex_email_bridge
+
+        assert rex_email_bridge._resolve_user({"user": "../evil"}) is None
+
+    def test_list_for_named_user_without_provider_is_unconfigured(self, monkeypatch):
+        import rex.config_manager as config_manager
+        from bridge import rex_email_bridge
+
+        monkeypatch.setenv("GMAIL_ACCESS_TOKEN", "global-secret-token")
+        monkeypatch.setattr(
+            config_manager,
+            "load_config",
+            lambda *a, **k: {"email": {"provider": "gmail"}},
+        )
+
+        result = rex_email_bridge._handle_list("james", 10)
+        assert result == {"ok": True, "messages": [], "configured": False}
+
+    def test_bridge_response_never_contains_credentials(self, monkeypatch):
+        import rex.config_manager as config_manager
+        from bridge import rex_email_bridge
+
+        monkeypatch.setenv("GMAIL_ACCESS_TOKEN", "global-secret-token")
+        monkeypatch.setattr(
+            config_manager,
+            "load_config",
+            lambda *a, **k: {"email": {"provider": "gmail"}},
+        )
+
+        result = rex_email_bridge._handle_list("james", 10)
+        assert "global-secret-token" not in repr(result)
+
+
+class TestServiceRecreationPersistence:
+    def test_ownership_and_defaults_survive_service_recreation(self, monkeypatch, fake_creds):
+        """A restarted process (new service over the same config) preserves
+        account ownership and per-user default selection."""
+        raw = _two_user_raw_config()
+        raw["users"][ALICE]["email_accounts"].append(
+            {"account_id": "bob-personal", "backend": "imap", "credentials_key": BOB_CRED_REF}
+        )
+        del raw["users"][BOB]
+        raw["users"][ALICE]["default_email_account_id"] = "bob-personal"
+
+        first = _make_service(monkeypatch, raw, fake_creds)
+        assert [m.subject for m in first.fetch_unread(user_id=ALICE)] == [f"mail-via-{BOB_HOST}"]
+
+        second = _make_service(monkeypatch, raw, FakeCredentialManager())
+        assert [m.subject for m in second.fetch_unread(user_id=ALICE)] == [f"mail-via-{BOB_HOST}"]
+        with pytest.raises(PermissionError):
+            second.fetch_unread(user_id="james", account_id="alice-work")
+
+    def test_revoked_assignment_takes_effect_without_restart(self, monkeypatch, fake_creds):
+        """A long-lived service must honour a config change that revokes a
+        user's account assignment — no stale-authorization window."""
+        import rex.config_manager as config_manager
+        import rex.email_accounts as email_accounts
+
+        svc = _make_service(monkeypatch, _two_user_raw_config(), fake_creds)
+        assert [m.subject for m in svc.fetch_unread(user_id=BOB)] == [f"mail-via-{BOB_HOST}"]
+
+        revoked = _two_user_raw_config()
+        del revoked["users"][BOB]
+        monkeypatch.setattr(config_manager, "load_config", lambda *a, **k: revoked)
+        monkeypatch.setattr(email_accounts, "config_stamp", lambda: 12345)
+
+        assert svc.fetch_unread(user_id=BOB) == []
+        result = svc.send(to="x@e.com", subject="s", body="b", user_id=BOB)
+        assert result.get("ok") is not True
+
+    def test_per_user_default_survives_config_reload_from_disk(
+        self, monkeypatch, fake_creds, tmp_path
+    ):
+        """Per-user defaults written to rex_config.json survive a reload."""
+        import json as _json
+
+        from rex.email_accounts import EmailAccountResolver
+
+        raw = _two_user_raw_config()
+        raw["users"][ALICE]["email_accounts"].append(
+            {"account_id": "bob-personal", "backend": "imap", "credentials_key": BOB_CRED_REF}
+        )
+        del raw["users"][BOB]
+        raw["users"][ALICE]["default_email_account_id"] = "bob-personal"
+
+        config_file = tmp_path / "rex_config.json"
+        config_file.write_text(_json.dumps(raw), encoding="utf-8")
+
+        reloaded = _json.loads(config_file.read_text(encoding="utf-8"))
+        resolver = EmailAccountResolver.from_raw_config(reloaded)
+        assert resolver.default_account_id_for_user(ALICE) == "bob-personal"
+
+
+class TestPerUserDefaults:
+    def test_user_default_account_selected_over_config_order(self, monkeypatch, fake_creds):
+        raw = _two_user_raw_config()
+        # Alice owns both accounts; her personal default is the second one.
+        raw["users"][ALICE]["email_accounts"].append(
+            {"account_id": "bob-personal", "backend": "imap", "credentials_key": BOB_CRED_REF}
+        )
+        del raw["users"][BOB]
+        raw["users"][ALICE]["default_email_account_id"] = "bob-personal"
+
+        svc = _make_service(monkeypatch, raw, fake_creds)
+        msgs = svc.fetch_unread(user_id=ALICE)
+
+        assert [m.subject for m in msgs] == [f"mail-via-{BOB_HOST}"]
+
+    def test_one_users_default_does_not_affect_another(self, monkeypatch, fake_creds):
+        raw = _two_user_raw_config()
+        raw["users"][ALICE]["default_email_account_id"] = "alice-work"
+
+        svc = _make_service(monkeypatch, raw, fake_creds)
+        msgs = svc.fetch_unread(user_id=BOB)
+
+        assert [m.subject for m in msgs] == [f"mail-via-{BOB_HOST}"]
+
+    def test_foreign_default_is_ignored_fail_closed(self, monkeypatch, fake_creds):
+        """A configured default pointing at a foreign account must not grant access."""
+        raw = _two_user_raw_config()
+        raw["users"][BOB]["default_email_account_id"] = "alice-work"
+
+        svc = _make_service(monkeypatch, raw, fake_creds)
+        msgs = svc.fetch_unread(user_id=BOB)
+
+        # Falls back to Bob's own account; never Alice's.
+        assert [m.subject for m in msgs] == [f"mail-via-{BOB_HOST}"]
+        assert ALICE_CRED_REF not in fake_creds.lookups

--- a/tests/test_me002_email_scoping.py
+++ b/tests/test_me002_email_scoping.py
@@ -104,12 +104,15 @@ def test_check_account_access_raises_for_foreign_account():
         svc._check_account_access("alice", "personal")  # Bob's account
 
 
-def test_check_account_access_no_op_when_no_scoping():
-    """When user_email_accounts is empty (no scoping), all access is allowed."""
+def test_check_account_access_denies_when_no_scoping_configured():
+    """An empty user_email_accounts map means no access — never allow-all."""
+    import pytest
+
     from rex.email_service import EmailService
 
     svc = EmailService()  # no user_email_accounts
-    svc._check_account_access("alice", "any-account")  # should not raise
+    with pytest.raises(PermissionError):
+        svc._check_account_access("alice", "any-account")
 
 
 # ---------------------------------------------------------------------------
@@ -150,12 +153,13 @@ def test_send_allows_own_account():
     assert result.get("ok") is True
 
 
-def test_send_without_user_id_skips_ownership_check():
-    """send() without user_id does not enforce ownership (backwards compat)."""
+def test_send_without_user_id_fails_closed():
+    """send() without a user identity is refused before any account routing."""
+    import pytest
+
     svc = _make_service({"alice": [_make_account("work", "alice")]})
-    # No user_id — should not raise even with an account_id that belongs to alice
-    result = svc.send(to="x@y.com", subject="s", body="b", account_id="work")
-    assert result.get("ok") is True
+    with pytest.raises(PermissionError):
+        svc.send(to="x@y.com", subject="s", body="b", account_id="work")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -276,11 +276,12 @@ def test_notifier_event_subscription():
         notifier = Notifier()
         notifier.setup_event_subscriptions()
 
-        # Should subscribe to email and calendar events via EventBridge
+        # Should subscribe to user-scoped email events (wildcard with a
+        # prefix filter) and calendar events via EventBridge
         assert mock_bridge.subscribe.call_count == 2
         calls = mock_bridge.subscribe.call_args_list
         event_types = [call[0][0] for call in calls]
-        assert "email.unread" in event_types
+        assert "*" in event_types
         assert "calendar.update" in event_types
 
 

--- a/tests/test_notification_email_channel.py
+++ b/tests/test_notification_email_channel.py
@@ -36,7 +36,7 @@ class TestNotificationEmailChannel:
             title="Test Alert",
             body="Something happened",
             channel_preferences=["email"],
-            metadata={"to_email": "user@example.com"},
+            metadata={"to_email": "user@example.com", "email_user_id": "default"},
         )
 
         with patch("rex.email_service.get_email_service", return_value=mock_service):
@@ -47,6 +47,7 @@ class TestNotificationEmailChannel:
             subject="Test Alert",
             body="Something happened",
             account_id=None,
+            user_id="default",
         )
 
     def test_email_channel_with_account_id(self, notifier):
@@ -63,6 +64,7 @@ class TestNotificationEmailChannel:
             metadata={
                 "to_email": "user@example.com",
                 "email_account_id": "work",
+                "email_user_id": "default",
             },
         )
 
@@ -74,6 +76,7 @@ class TestNotificationEmailChannel:
             subject="Alert",
             body="Body",
             account_id="work",
+            user_id="default",
         )
 
     def test_email_channel_stub_mode_no_backend(self, notifier):
@@ -111,6 +114,24 @@ class TestNotificationEmailChannel:
 
         mock_service.send.assert_not_called()
 
+    def test_email_channel_no_owner_fails_closed(self, notifier):
+        """Without email_user_id, delivery is skipped — never another user's account."""
+        mock_service = MagicMock()
+        mock_service.active_backend = MagicMock()
+
+        notif = NotificationRequest(
+            priority="normal",
+            title="No Owner",
+            body="Body",
+            channel_preferences=["email"],
+            metadata={"to_email": "user@example.com"},  # no email_user_id
+        )
+
+        with patch("rex.email_service.get_email_service", return_value=mock_service):
+            notifier._send_to_email(notif)
+
+        mock_service.send.assert_not_called()
+
     def test_email_channel_send_failure_raises(self, notifier):
         """When send() returns ok=False, RuntimeError is raised."""
         mock_service = MagicMock()
@@ -122,7 +143,7 @@ class TestNotificationEmailChannel:
             title="Fail",
             body="Oops",
             channel_preferences=["email"],
-            metadata={"to_email": "user@example.com"},
+            metadata={"to_email": "user@example.com", "email_user_id": "default"},
         )
 
         with patch("rex.email_service.get_email_service", return_value=mock_service):
@@ -140,7 +161,7 @@ class TestNotificationEmailChannel:
             title="Urgent",
             body="Do something",
             channel_preferences=["email", "dashboard"],
-            metadata={"to_email": "admin@example.com"},
+            metadata={"to_email": "admin@example.com", "email_user_id": "default"},
         )
 
         with patch("rex.email_service.get_email_service", return_value=mock_service):

--- a/tests/test_notification_email_delivery.py
+++ b/tests/test_notification_email_delivery.py
@@ -33,6 +33,7 @@ def _make_notification(
     body: str = "Alert body",
     to_email: str | None = "user@example.com",
     account_id: str | None = None,
+    user_id: str | None = "default",
     priority: str = "normal",
     channel: str = "email",
 ) -> NotificationRequest:
@@ -41,6 +42,8 @@ def _make_notification(
         meta["to_email"] = to_email
     if account_id is not None:
         meta["email_account_id"] = account_id
+    if user_id is not None:
+        meta["email_user_id"] = user_id
     return NotificationRequest(
         title=title,
         body=body,
@@ -76,6 +79,7 @@ class TestSendToEmail:
             subject="Test alert",
             body="Alert body",
             account_id=None,
+            user_id="default",
         )
 
     def test_passes_account_id_to_send(self, tmp_path):
@@ -88,6 +92,17 @@ class TestSendToEmail:
 
         _, kwargs = mock_svc.send.call_args
         assert kwargs["account_id"] == "work"
+
+    def test_no_send_when_owner_missing(self, tmp_path):
+        """Delivery without an owning user is skipped — fail closed."""
+        notifier = _make_notifier(tmp_path)
+        notification = _make_notification(user_id=None)
+        mock_svc = _stub_email_service()
+
+        with patch("rex.notification.get_email_service", return_value=mock_svc):
+            notifier._send_to_email(notification)
+
+        mock_svc.send.assert_not_called()
 
     def test_no_send_when_to_email_missing(self, tmp_path):
         notifier = _make_notifier(tmp_path)
@@ -155,7 +170,7 @@ class TestDigestFlushEmailDelivery:
             body="Nothing urgent",
             priority="digest",
             channel_preferences=["email"],
-            metadata={"to_email": "user@example.com"},
+            metadata={"to_email": "user@example.com", "email_user_id": "default"},
         )
         notifier._queue_digest(digest_notif)
 
@@ -176,7 +191,7 @@ class TestDigestFlushEmailDelivery:
             body="Body",
             priority="digest",
             channel_preferences=["email"],
-            metadata={"to_email": "admin@example.com"},
+            metadata={"to_email": "admin@example.com", "email_user_id": "default"},
         )
         notifier._queue_digest(digest_notif)
 

--- a/tests/test_openclaw_policy_gated_tools.py
+++ b/tests/test_openclaw_policy_gated_tools.py
@@ -29,19 +29,34 @@ class TestEmailTool:
         assert "email" in TOOL_DESCRIPTION.lower()
 
     def test_send_email_calls_service(self):
-        """send_email delegates to EmailService.send with correct kwargs."""
+        """send_email delegates to EmailService.send as the dispatching user."""
         from rex.openclaw.tools.email_tool import send_email
 
         mock_service = MagicMock()
         mock_service.send.return_value = {"ok": True, "message_id": "msg-1", "error": None}
 
         with patch("rex.openclaw.tools.email_tool._get_email_service", return_value=mock_service):
-            result = send_email("alice@example.com", "Hello", "Hi Alice!")
+            result = send_email("alice@example.com", "Hello", "Hi Alice!", _user_id="alice")
 
         mock_service.send.assert_called_once_with(
-            to="alice@example.com", subject="Hello", body="Hi Alice!"
+            to="alice@example.com",
+            subject="Hello",
+            body="Hi Alice!",
+            account_id=None,
+            user_id="alice",
         )
         assert result == {"ok": True, "message_id": "msg-1", "error": None}
+
+    def test_send_email_fails_closed_without_user(self):
+        """send_email without _user_id is refused before any service access."""
+        from rex.openclaw.tools.email_tool import send_email
+
+        with patch("rex.openclaw.tools.email_tool._get_email_service") as get_svc:
+            result = send_email("alice@example.com", "Hello", "Hi!")
+
+        assert result["ok"] is False
+        assert "identity" in result["error"].lower()
+        get_svc.assert_not_called()
 
     def test_send_email_to_list(self):
         """send_email accepts a list of recipients."""
@@ -51,10 +66,14 @@ class TestEmailTool:
         mock_service.send.return_value = {"ok": True, "message_id": "msg-2", "error": None}
 
         with patch("rex.openclaw.tools.email_tool._get_email_service", return_value=mock_service):
-            result = send_email(["a@x.com", "b@x.com"], "Sub", "Body")
+            result = send_email(["a@x.com", "b@x.com"], "Sub", "Body", _user_id="alice")
 
         mock_service.send.assert_called_once_with(
-            to=["a@x.com", "b@x.com"], subject="Sub", body="Body"
+            to=["a@x.com", "b@x.com"],
+            subject="Sub",
+            body="Body",
+            account_id=None,
+            user_id="alice",
         )
         assert result["ok"] is True
 
@@ -66,7 +85,9 @@ class TestEmailTool:
         mock_service.send.return_value = {"ok": True, "message_id": None, "error": None}
 
         with patch("rex.openclaw.tools.email_tool._get_email_service", return_value=mock_service):
-            result = send_email("x@example.com", "S", "B", context={"location": "London"})
+            result = send_email(
+                "x@example.com", "S", "B", context={"location": "London"}, _user_id="alice"
+            )
 
         assert result["ok"] is True
 

--- a/tests/test_outlook_integration_honesty.py
+++ b/tests/test_outlook_integration_honesty.py
@@ -25,13 +25,15 @@ def test_config_loads_email_and_calendar_provider_selection() -> None:
 
 
 def test_email_bridge_reports_outlook_as_unsupported(monkeypatch) -> None:
+    import rex.config_manager
+
     monkeypatch.setattr(
-        rex.config,
+        rex.config_manager,
         "load_config",
-        lambda: SimpleNamespace(email_provider="outlook"),
+        lambda *a, **k: {"email": {"provider": "outlook"}},
     )
 
-    result = rex_email_bridge._handle_list(10)
+    result = rex_email_bridge._handle_list("default", 10)
 
     assert result["ok"] is False
     assert result["configured"] is True

--- a/tests/test_tool_router.py
+++ b/tests/test_tool_router.py
@@ -166,10 +166,17 @@ class TestSendEmail:
         with patch("rex.local_tool_executor.EmailService", return_value=mock_svc):
             result = execute_tool(
                 "send_email",
-                {"to": "alice@example.com", "subject": "Hi", "body": "Hello"},
+                {
+                    "to": "alice@example.com",
+                    "subject": "Hi",
+                    "body": "Hello",
+                    "_user_id": "default",
+                },
             )
         assert result == "Email sent"
-        mock_svc.send.assert_called_once_with(to="alice@example.com", subject="Hi", body="Hello")
+        mock_svc.send.assert_called_once_with(
+            to="alice@example.com", subject="Hi", body="Hello", user_id="default"
+        )
 
     def test_returns_error_string_on_failure(self):
         """EmailService.send() returning ok=False → error string."""
@@ -178,10 +185,26 @@ class TestSendEmail:
         with patch("rex.local_tool_executor.EmailService", return_value=mock_svc):
             result = execute_tool(
                 "send_email",
-                {"to": "alice@example.com", "subject": "Hi", "body": "Hello"},
+                {
+                    "to": "alice@example.com",
+                    "subject": "Hi",
+                    "body": "Hello",
+                    "_user_id": "default",
+                },
             )
         assert "[send_email error:" in result
         assert "Auth failed" in result
+
+    def test_missing_user_fails_closed(self):
+        """send_email without a requesting user is refused before service use."""
+        with patch("rex.local_tool_executor.EmailService") as svc_cls:
+            result = execute_tool(
+                "send_email",
+                {"to": "alice@example.com", "subject": "Hi", "body": "Hello"},
+            )
+        assert "[send_email error:" in result
+        assert "identity" in result.lower()
+        svc_cls.assert_not_called()
 
     def test_missing_to_returns_error(self):
         result = execute_tool("send_email", {"subject": "Hi", "body": "Hello"})
@@ -193,7 +216,10 @@ class TestSendEmail:
         with patch(
             "rex.local_tool_executor.EmailService", side_effect=RuntimeError("no connection")
         ):
-            result = execute_tool("send_email", {"to": "a@b.com", "subject": "s", "body": "b"})
+            result = execute_tool(
+                "send_email",
+                {"to": "a@b.com", "subject": "s", "body": "b", "_user_id": "default"},
+            )
         assert "[send_email error:" in result
         assert isinstance(result, str)
 
@@ -201,7 +227,7 @@ class TestSendEmail:
         mock_svc = MagicMock()
         mock_svc.send.return_value = {"ok": True, "message_id": None, "error": None}
         with patch("rex.local_tool_executor.EmailService", return_value=mock_svc):
-            execute_tool("send_email", {"to": "a@b.com", "body": "b"})
+            execute_tool("send_email", {"to": "a@b.com", "body": "b", "_user_id": "default"})
         call_kwargs = mock_svc.send.call_args.kwargs
         assert call_kwargs["subject"] == "(no subject)"
 

--- a/tests/test_us014_email_not_configured.py
+++ b/tests/test_us014_email_not_configured.py
@@ -62,13 +62,14 @@ def test_email_service_has_no_hardcoded_mock_data() -> None:
 
 
 def test_get_email_service_raises_when_not_configured() -> None:
-    """get_email_service() raises IntegrationNotConfiguredError when no credentials."""
+    """get_email_service() raises IntegrationNotConfiguredError when no accounts."""
+    import rex.config_manager as config_manager
     import rex.email_service as svc_mod
 
     original = svc_mod._email_service
     try:
         svc_mod._email_service = None
-        with patch.object(EmailService, "_resolve_backend_from_config", return_value=(None, None)):
+        with patch.object(config_manager, "load_config", return_value={}):
             with pytest.raises(IntegrationNotConfiguredError):
                 svc_mod.get_email_service()
     finally:
@@ -76,15 +77,19 @@ def test_get_email_service_raises_when_not_configured() -> None:
 
 
 def test_create_configured_raises_when_no_backend() -> None:
-    """_create_configured_email_service() raises when no backend resolved."""
-    with patch.object(EmailService, "_resolve_backend_from_config", return_value=(None, None)):
+    """_create_configured_email_service() raises when no accounts configured."""
+    import rex.config_manager as config_manager
+
+    with patch.object(config_manager, "load_config", return_value={}):
         with pytest.raises(IntegrationNotConfiguredError):
             _create_configured_email_service()
 
 
 def test_create_configured_error_message_mentions_email() -> None:
     """IntegrationNotConfiguredError message references email."""
-    with patch.object(EmailService, "_resolve_backend_from_config", return_value=(None, None)):
+    import rex.config_manager as config_manager
+
+    with patch.object(config_manager, "load_config", return_value={}):
         with pytest.raises(IntegrationNotConfiguredError, match="Email"):
             _create_configured_email_service()
 
@@ -95,28 +100,39 @@ def test_create_configured_error_message_mentions_email() -> None:
 
 
 def test_get_email_service_returns_service_when_configured() -> None:
-    """get_email_service() returns EmailService with a real backend when configured."""
+    """get_email_service() returns an owner-enforcing EmailService when configured."""
+    import rex.config_manager as config_manager
     import rex.email_service as svc_mod
 
-    mock_backend = MagicMock()
+    raw_config = {
+        "email": {
+            "default_account_id": "personal",
+            "accounts": [
+                {
+                    "id": "personal",
+                    "address": "you@example.com",
+                    "imap": {"host": "imap.example.com"},
+                    "smtp": {"host": "smtp.example.com"},
+                    "credential_ref": "email:personal",
+                }
+            ],
+        }
+    }
     original = svc_mod._email_service
     try:
         svc_mod._email_service = None
-        with patch.object(
-            EmailService,
-            "_resolve_backend_from_config",
-            return_value=(mock_backend, None),
-        ):
+        with patch.object(config_manager, "load_config", return_value=raw_config):
             service = svc_mod.get_email_service()
         assert service is not None
         assert isinstance(service, EmailService)
-        assert service.active_backend is mock_backend
+        # Backends are resolved lazily per user; nothing is pre-bound.
+        assert service.active_backend is None
     finally:
         svc_mod._email_service = original
 
 
 def test_configured_service_uses_real_backend_for_fetch() -> None:
-    """EmailService delegates fetch_unread to the configured backend."""
+    """EmailService delegates fetch_unread to the bound backend for its owner."""
     from datetime import UTC, datetime
 
     from rex.email_backends.base import EmailEnvelope
@@ -137,7 +153,7 @@ def test_configured_service_uses_real_backend_for_fetch() -> None:
     service = EmailService(backend=mock_backend)
     service.connected = True
 
-    results = service.fetch_unread(limit=5)
+    results = service.fetch_unread(limit=5, user_id="default")
     assert len(results) == 1
     assert results[0].id == "real-001"
     mock_backend.fetch_unread.assert_called_once_with(limit=5)


### PR DESCRIPTION
Closes the per-user email-account and credential-routing gap of #303 (does not close the issue; other gaps remain tracked there).

## Reproduced defects (locked in as tests that fail on master)

1. **Foreign account/credential routing** — `EmailService().send(user_id="james")` with no assigned accounts resolved the **global default account** and looked up its owner's credential ref (`tests/test_email_user_isolation.py::TestNoForeignAccountRouting`).
2. **Cross-user backend reuse** — after Alice's `fetch_unread`, the resolved backend was cached in `self._backend` and served **Bob's** `fetch_unread`, returning Alice's mail (`TestNoCrossUserBackendReuse::test_backend_resolved_for_alice_not_reused_for_bob`).

30 of the 33 initial isolation tests failed against the prior implementation (the 3 passers are behavior-preservation guards: same-user reuse, legacy default profile, secret hygiene).

## Ownership model

- New canonical resolver **`rex/email_accounts.py`** (`EmailAccountResolver`, `require_user_id`) shared by service, CLI, Electron bridge, OpenClaw tool, scheduler, notification channel, and GUI route.
- `email.accounts` = non-secret definitions; `users.{id}.email_accounts` = authoritative authorization map (entries must reference real definitions); `users.{id}.default_email_account_id` = per-user default.
- Identity validated via `rex.identity.validate_user_id`; missing/blank/malformed/traversal IDs fail closed **before** any account or credential lookup.
- Routing order (always inside the requester's authorized set): explicit account (ownership-validated) → user default → legacy global default (**explicit `default` profile only**) → first assigned account → fail closed / documented not-configured result.
- Unauthorized and nonexistent accounts raise the same generic `EmailAccountAccessError` message.

## Credential routing

- Credential lookup happens only after ownership validation, via `build_backend_for_account`, and only with the **authorized definition's own `credential_ref`** — a tampered per-user `credentials_key` cannot redirect it, and no public API accepts a credential reference (both pinned by tests).
- Backends cached per `(user_id, account_id)`; never reused across users. Stub inboxes are per-user copies (mark-read isolation).
- Resolver is invalidated when `config/rex_config.json` changes, so revoking an assignment takes effect in long-lived processes without restart (fresh-context review finding, fixed + tested).

## Legacy policy

- Unassigned `email.accounts`, `email.default_account_id`, and global `GMAIL_ACCESS_TOKEN` behavior belong **only** to the explicit `default` profile. Named users never inherit them and require explicit assignments (documented in `docs/email.md`). No credentials moved or rewritten; no automatic reassignment tooling.

## Surface changes

- **CLI** (`rex/commands/email_calendar.py`): every `rex email` subcommand resolves one validated user (`--user` on each subparser); missing identity fails closed with actionable text; `accounts list`/`test-connection` reveal only the user's own accounts; `set-active` validates ownership and writes only `users.{id}.default_email_account_id`.
- **Electron bridge** (`bridge/rex_email_bridge.py`): explicit `"user"` payload field or canonical identity chain, fail closed; per-user Gmail token via `create_email_service_for_user`; no credential material to the renderer.
- **GUI route** (`rex/routes/integrations.py` `/api/email/inbox`): same owner rules, 403 fail-closed without identity.
- **OpenClaw tool** (`rex/openclaw/tools/email_tool.py`): requires dispatcher `_user_id` before any service/credential access; optional `account_id` after ownership validation; audit log records user + account only. `local_tool_executor` send handler likewise.
- **Scheduler** (`rex/services.py`, `rex/integrations/_setup.py`): triage/check iterate configured owners, each in an isolated context; one owner's failure never falls through to another; legacy no-owner jobs stay default-profile/stub-only.
- **Events**: private fields only on `email.unread.user.<id>` / `email.triaged.user.<id>`; shared topics carry `{count, user_id, account_id}` envelopes. Notifier consumes the user-scoped topics.
- **Notification email channel** (`rex/notification.py`): requires `email_user_id` metadata (fail closed), passes owner through `send()`.

## Tests

- New `tests/test_email_user_isolation.py` (57 tests): foreign routing, backend reuse, identity fail-closed, allow-all removal, legacy policy, per-user defaults, credential-ref integrity, event scoping, scheduled-triage ownership, OpenClaw tool, Gmail per-user tokens, bridge identity, stub isolation, secret hygiene, revocation-without-restart, persistence.
- `tests/test_cli_email_accounts.py` rewritten user-scoped (17 tests incl. enumeration negatives).
- 12 existing test files updated to the owner-required API; 2 tests that encoded the allow-all/no-identity behavior now assert fail-closed.

## Local results (venv Python 3.11.9)

```
pytest tests/test_email_user_isolation.py -q                    → 57 passed
pytest tests/ -q -k "email or notification or bridge or tool_router or openclaw_tool or planner_tool or integration or scheduler or identity or isolation or cli"
                                                                → 2087 passed, 4 skipped
pytest tests/ -q                                                → 7582 passed, 1 failed*, 94 skipped
ruff check <changed files>                                      → All checks passed
black --check <changed files>                                   → clean
mypy rex --ignore-missing-imports                               → Success: no issues found in 336 source files
```
\* `test_us098_test_coverage.py::test_coverage_txt_exists` — known environmental failure in fresh worktrees (expects a locally generated `coverage.txt`); unrelated to this change.

## Fresh-context review

An independent reviewer inspected the full diff against the twelve-point checklist (enumeration, backend reuse, arbitrary credential lookup, unsafe fallbacks, bridge/CLI/tool bypasses, scheduled identity loss, event leakage, legacy reassignment, secret exposure, test adequacy). One substantive finding — stale resolver cache allowing a revoked assignment to keep working in long-lived processes — was fixed (config-stamp invalidation) and covered by `test_revoked_assignment_takes_effect_without_restart`. All other categories: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)