### PR TITLE
fix(calendar): enforce per-user account ownership and credential routing

### DIFF
--- a/bridge/rex_calendar_bridge.py
+++ b/bridge/rex_calendar_bridge.py
@@ -2,16 +2,37 @@
 
 Reads a JSON command from stdin and writes a JSON response to stdout.
 
+Every command operates on behalf of a resolved user identity (US-303
+per-user isolation):
+
+- An explicit ``"user"`` field in the payload takes precedence (it is
+  validated; malformed IDs fail closed).
+- Otherwise the active user is resolved through the standard identity
+  chain (``rex identify`` session state, then ``runtime.active_user`` /
+  ``runtime.user_id`` in ``config/rex_config.json``).
+- If no user can be resolved, the command fails closed with an error.
+  Single-user setups keep working by explicitly selecting the ``default``
+  profile (``rex identify --user default`` or ``"user": "default"``).
+
+Provider and credential selection is per user via
+``rex.calendar_accounts``: named users use only their own assigned calendar
+accounts and tokens; the legacy global provider configuration serves only
+the explicit ``default`` profile.
+
 Commands:
-  {"command": "list", "start": "<ISO>", "end": "<ISO>"}
+  {"command": "list", "user"?: "<user_id>", "start": "<ISO>", "end": "<ISO>"}
     -> {"ok": true, "events": [...], "configured": bool}
+
+  {"command": "create", "user"?: "<user_id>", "event": {...}}
+    -> {"ok": true, "event": {...}, "configured": bool}
 
 Event format (GUI):
   {id, title, start, end, location?, description?, attendees?, source,
    is_all_day}
 
-When no calendar provider is configured, returns {"ok": true, "events": [],
-"configured": false} so the GUI can show an empty-state prompt.
+When the resolved user has no calendar provider configured, returns
+{"ok": true, "events": [], "configured": false} so the GUI can show an
+empty-state prompt.
 """
 
 from __future__ import annotations
@@ -29,6 +50,33 @@ OUTLOOK_CALENDAR_UNSUPPORTED = (
     "Microsoft Graph OAuth token support is added."
 )
 
+_NO_USER_ERROR = (
+    "No active user for calendar. Set one with 'rex identify --user <id>' "
+    "or include a 'user' field in the request."
+)
+
+
+def _resolve_user(payload: dict[str, Any]) -> str | None:
+    """Resolve the requesting user, failing closed on missing/invalid identity.
+
+    Never falls back to ``"default"`` or any other profile implicitly.
+    """
+    from rex.identity import resolve_active_user
+
+    explicit = str(payload.get("user") or "").strip() or None
+    try:
+        config: dict[str, Any] | None
+        try:
+            from rex.config_manager import load_config
+
+            config = load_config()
+        except Exception:
+            config = None
+        return resolve_active_user(explicit, config=config)
+    except ValueError:
+        # Malformed explicit user ID: fail closed, no fallback.
+        return None
+
 
 def _event_to_gui(event: Any) -> dict[str, Any]:
     return {
@@ -44,13 +92,19 @@ def _event_to_gui(event: Any) -> dict[str, Any]:
     }
 
 
-def _handle_list(start_str: str, end_str: str) -> dict[str, Any]:
-    from rex.config import load_config
-    from rex.integrations.calendar_service import CalendarService
+def _service_for_user(user_id: str) -> tuple[Any, str]:
+    from rex.integrations.calendar_service import create_calendar_service_for_user
 
-    cfg = load_config()
-    provider = getattr(cfg, "calendar_provider", "none") or "none"
-    if str(provider).lower() == "outlook":
+    return create_calendar_service_for_user(user_id)
+
+
+def _handle_list(user_id: str, start_str: str, end_str: str) -> dict[str, Any]:
+    try:
+        svc, provider = _service_for_user(user_id)
+    except PermissionError:
+        return {"ok": False, "error": _NO_USER_ERROR, "events": [], "configured": False}
+
+    if provider == "outlook":
         return {
             "ok": False,
             "error": OUTLOOK_CALENDAR_UNSUPPORTED,
@@ -58,7 +112,8 @@ def _handle_list(start_str: str, end_str: str) -> dict[str, Any]:
             "configured": True,
         }
 
-    svc = CalendarService(calendar_provider=provider)
+    if svc is None:
+        return {"ok": True, "events": [], "configured": False}
 
     try:
         start = datetime.fromisoformat(start_str) if start_str else datetime.now(UTC)
@@ -68,33 +123,38 @@ def _handle_list(start_str: str, end_str: str) -> dict[str, Any]:
         end = start + timedelta(days=30)
 
     events = svc.get_events(start, end)
-    configured = provider != "none"
     return {
         "ok": True,
         "events": [_event_to_gui(e) for e in events],
-        "configured": configured,
+        "configured": True,
     }
 
 
-def _handle_create(event_data: dict[str, Any]) -> dict[str, Any]:
-    from rex.config import load_config
-    from rex.integrations.calendar_service import CalendarService
+def _handle_create(user_id: str, event_data: dict[str, Any]) -> dict[str, Any]:
+    try:
+        svc, provider = _service_for_user(user_id)
+    except PermissionError:
+        return {"ok": False, "error": _NO_USER_ERROR, "configured": False}
 
-    cfg = load_config()
-    provider = getattr(cfg, "calendar_provider", "none") or "none"
-    if str(provider).lower() == "outlook":
+    if provider == "outlook":
         return {
             "ok": False,
             "error": OUTLOOK_CALENDAR_UNSUPPORTED,
             "configured": True,
         }
 
-    svc = CalendarService(calendar_provider=provider)
+    if svc is None:
+        return {
+            "ok": False,
+            "error": "No calendar account is configured for this user.",
+            "configured": False,
+        }
+
     event = svc.create_event(event_data)
     return {
         "ok": True,
         "event": _event_to_gui(event),
-        "configured": provider != "none",
+        "configured": True,
     }
 
 
@@ -107,8 +167,17 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        if command == "list":
+        user_id = _resolve_user(payload)
+        if not user_id:
+            result: dict[str, Any] = {
+                "ok": False,
+                "error": _NO_USER_ERROR,
+                "events": [],
+                "configured": False,
+            }
+        elif command == "list":
             result = _handle_list(
+                user_id,
                 str(payload.get("start") or ""),
                 str(payload.get("end") or ""),
             )
@@ -117,7 +186,7 @@ def main() -> None:
             if not isinstance(raw_event, dict):
                 result = {"ok": False, "error": "Missing event payload."}
             else:
-                result = _handle_create(raw_event)
+                result = _handle_create(user_id, raw_event)
         else:
             result = {"ok": False, "error": f"Unknown command: {command!r}"}
     except Exception as exc:

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -49,6 +49,87 @@ class CalendarEvent(BaseModel):
     all_day: bool = False         # Whether this is an all-day event
 ```
 
+## Per-User Account Ownership (issue #303)
+
+Every calendar operation runs under **one explicit, validated user
+identity**.  Account authorization and routing are handled by
+`rex.calendar_accounts.CalendarAccountResolver`:
+
+- `calendar.accounts` in `config/rex_config.json` is the canonical
+  non-secret account list (provider, ICS source, `credential_ref` — an
+  environment-variable *name*, never a secret value).
+- `users.{user_id}.calendar_accounts` assigns account IDs to users.  A named
+  user can only ever use accounts explicitly assigned to them.
+- `users.{user_id}.default_calendar_account_id` selects that user's default
+  account (must reference an account the user owns).
+- Missing, blank, malformed, or traversal-style user IDs fail closed before
+  any account or credential lookup.
+- Unauthorized and nonexistent account IDs produce the same generic error,
+  so users cannot enumerate other users' accounts.
+- Backends and event stores are cached per `(user_id, account_id)`; a
+  backend created for one user is never reused for another.
+
+### Legacy policy
+
+The pre-#303 global configuration keeps working **for the explicit
+`default` profile only**:
+
+- `calendar.backend = "ics"` + `calendar.ics.source` is synthesized into a
+  reserved legacy account owned by the `default` profile.
+- `calendar.provider = "google"` + the `GOOGLE_CALENDAR_ACCESS_TOKEN`
+  environment variable serve only the `default` profile.
+- Named users (e.g. `james`, `cole`) are **never** automatically assigned to
+  legacy accounts or legacy environment tokens — not even via an explicit
+  `users.{user}.calendar_accounts` entry pointing at a legacy account ID.
+
+### Assigning calendar accounts to named users
+
+Administrators assign accounts explicitly in `config/rex_config.json`:
+
+```json
+{
+  "calendar": {
+    "accounts": [
+      {
+        "id": "james-work",
+        "label": "James work calendar",
+        "provider": "ics",
+        "ics": {"source": "https://example.com/james.ics", "url_timeout": 15}
+      },
+      {
+        "id": "cole-google",
+        "label": "Cole Google calendar",
+        "provider": "google",
+        "credential_ref": "GOOGLE_CALENDAR_TOKEN_COLE"
+      }
+    ]
+  },
+  "users": {
+    "james": {
+      "calendar_accounts": [{"account_id": "james-work"}],
+      "default_calendar_account_id": "james-work"
+    },
+    "cole": {
+      "calendar_accounts": [{"account_id": "cole-google"}]
+    }
+  }
+}
+```
+
+For provider accounts (`google`), put the token itself in `.env` under the
+variable named by `credential_ref` (e.g. `GOOGLE_CALENDAR_TOKEN_COLE=...`).
+Credential *references* are config; credential *values* are secrets and
+belong in `.env` only.  CLI output, API responses, events, and error
+messages never echo credential references or token values.
+
+Routing order for a request by user U:
+
+1. Explicit account ID (after ownership validation)
+2. `users.U.default_calendar_account_id`
+3. Legacy global default — `default` profile only
+4. First account assigned to U (config order)
+5. Fail closed: not-configured result (never another user's account)
+
 ## Using the Calendar Service
 
 ### Getting the Calendar Service Instance
@@ -62,8 +143,8 @@ calendar_service = get_calendar_service()
 ### Connecting to Calendar
 
 ```python
-# Connect (loads credentials and initializes)
-if calendar_service.connect():
+# Connect for one validated user (loads that user's events)
+if calendar_service.connect(user_id="james"):
     print("Connected to calendar service")
 else:
     print("Failed to connect")
@@ -76,10 +157,10 @@ else:
 ```python
 from datetime import datetime, timedelta
 
-# Get events for the next 7 days
+# Get events for the next 7 days (requesting user's own events only)
 start = datetime.now()
 end = start + timedelta(days=7)
-events = calendar_service.get_events(start, end)
+events = calendar_service.get_events(start, end, user_id="james")
 
 for event in events:
     print(f"{event.title}: {event.start_time}")
@@ -89,10 +170,10 @@ for event in events:
 
 ```python
 # Get events in the next 7 days
-events = calendar_service.get_upcoming_events(days=7)
+events = calendar_service.get_upcoming_events(days=7, user_id="james")
 
 # Get events in the next 14 days
-events = calendar_service.get_upcoming_events(days=14)
+events = calendar_service.get_upcoming_events(days=14, user_id="james")
 ```
 
 ### Creating Events
@@ -164,9 +245,14 @@ if event1.overlaps_with(event2):
 
 ## CLI Commands
 
+Every calendar subcommand resolves one validated user (from `--user`, the
+`rex identify` session, or `runtime.active_user`) and fails closed with an
+actionable message when no user can be resolved.  Single-user setups select
+the legacy profile explicitly: `rex identify --user default`.
+
 ### Show Upcoming Events
 
-Display upcoming calendar events:
+Display upcoming calendar events for the resolved user only:
 
 ```bash
 rex calendar upcoming
@@ -176,12 +262,27 @@ rex calendar upcoming -v                 # Verbose with descriptions
 rex calendar upcoming --user cole        # Override active user context
 ```
 
-### Test Backend Connection
+### Manage Calendar Accounts
 
-Verify the configured calendar backend:
+List the resolved user's own accounts (never another user's) and set the
+per-user default:
+
+```bash
+rex calendar accounts list --user james
+rex calendar accounts set-active --account-id james-work --user james
+```
+
+`set-active` writes only `users.james.default_calendar_account_id`; it
+never modifies another user's routing or the legacy global default.
+
+### Test Account Connection
+
+Verify the resolved user's own calendar account (foreign accounts cannot be
+tested):
 
 ```bash
 rex calendar test-connection
+rex calendar test-connection --account-id james-work --user james
 ```
 
 ## Configuration
@@ -279,8 +380,15 @@ initialize_scheduler_system(start_scheduler=True)
 
 This creates a job that:
 - Runs every hour (configurable)
-- Fetches upcoming events (next 7 days)
-- Publishes a `calendar.update` event
+- Iterates configured calendar owners; each owner runs in an isolated
+  context (one owner's failure never falls through to another's account)
+- Fetches upcoming events (next 7 days) per owner
+- Publishes a **safe envelope** (`{count, user_id}`) on the shared
+  `calendar.update` topic and the full event payload only on the
+  owner-scoped `calendar.update.user.<user_id>` topic
+
+Private event fields (titles, attendees, locations, descriptions,
+conferencing links) are never published on shared topics.
 
 ## Event Integration
 
@@ -292,7 +400,10 @@ from rex.event_bus import get_event_bus
 event_bus = get_event_bus()
 
 def handle_calendar_update(event):
-    events = event.payload['events']
+    # Full payloads are published only on the owner-scoped topic
+    # calendar.update.user.<user_id>; the shared calendar.update topic
+    # carries a safe envelope ({count, user_id}) without event details.
+    events = event.payload.get('events', [])
     print(f"Calendar updated: {len(events)} upcoming events")
 
     # Check for events today
@@ -352,13 +463,13 @@ print("Daily agenda system active")
 from rex.calendar_service import get_calendar_service
 
 calendar_service = get_calendar_service()
-calendar_service.connect()
+calendar_service.connect(user_id="james")
 
 # Get upcoming events
-events = calendar_service.get_upcoming_events(days=7)
+events = calendar_service.get_upcoming_events(days=7, user_id="james")
 
 # Check for conflicts
-conflicts = calendar_service.find_conflicts(events)
+conflicts = calendar_service.find_conflicts(events, user_id="james")
 
 if conflicts:
     print(f"⚠️  Warning: {len(conflicts)} scheduling conflict(s) detected!")
@@ -377,12 +488,12 @@ from datetime import datetime, timedelta
 from rex.calendar_service import get_calendar_service
 
 calendar_service = get_calendar_service()
-calendar_service.connect()
+calendar_service.connect(user_id="james")
 
 # Get events in the next hour
 now = datetime.now()
 soon = now + timedelta(hours=1)
-upcoming = calendar_service.get_events(now, soon)
+upcoming = calendar_service.get_events(now, soon, user_id="james")
 
 for event in upcoming:
     # Send reminder for meetings with multiple attendees

--- a/rex/calendar_accounts.py
+++ b/rex/calendar_accounts.py
@@ -1,0 +1,534 @@
+"""Canonical per-user calendar account authorization and routing (issue #303).
+
+This module is the single source of truth for deciding **which calendar
+accounts a user may touch** and **which account serves a request**.  Every
+real calendar surface (service, CLI, GUI/API routes, Electron bridge,
+OpenClaw tools, local tool executor, scheduler) must route account selection
+through :class:`CalendarAccountResolver`.
+
+Ownership model
+---------------
+- ``calendar.accounts`` in ``config/rex_config.json`` is the canonical
+  non-secret account-definition list (provider, ICS source,
+  ``credential_ref`` — an environment-variable *name*, never a secret value).
+- ``users.{user_id}.calendar_accounts`` is the authoritative authorization
+  map assigning account IDs to users.
+- ``users.{user_id}.default_calendar_account_id`` selects that user's
+  default account.  It must reference an account the user owns; a foreign or
+  unknown default is ignored (fail closed to the user's own fallback).
+- ``calendar.accounts`` entries not assigned to any user belong **only** to
+  the distinct ``default`` profile.  They are never shared with or silently
+  reassigned to named users.
+- The legacy global calendar configuration (``calendar.backend``/
+  ``calendar.ics`` and ``calendar.provider`` with its global environment
+  token) is synthesized into reserved legacy accounts that belong only to
+  the ``default`` profile.  Named users can never use them — not even via an
+  explicit assignment — so legacy global credentials are usable only by the
+  explicit ``default`` profile.
+- Legacy ``calendar.default_account_id`` applies only to the ``default``
+  profile.
+
+Routing order (always within the requesting user's authorized set):
+
+1. Explicit requested account ID (after ownership validation).
+2. The user's configured default account.
+3. Legacy global default — only for the explicit ``default`` profile.
+4. The first account assigned to the user (deterministic, config order).
+5. Otherwise: no account (callers fail closed / report not-configured).
+
+Unauthorized and nonexistent accounts are indistinguishable to callers:
+both raise :class:`CalendarAccountAccessError` with the same generic
+message.  Credential lookup happens only *after* ownership validation and
+only with the authorized account definition's own ``credential_ref``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rex.identity import validate_user_id
+
+logger = logging.getLogger(__name__)
+
+#: Runtime config file backing the authorization map.
+_CONFIG_PATH = Path("config/rex_config.json")
+
+
+def config_stamp() -> int | None:
+    """Modification stamp of the runtime config file.
+
+    Used by long-lived services to invalidate cached resolvers so that
+    revoking or reassigning a user's calendar accounts takes effect without
+    a process restart.
+    """
+    try:
+        return _CONFIG_PATH.stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+#: The distinct legacy single-user profile.  Legacy global calendar
+#: configuration and the legacy global default belong to this profile only.
+DEFAULT_PROFILE = "default"
+
+#: Reserved IDs for accounts synthesized from the legacy global calendar
+#: configuration.  These are never available to named users.
+LEGACY_ICS_ACCOUNT_ID = "legacy-ics"
+LEGACY_PROVIDER_ACCOUNT_PREFIX = "legacy-provider-"
+_LEGACY_GOOGLE_TOKEN_ENV = "GOOGLE_CALENDAR_ACCESS_TOKEN"
+
+#: Generic message for unauthorized-or-nonexistent accounts.  Must not vary
+#: with account existence so callers cannot enumerate other users' accounts.
+ACCOUNT_UNAVAILABLE_MSG = "Calendar account {account_id!r} is not available for user {user_id!r}"
+
+_IDENTITY_REQUIRED_MSG = (
+    "Calendar operations require an explicit valid user identity; "
+    "refusing to fall back to a default or shared account"
+)
+
+
+class CalendarAccountAccessError(PermissionError):
+    """The requested account is not available to the requesting user.
+
+    Raised both for accounts owned by another user and for accounts that do
+    not exist, with an identical message shape, so the two cases cannot be
+    distinguished by the caller.
+    """
+
+
+class CalendarIdentityError(PermissionError):
+    """A real calendar operation was attempted without a valid user identity."""
+
+
+def require_user_id(user_id: object) -> str:
+    """Validate *user_id* for calendar operations, failing closed.
+
+    Returns:
+        The validated user ID.
+
+    Raises:
+        CalendarIdentityError: If *user_id* is missing, blank, malformed, or
+            traversal-style.  Raised before any account or credential lookup.
+    """
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise CalendarIdentityError(_IDENTITY_REQUIRED_MSG)
+    try:
+        return validate_user_id(user_id)
+    except ValueError as exc:
+        raise CalendarIdentityError(_IDENTITY_REQUIRED_MSG) from exc
+
+
+@dataclass(frozen=True)
+class CalendarAccountDefinition:
+    """Canonical non-secret calendar account definition.
+
+    ``credential_ref`` names the environment variable (or credential-store
+    key) that holds this account's token.  It is a *reference*, never the
+    secret itself, and must not be echoed to CLI output, API responses,
+    events, or error messages.
+    """
+
+    id: str
+    label: str = ""
+    provider: str = "ics"  # "ics" | "google" | "outlook" | "stub"
+    credential_ref: str = ""
+    ics_source: str = ""
+    ics_url_timeout: int = 15
+    legacy: bool = False  # synthesized from legacy global config
+
+
+def _parse_account_definition(raw: dict[str, Any]) -> CalendarAccountDefinition | None:
+    account_id = str(raw.get("id") or "").strip()
+    if not account_id:
+        return None
+    ics_raw = raw.get("ics")
+    ics_cfg = ics_raw if isinstance(ics_raw, dict) else {}
+    try:
+        url_timeout = int(ics_cfg.get("url_timeout", 15))
+    except (TypeError, ValueError):
+        url_timeout = 15
+    return CalendarAccountDefinition(
+        id=account_id,
+        label=str(raw.get("label") or ""),
+        provider=str(raw.get("provider") or "ics").strip().lower(),
+        credential_ref=str(raw.get("credential_ref") or ""),
+        ics_source=str(ics_cfg.get("source") or raw.get("ics_source") or ""),
+        ics_url_timeout=url_timeout,
+        legacy=False,
+    )
+
+
+def _synthesize_legacy_accounts(
+    calendar_section: dict[str, Any],
+) -> list[CalendarAccountDefinition]:
+    """Build reserved legacy accounts from the pre-#303 global configuration.
+
+    These represent the single-user global calendar setup (``backend: ics``
+    and/or ``provider: google``) and belong only to the ``default`` profile.
+    """
+    legacy: list[CalendarAccountDefinition] = []
+
+    backend = str(calendar_section.get("backend") or "").strip().lower()
+    ics_raw = calendar_section.get("ics")
+    ics_cfg = ics_raw if isinstance(ics_raw, dict) else {}
+    source = str(ics_cfg.get("source") or "")
+    if backend == "ics" and source:
+        try:
+            url_timeout = int(ics_cfg.get("url_timeout", 15))
+        except (TypeError, ValueError):
+            url_timeout = 15
+        legacy.append(
+            CalendarAccountDefinition(
+                id=LEGACY_ICS_ACCOUNT_ID,
+                label="Legacy ICS calendar",
+                provider="ics",
+                ics_source=source,
+                ics_url_timeout=url_timeout,
+                legacy=True,
+            )
+        )
+
+    provider = str(calendar_section.get("provider") or "").strip().lower()
+    if provider == "gmail":
+        provider = "google"
+    if provider in ("google", "outlook"):
+        legacy.append(
+            CalendarAccountDefinition(
+                id=f"{LEGACY_PROVIDER_ACCOUNT_PREFIX}{provider}",
+                label=f"Legacy {provider} calendar",
+                provider=provider,
+                credential_ref=_LEGACY_GOOGLE_TOKEN_ENV if provider == "google" else "",
+                legacy=True,
+            )
+        )
+
+    return legacy
+
+
+def _parse_user_assignments(users_block: object) -> dict[str, list[str]]:
+    """Parse ``users.{user_id}.calendar_accounts`` into ``{user_id: [account_id]}``.
+
+    Accepts entries as ``{"account_id": "..."}`` dicts or bare strings.
+    """
+    result: dict[str, list[str]] = {}
+    if not isinstance(users_block, dict):
+        return result
+    for user_id, user_data in users_block.items():
+        if not isinstance(user_data, dict):
+            continue
+        raw_accounts = user_data.get("calendar_accounts", [])
+        if not isinstance(raw_accounts, list):
+            continue
+        parsed: list[str] = []
+        for entry in raw_accounts:
+            if isinstance(entry, str) and entry.strip():
+                parsed.append(entry.strip())
+            elif isinstance(entry, dict):
+                account_id = str(entry.get("account_id") or "").strip()
+                if account_id:
+                    parsed.append(account_id)
+        if parsed:
+            result[str(user_id)] = parsed
+    return result
+
+
+def _parse_user_defaults(users_block: object) -> dict[str, str]:
+    """Parse ``users.{user_id}.default_calendar_account_id`` into a per-user map."""
+    result: dict[str, str] = {}
+    if not isinstance(users_block, dict):
+        return result
+    for user_id, user_data in users_block.items():
+        if not isinstance(user_data, dict):
+            continue
+        default_id = user_data.get("default_calendar_account_id")
+        if isinstance(default_id, str) and default_id.strip():
+            result[str(user_id)] = default_id.strip()
+    return result
+
+
+class CalendarAccountResolver:
+    """Authorization and routing for per-user calendar accounts.
+
+    Args:
+        accounts:        Canonical explicit account definitions.
+        legacy_accounts: Accounts synthesized from the legacy global config
+                         (``default`` profile only).
+        user_accounts:   ``{user_id: [account_id, ...]}`` authorization map.
+        user_defaults:   ``{user_id: account_id}`` per-user default selection.
+        legacy_default_account_id: Legacy global ``calendar.default_account_id``
+                         (``default`` profile only).
+    """
+
+    def __init__(
+        self,
+        accounts: list[CalendarAccountDefinition] | None = None,
+        legacy_accounts: list[CalendarAccountDefinition] | None = None,
+        user_accounts: dict[str, list[str]] | None = None,
+        user_defaults: dict[str, str] | None = None,
+        legacy_default_account_id: str | None = None,
+    ) -> None:
+        self._accounts: list[CalendarAccountDefinition] = list(accounts or [])
+        self._legacy_accounts: list[CalendarAccountDefinition] = list(legacy_accounts or [])
+        self._user_accounts: dict[str, list[str]] = dict(user_accounts or {})
+        self._user_defaults: dict[str, str] = dict(user_defaults or {})
+        self._legacy_default_account_id = legacy_default_account_id
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_raw_config(cls, raw_config: dict[str, Any] | None) -> CalendarAccountResolver:
+        """Build a resolver from the merged runtime config dict."""
+        raw = raw_config or {}
+        calendar_section = raw.get("calendar")
+        if not isinstance(calendar_section, dict):
+            calendar_section = {}
+
+        accounts: list[CalendarAccountDefinition] = []
+        accounts_raw = calendar_section.get("accounts")
+        if isinstance(accounts_raw, list):
+            for item in accounts_raw:
+                if not isinstance(item, dict):
+                    continue
+                definition = _parse_account_definition(item)
+                if definition is None:
+                    logger.warning("Skipping malformed calendar account entry (missing id)")
+                    continue
+                accounts.append(definition)
+
+        legacy_accounts = _synthesize_legacy_accounts(calendar_section)
+
+        users_block = raw.get("users")
+        user_accounts = _parse_user_assignments(users_block)
+        user_defaults = _parse_user_defaults(users_block)
+
+        legacy_default = calendar_section.get("default_account_id")
+        legacy_default_id = (
+            legacy_default.strip()
+            if isinstance(legacy_default, str) and legacy_default.strip()
+            else None
+        )
+
+        return cls(
+            accounts=accounts,
+            legacy_accounts=legacy_accounts,
+            user_accounts=user_accounts,
+            user_defaults=user_defaults,
+            legacy_default_account_id=legacy_default_id,
+        )
+
+    @classmethod
+    def load(cls) -> CalendarAccountResolver:
+        """Build a resolver from ``config/rex_config.json``."""
+        from rex.config_manager import load_config
+
+        try:
+            raw = load_config()
+        except Exception as exc:
+            logger.warning("Failed to load config for calendar account resolution: %s", exc)
+            raw = {}
+        return cls.from_raw_config(raw)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def has_configured_accounts(self) -> bool:
+        """True when any real account definition exists (explicit or legacy)."""
+        return bool(self._accounts or self._legacy_accounts)
+
+    def get_account_definition(self, account_id: str) -> CalendarAccountDefinition | None:
+        """Return the canonical account definition for *account_id*, if any.
+
+        This is an internal lookup used *after* ownership authorization;
+        surfaces must never expose foreign definitions obtained here.
+        """
+        for acct in self._accounts:
+            if acct.id == account_id:
+                return acct
+        for acct in self._legacy_accounts:
+            if acct.id == account_id:
+                return acct
+        return None
+
+    # ------------------------------------------------------------------
+    # Authorization
+    # ------------------------------------------------------------------
+
+    def account_ids_for_user(self, user_id: str) -> list[str]:
+        """Return the account IDs authorized for *user_id* (deterministic order).
+
+        Named users get only their explicit assignments, restricted to
+        accounts that actually exist in ``calendar.accounts``.  Legacy
+        synthesized accounts are excluded for named users even when a config
+        entry tries to assign one (legacy global credentials are usable only
+        by the ``default`` profile).
+
+        The ``default`` profile additionally receives every explicit account
+        no user has claimed, plus the legacy synthesized accounts.
+        """
+        validated = require_user_id(user_id)
+        explicit_ids = [acct.id for acct in self._accounts]
+        legacy_ids = [acct.id for acct in self._legacy_accounts]
+
+        owned: list[str] = []
+        for account_id in self._user_accounts.get(validated, []):
+            if account_id in legacy_ids:
+                logger.warning(
+                    "Ignoring assignment of legacy calendar account to user %r: "
+                    "legacy global calendar configuration is restricted to the "
+                    "'default' profile",
+                    validated,
+                )
+                continue
+            if account_id in explicit_ids and account_id not in owned:
+                owned.append(account_id)
+
+        if validated == DEFAULT_PROFILE:
+            assigned = {account_id for ids in self._user_accounts.values() for account_id in ids}
+            for account_id in explicit_ids:
+                if account_id not in assigned and account_id not in owned:
+                    owned.append(account_id)
+            for account_id in legacy_ids:
+                if account_id not in owned:
+                    owned.append(account_id)
+        return owned
+
+    def accounts_for_user(self, user_id: str) -> list[CalendarAccountDefinition]:
+        """Return the canonical account definitions authorized for *user_id*."""
+        definitions = []
+        for account_id in self.account_ids_for_user(user_id):
+            definition = self.get_account_definition(account_id)
+            if definition is not None:
+                definitions.append(definition)
+        return definitions
+
+    def configured_user_ids(self) -> list[str]:
+        """Return the users with at least one authorized account.
+
+        Only valid user IDs are returned (invalid persisted IDs are skipped,
+        fail closed).  The ``default`` profile is included when unassigned or
+        legacy accounts exist.  Order is deterministic.
+        """
+        ids: list[str] = []
+        for user_id in self._user_accounts:
+            try:
+                validated = require_user_id(user_id)
+            except CalendarIdentityError:
+                logger.warning("Skipping calendar accounts assigned to an invalid user ID")
+                continue
+            if validated not in ids and self.account_ids_for_user(validated):
+                ids.append(validated)
+        if DEFAULT_PROFILE not in ids and self.account_ids_for_user(DEFAULT_PROFILE):
+            ids.append(DEFAULT_PROFILE)
+        return ids
+
+    def is_account_authorized(self, user_id: str, account_id: str) -> bool:
+        return account_id in self.account_ids_for_user(user_id)
+
+    def check_account_access(self, user_id: str, account_id: str) -> None:
+        """Raise :class:`CalendarAccountAccessError` unless *user_id* owns *account_id*."""
+        validated = require_user_id(user_id)
+        if not self.is_account_authorized(validated, account_id):
+            raise CalendarAccountAccessError(
+                ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
+            )
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+
+    def default_account_id_for_user(self, user_id: str) -> str | None:
+        """Return the user's effective default account ID, or ``None``.
+
+        A configured default that the user does not own is ignored (fail
+        closed) rather than granting access or aborting.
+        """
+        validated = require_user_id(user_id)
+        owned = self.account_ids_for_user(validated)
+        configured = self._user_defaults.get(validated)
+        if configured:
+            if configured in owned:
+                return configured
+            logger.warning(
+                "Ignoring default calendar account for user %r: not owned by that user",
+                validated,
+            )
+        if validated == DEFAULT_PROFILE:
+            legacy = self._legacy_default_account_id
+            if legacy and legacy in owned:
+                return legacy
+        return None
+
+    def resolve_account_id(self, user_id: str, account_id: str | None = None) -> str | None:
+        """Resolve the account that serves a request for *user_id*.
+
+        Returns:
+            The resolved account ID, or ``None`` when the user has no
+            authorized accounts (callers fail closed or report
+            not-configured).
+
+        Raises:
+            CalendarIdentityError: On missing/invalid identity.
+            CalendarAccountAccessError: When *account_id* is explicitly
+                requested but is not available to this user (unauthorized or
+                nonexistent — indistinguishable).
+        """
+        validated = require_user_id(user_id)
+        owned = self.account_ids_for_user(validated)
+
+        if account_id:
+            if account_id not in owned:
+                raise CalendarAccountAccessError(
+                    ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
+                )
+            return account_id
+
+        default_id = self.default_account_id_for_user(validated)
+        if default_id:
+            return default_id
+
+        return owned[0] if owned else None
+
+    def resolve_account(
+        self, user_id: str, account_id: str | None = None
+    ) -> CalendarAccountDefinition | None:
+        """Resolve the canonical account definition serving a request.
+
+        Same contract as :meth:`resolve_account_id`, but returns the account
+        definition.
+        """
+        resolved_id = self.resolve_account_id(user_id, account_id)
+        if resolved_id is None:
+            return None
+        return self.get_account_definition(resolved_id)
+
+    def provider_account_for_user(self, user_id: str) -> CalendarAccountDefinition | None:
+        """Return the user's first OAuth-provider (google/outlook) account.
+
+        Used by the GUI/bridge calendar surfaces, which speak the provider
+        API rather than ICS.  Ownership is enforced by
+        :meth:`accounts_for_user`.
+        """
+        for definition in self.accounts_for_user(user_id):
+            if definition.provider in ("google", "outlook"):
+                return definition
+        return None
+
+
+__all__ = [
+    "ACCOUNT_UNAVAILABLE_MSG",
+    "DEFAULT_PROFILE",
+    "LEGACY_ICS_ACCOUNT_ID",
+    "LEGACY_PROVIDER_ACCOUNT_PREFIX",
+    "CalendarAccountAccessError",
+    "CalendarAccountDefinition",
+    "CalendarAccountResolver",
+    "CalendarIdentityError",
+    "config_stamp",
+    "require_user_id",
+]

--- a/rex/calendar_backends/stub.py
+++ b/rex/calendar_backends/stub.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from rex.calendar_accounts import DEFAULT_PROFILE
 from rex.calendar_backends.base import CalendarBackend
 from rex.calendar_service import CalendarEvent, CalendarService
 
 
 class StubCalendarBackend(CalendarBackend):
-    """Read events from the existing JSON mock store."""
+    """Read events from the existing JSON mock store.
+
+    This legacy backend serves the single-user global configuration, which
+    belongs to the explicit ``default`` profile only (issue #303).
+    """
 
     def __init__(
         self,
@@ -25,16 +30,17 @@ class StubCalendarBackend(CalendarBackend):
         self._inner = CalendarService(
             mock_data_path=mock_data_path,
             mock_events=mock_events,
+            owner_user_id=DEFAULT_PROFILE,
         )
         self._connected = False
 
     def connect(self) -> bool:
-        ok = self._inner.connect()
+        ok = self._inner.connect(user_id=DEFAULT_PROFILE)
         self._connected = ok
         return ok
 
     def fetch_events(self) -> list[CalendarEvent]:
-        return self._inner.get_all_events()
+        return self._inner.get_all_events(user_id=DEFAULT_PROFILE)
 
     def disconnect(self) -> None:
         self._connected = False

--- a/rex/calendar_service.py
+++ b/rex/calendar_service.py
@@ -268,51 +268,14 @@ class CalendarService:
 
         # In-memory / explicit-path modes are bound to exactly one owner.
         if self._mock_events is not None or self._mock_data_path is not None:
-            if account_id:
-                # No configured accounts exist in these modes; unauthorized
-                # and nonexistent are indistinguishable.
-                raise CalendarAccountAccessError(
-                    ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
-                )
-            key = (validated, "")
-            store = self._stores.get(key)
-            if store is None:
-                if validated == self._owner:
-                    if self._mock_events is not None:
-                        store = _EventStore(list(self._mock_events), None, None)
-                    else:
-                        events: list[CalendarEvent] = []
-                        assert self._mock_data_path is not None
-                        if self._mock_data_path.exists():
-                            try:
-                                events = self._load_mock_events(self._mock_data_path)
-                            except Exception as exc:
-                                logger.warning(
-                                    "Failed to load calendar data from %s: %s",
-                                    self._mock_data_path,
-                                    exc,
-                                )
-                        store = _EventStore(events, self._mock_data_path, None)
-                else:
-                    # Isolated empty in-memory store for any other user.
-                    store = _EventStore([], None, None)
-                self._stores[key] = store
-            return store
+            self._reject_explicit_account(validated, account_id)
+            return self._owner_bound_store(validated)
 
         resolver = self._get_resolver()
         if not resolver.has_configured_accounts():
             # Pure stub mode: isolated per-user disk store.
-            if account_id:
-                raise CalendarAccountAccessError(
-                    ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
-                )
-            key = (validated, "")
-            store = self._stores.get(key)
-            if store is None:
-                events, storage_path = self._seeded_stub_events(validated)
-                store = _EventStore(events, storage_path, None)
-                self._stores[key] = store
-            return store
+            self._reject_explicit_account(validated, account_id)
+            return self._stub_disk_store(validated, None)
 
         # Accounts are configured: ownership check before anything else.
         definition = resolver.resolve_account(validated, account_id)
@@ -323,22 +286,69 @@ class CalendarService:
         if definition.provider == "ics":
             return self._ics_store(validated, definition)
         if definition.provider == "stub":
-            key = (validated, definition.id)
-            store = self._stores.get(key)
-            if store is None:
-                events, storage_path = self._seeded_stub_events(validated)
-                store = _EventStore(events, storage_path, definition.id)
-                self._stores[key] = store
-            return store
+            return self._stub_disk_store(validated, definition.id)
 
         # google/outlook accounts are served by the provider-API surface
         # (rex.integrations.calendar_service), not this store-backed service.
         logger.warning(
-            "Calendar account for user %r uses provider %r, which this surface " "does not serve",
+            "Calendar account for user %r uses provider %r, which this surface does not serve",
             validated,
             definition.provider,
         )
         return None
+
+    @staticmethod
+    def _reject_explicit_account(validated: str, account_id: str | None) -> None:
+        """Reject explicit account selection where no accounts exist.
+
+        Unauthorized and nonexistent accounts are indistinguishable.
+        """
+        if account_id:
+            raise CalendarAccountAccessError(
+                ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
+            )
+
+    def _owner_bound_store(self, validated: str) -> _EventStore:
+        """Store for in-memory / explicit-path modes (owner-bound).
+
+        The configured owner gets the injected events or path; any other
+        user gets an isolated empty in-memory store.
+        """
+        key = (validated, "")
+        store = self._stores.get(key)
+        if store is not None:
+            return store
+
+        if validated != self._owner:
+            # Isolated empty in-memory store for any other user.
+            store = _EventStore([], None, None)
+        elif self._mock_events is not None:
+            store = _EventStore(list(self._mock_events), None, None)
+        else:
+            events: list[CalendarEvent] = []
+            assert self._mock_data_path is not None
+            if self._mock_data_path.exists():
+                try:
+                    events = self._load_mock_events(self._mock_data_path)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to load calendar data from %s: %s",
+                        self._mock_data_path,
+                        exc,
+                    )
+            store = _EventStore(events, self._mock_data_path, None)
+        self._stores[key] = store
+        return store
+
+    def _stub_disk_store(self, validated: str, account_id: str | None) -> _EventStore:
+        """The user's isolated, disk-backed stub store."""
+        key = (validated, account_id or "")
+        store = self._stores.get(key)
+        if store is None:
+            events, storage_path = self._seeded_stub_events(validated)
+            store = _EventStore(events, storage_path, account_id)
+            self._stores[key] = store
+        return store
 
     def _ics_store(self, user_id: str, definition: CalendarAccountDefinition) -> _EventStore | None:
         """Return the user's store seeded from their authorized ICS source."""

--- a/rex/calendar_service.py
+++ b/rex/calendar_service.py
@@ -1,8 +1,25 @@
 """
 Calendar service module for Rex AI Assistant.
 
-Provides calendar integration with read/write capabilities using mock data.
-A real calendar API integration (Google Calendar, Outlook, etc.) can be added later.
+Provides calendar integration with read/write capabilities using per-user
+stores (stub/mock data or an ICS backend resolved per authorized account).
+
+Per-user isolation (issue #303):
+- Every operation that reads or mutates calendar data requires an explicit,
+  validated ``user_id``.  Missing, blank, malformed, or traversal-style
+  identities fail closed (``CalendarIdentityError``) before any account or
+  credential lookup.
+- Account selection is restricted to the requesting user's authorized
+  accounts via :class:`rex.calendar_accounts.CalendarAccountResolver`;
+  explicit foreign or nonexistent accounts raise the generic
+  ``CalendarAccountAccessError`` (indistinguishable to the caller).
+- Backends are cached per ``(user_id, account_id)``; a backend resolved for
+  one user is never reused for another.
+- Stub/mock mode keeps a separate mutable event store per user so one
+  user's create/update/delete never alters another user's view.
+- Private event fields (titles, attendees, locations, descriptions) are
+  published only on user-scoped topics (``{topic}.user.{user_id}``); shared
+  topics carry a safe envelope (user_id, count, success) only.
 """
 
 from __future__ import annotations
@@ -18,24 +35,38 @@ from pathlib import Path
 from typing import Any
 
 from rex.assistant_errors import IntegrationNotConfiguredError
+from rex.calendar_accounts import (
+    ACCOUNT_UNAVAILABLE_MSG,
+    DEFAULT_PROFILE,
+    CalendarAccountAccessError,
+    CalendarAccountDefinition,
+    CalendarAccountResolver,
+    require_user_id,
+)
 from rex.openclaw.event_bus import EventBus
 
 logger = logging.getLogger(__name__)
 
 _REPO_SEED_PATH = Path("data/mock_calendar.json")
 
+_NOT_CONFIGURED_FOR_USER_MSG = "Calendar: not configured"
 
-def _runtime_calendar_path() -> Path:
-    """Return a writable runtime path for calendar persistence.
+
+def _runtime_calendar_path(user_id: str) -> Path:
+    """Return a writable per-user runtime path for calendar persistence.
 
     Uses OS-appropriate app data directories so the repo's
-    data/mock_calendar.json is never modified at runtime.
+    data/mock_calendar.json is never modified at runtime.  The legacy
+    single-user file (``rex-ai/calendar.json``) is preserved for the
+    ``default`` profile only; named users get isolated per-user files.
     """
     if os.name == "nt":
         base = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local")))
     else:
         base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
-    return base / "rex-ai" / "calendar.json"
+    if user_id == DEFAULT_PROFILE:
+        return base / "rex-ai" / "calendar.json"
+    return base / "rex-ai" / "calendar" / f"{user_id}.json"
 
 
 class _NoOpEventBus:
@@ -116,22 +147,41 @@ class CalendarEvent:
         return self.start_time < other.end_time and self.end_time > other.start_time
 
 
+class _EventStore:
+    """One user's isolated mutable event list, optionally disk-backed."""
+
+    __slots__ = ("account_id", "events", "storage_path")
+
+    def __init__(
+        self,
+        events: list[CalendarEvent],
+        storage_path: Path | None,
+        account_id: str | None,
+    ) -> None:
+        self.events = events
+        self.storage_path = storage_path
+        self.account_id = account_id
+
+
 class CalendarService:
     """
-    Read/write calendar service backed by mock data.
-
-    Supports:
-    - Loading from mock file (two formats supported)
-    - Creating, updating, deleting events
-    - Listing upcoming events
-    - Getting events in a time range
-    - Conflict detection
+    Read/write calendar service with per-user isolated stores.
 
     Storage modes:
-    - mock_events provided: in-memory only, no disk writes.
-    - mock_data_path provided: read/write to that path (tests use tmp_path).
-    - Neither provided: read seed from data/mock_calendar.json, write to a
-      user-specific runtime directory so tracked repo files are never modified.
+    - ``mock_events`` provided: in-memory only, no disk writes.  The events
+      belong to ``owner_user_id`` (default: the ``default`` profile); other
+      users see their own empty isolated stores.
+    - ``mock_data_path`` provided: read/write to that path (tests use
+      tmp_path) for ``owner_user_id`` only; other users get isolated
+      in-memory stores.
+    - Neither provided: accounts are resolved per validated user via
+      :class:`CalendarAccountResolver`.  Users whose resolved account is an
+      ICS source get a read-seeded in-memory store; stub users get an
+      isolated per-user runtime file seeded from ``data/mock_calendar.json``.
+      When real accounts are configured, a user with no authorized account
+      fails closed (reads return ``[]``, writes raise
+      :class:`IntegrationNotConfiguredError`) — never another user's
+      account.
     """
 
     def __init__(
@@ -140,50 +190,274 @@ class CalendarService:
         *,
         mock_data_path: Path | str | None = None,
         mock_events: list[CalendarEvent] | None = None,
+        owner_user_id: str = DEFAULT_PROFILE,
+        account_resolver: CalendarAccountResolver | None = None,
     ) -> None:
         self._event_bus = event_bus if event_bus is not None else _NoOpEventBus()
+        self._owner = require_user_id(owner_user_id)
 
-        if mock_events is not None:
-            # In-memory mode: caller supplied events, never touch disk.
-            self._seed_path: Path | None = None
-            self._storage_path: Path | None = None
-            self._events: list[CalendarEvent] | None = list(mock_events)
-        elif mock_data_path is not None:
-            # Explicit path: read and write to the caller-supplied location.
-            p = Path(mock_data_path)
-            self._seed_path = p
-            self._storage_path = p
-            self._events = None
-        else:
-            # Default mode: seed from repo fixture, persist to runtime dir.
-            self._seed_path = _REPO_SEED_PATH
-            self._storage_path = _runtime_calendar_path()
-            self._events = None
+        self._mock_events: list[CalendarEvent] | None = (
+            list(mock_events) if mock_events is not None else None
+        )
+        self._mock_data_path: Path | None = Path(mock_data_path) if mock_data_path else None
+
+        # Per-user isolated stores, keyed by (user_id, account_id or "").
+        self._stores: dict[tuple[str, str], _EventStore] = {}
+        # ICS backends cached per (user_id, account_id).  A backend created
+        # for one user is never served to another.
+        self._user_backends: dict[tuple[str, str], Any] = {}
+
+        # Injected authorization/routing resolver (tests/embedding only; the
+        # production path loads lazily so config changes — including account
+        # revocations — are picked up without a restart).
+        self._injected_resolver = account_resolver
+        self._resolver_cache: CalendarAccountResolver | None = None
+        self._resolver_stamp: int | None = None
 
         self.connected = False
 
-    def connect(self) -> bool:
-        """
-        Connect to calendar service.
+    # ------------------------------------------------------------------
+    # Resolver / store plumbing
+    # ------------------------------------------------------------------
 
-        For mock mode, this loads mock data. Always returns True unless a hard failure occurs.
+    def _get_resolver(self) -> CalendarAccountResolver:
+        """Return the account resolver, refreshing when the config changes.
+
+        Authorization is re-checked on every operation, so cached stores and
+        backends never outlive their owner's assignment.
+        """
+        if self._injected_resolver is not None:
+            return self._injected_resolver
+
+        from rex import calendar_accounts as _calendar_accounts
+
+        stamp = _calendar_accounts.config_stamp()
+        if self._resolver_cache is None or stamp != self._resolver_stamp:
+            self._resolver_cache = CalendarAccountResolver.load()
+            self._resolver_stamp = stamp
+        return self._resolver_cache
+
+    def _seeded_stub_events(self, user_id: str) -> tuple[list[CalendarEvent], Path | None]:
+        """Load a user's stub store from disk (runtime file, then repo seed)."""
+        storage_path = _runtime_calendar_path(user_id)
+        for path in (storage_path, _REPO_SEED_PATH):
+            if path is not None and path.exists():
+                try:
+                    return self._load_mock_events(path), storage_path
+                except Exception as exc:
+                    logger.warning("Failed to load calendar data from %s: %s", path, exc)
+        return [], storage_path
+
+    def _get_store(
+        self,
+        user_id: str,
+        account_id: str | None = None,
+    ) -> _EventStore | None:
+        """Return *user_id*'s isolated store, after ownership validation.
+
+        Returns ``None`` when real accounts are configured but none is
+        available/usable for this user (documented not-configured result —
+        callers fail closed, never through another user's account).
+
+        Raises:
+            CalendarIdentityError: On missing or invalid identity.
+            CalendarAccountAccessError: When *account_id* is explicitly
+                requested but not available to this user.
+        """
+        validated = require_user_id(user_id)
+
+        # In-memory / explicit-path modes are bound to exactly one owner.
+        if self._mock_events is not None or self._mock_data_path is not None:
+            if account_id:
+                # No configured accounts exist in these modes; unauthorized
+                # and nonexistent are indistinguishable.
+                raise CalendarAccountAccessError(
+                    ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
+                )
+            key = (validated, "")
+            store = self._stores.get(key)
+            if store is None:
+                if validated == self._owner:
+                    if self._mock_events is not None:
+                        store = _EventStore(list(self._mock_events), None, None)
+                    else:
+                        events: list[CalendarEvent] = []
+                        assert self._mock_data_path is not None
+                        if self._mock_data_path.exists():
+                            try:
+                                events = self._load_mock_events(self._mock_data_path)
+                            except Exception as exc:
+                                logger.warning(
+                                    "Failed to load calendar data from %s: %s",
+                                    self._mock_data_path,
+                                    exc,
+                                )
+                        store = _EventStore(events, self._mock_data_path, None)
+                else:
+                    # Isolated empty in-memory store for any other user.
+                    store = _EventStore([], None, None)
+                self._stores[key] = store
+            return store
+
+        resolver = self._get_resolver()
+        if not resolver.has_configured_accounts():
+            # Pure stub mode: isolated per-user disk store.
+            if account_id:
+                raise CalendarAccountAccessError(
+                    ACCOUNT_UNAVAILABLE_MSG.format(account_id=account_id, user_id=validated)
+                )
+            key = (validated, "")
+            store = self._stores.get(key)
+            if store is None:
+                events, storage_path = self._seeded_stub_events(validated)
+                store = _EventStore(events, storage_path, None)
+                self._stores[key] = store
+            return store
+
+        # Accounts are configured: ownership check before anything else.
+        definition = resolver.resolve_account(validated, account_id)
+        if definition is None:
+            logger.warning("No usable calendar account for user %r", validated)
+            return None
+
+        if definition.provider == "ics":
+            return self._ics_store(validated, definition)
+        if definition.provider == "stub":
+            key = (validated, definition.id)
+            store = self._stores.get(key)
+            if store is None:
+                events, storage_path = self._seeded_stub_events(validated)
+                store = _EventStore(events, storage_path, definition.id)
+                self._stores[key] = store
+            return store
+
+        # google/outlook accounts are served by the provider-API surface
+        # (rex.integrations.calendar_service), not this store-backed service.
+        logger.warning(
+            "Calendar account for user %r uses provider %r, which this surface " "does not serve",
+            validated,
+            definition.provider,
+        )
+        return None
+
+    def _ics_store(self, user_id: str, definition: CalendarAccountDefinition) -> _EventStore | None:
+        """Return the user's store seeded from their authorized ICS source."""
+        key = (user_id, definition.id)
+        store = self._stores.get(key)
+        if store is not None:
+            return store
+
+        backend = self._user_backends.get(key)
+        if backend is None:
+            from rex.calendar_backends.ics_backend import ICSCalendarBackend
+
+            backend = ICSCalendarBackend(
+                source=definition.ics_source,
+                url_timeout=definition.ics_url_timeout,
+            )
+            if not backend.connect():
+                logger.warning("ICS calendar backend failed to connect for user %r", user_id)
+                return None
+            self._user_backends[key] = backend
+
+        events = list(backend.fetch_events())
+        store = _EventStore(events, None, definition.id)
+        self._stores[key] = store
+        return store
+
+    # ------------------------------------------------------------------
+    # Event publishing
+    # ------------------------------------------------------------------
+
+    def _publish(self, topic: str, payload: dict[str, Any]) -> None:
+        try:
+            self._event_bus.publish(topic, payload)
+        except Exception as exc:
+            logger.debug("EventBus publish failed for %s: %s", topic, exc)
+
+    def _publish_user_event(
+        self,
+        topic: str,
+        user_id: str,
+        shared_payload: dict[str, Any],
+        private_payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Publish a safe envelope on the shared topic and the full payload
+        on the owner's user-scoped topic.
+
+        The shared topic must never carry private event fields (titles,
+        attendees, locations, descriptions); those go only to
+        ``{topic}.user.{user_id}``.
+        """
+        self._publish(topic, shared_payload)
+        if private_payload is not None:
+            self._publish(f"{topic}.user.{user_id}", private_payload)
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    def connect(self, user_id: str | None = None) -> bool:
+        """
+        Connect the calendar service for one validated user.
+
+        Loads that user's isolated events.  Fails closed (returns ``False``)
+        on missing/invalid identity or when no account is available to the
+        user.
         """
         try:
-            self._events = self._load_events()
-            self.connected = True
-            logger.info("Calendar service connected (local storage)")
-            self._event_bus.publish(
-                "calendar.connected", {"connected": True, "count": len(self._events)}
-            )
-            return True
-        except Exception as e:
-            logger.error("Failed to connect calendar service: %s", e, exc_info=True)
-            self.connected = False
-            self._event_bus.publish("calendar.connected", {"connected": False, "error": str(e)})
+            validated = require_user_id(user_id)
+        except PermissionError:
+            logger.warning("Calendar connect refused: a valid user identity is required")
             return False
 
-    def list_upcoming(self, *, horizon_hours: int = 72) -> list[CalendarEvent]:
-        events = self._load_events()
+        try:
+            store = self._get_store(validated)
+        except PermissionError:
+            return False
+        except Exception as exc:
+            logger.error("Failed to connect calendar service: %s", exc, exc_info=True)
+            self._publish(
+                "calendar.connected",
+                {"connected": False, "user_id": validated, "error": str(exc)},
+            )
+            return False
+
+        if store is None:
+            self._publish(
+                "calendar.connected",
+                {"connected": False, "user_id": validated},
+            )
+            return False
+
+        self.connected = True
+        logger.info("Calendar service connected (local storage) for user %s", validated)
+        self._publish(
+            "calendar.connected",
+            {"connected": True, "count": len(store.events), "user_id": validated},
+        )
+        return True
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    def _events_for(self, user_id: str, account_id: str | None = None) -> list[CalendarEvent]:
+        """Return a copy of the requesting user's events (fail closed to [])."""
+        store = self._get_store(user_id, account_id)
+        if store is None:
+            return []
+        return list(store.events)
+
+    def list_upcoming(
+        self,
+        *,
+        horizon_hours: int = 72,
+        user_id: str | None = None,
+        account_id: str | None = None,
+    ) -> list[CalendarEvent]:
+        validated = require_user_id(user_id)
+        events = self._events_for(validated, account_id)
         now = datetime.now(UTC)
         horizon = now + timedelta(hours=horizon_hours)
 
@@ -193,44 +467,106 @@ class CalendarService:
         ]
         upcoming.sort(key=lambda e: e.start_time)
 
-        self._event_bus.publish(
+        self._publish_user_event(
             "calendar.upcoming",
-            {"count": len(upcoming), "events": [e.to_summary() for e in upcoming]},
+            validated,
+            {"count": len(upcoming), "user_id": validated},
+            {
+                "count": len(upcoming),
+                "user_id": validated,
+                "events": [e.to_summary() for e in upcoming],
+            },
         )
         return upcoming
 
-    def refresh_upcoming(self) -> list[CalendarEvent]:
-        return self.list_upcoming()
+    def refresh_upcoming(
+        self, *, user_id: str | None = None, account_id: str | None = None
+    ) -> list[CalendarEvent]:
+        return self.list_upcoming(user_id=user_id, account_id=account_id)
 
-    def get_events(self, start: datetime, end: datetime) -> list[CalendarEvent]:
+    def get_events(
+        self,
+        start: datetime,
+        end: datetime,
+        *,
+        user_id: str | None = None,
+        account_id: str | None = None,
+    ) -> list[CalendarEvent]:
         """
-        Get calendar events that overlap a time range.
+        Get the requesting user's calendar events that overlap a time range.
         """
-        if not self.connected and self._events is None:
-            logger.warning("Calendar service not connected; returning empty list")
-            return []
+        validated = require_user_id(user_id)
 
         start_utc = _ensure_aware_utc(start)
         end_utc = _ensure_aware_utc(end)
 
-        events = self._load_events()
+        events = self._events_for(validated, account_id)
         result = [e for e in events if e.start_time < end_utc and e.end_time > start_utc]
         result.sort(key=lambda e: e.start_time)
 
-        self._event_bus.publish(
+        self._publish_user_event(
             "calendar.range",
-            {"count": len(result), "start": start_utc.isoformat(), "end": end_utc.isoformat()},
+            validated,
+            {
+                "count": len(result),
+                "user_id": validated,
+                "start": start_utc.isoformat(),
+                "end": end_utc.isoformat(),
+            },
         )
         return result
 
-    def list_past_events(self, *, lookback_hours: int = 72) -> list[CalendarEvent]:
-        """Return events that ended within the lookback window."""
+    def list_past_events(
+        self, *, lookback_hours: int = 72, user_id: str | None = None
+    ) -> list[CalendarEvent]:
+        """Return the user's events that ended within the lookback window."""
         now = datetime.now(UTC)
         start = now - timedelta(hours=lookback_hours)
-        events = self.get_events(start, now)
+        events = self.get_events(start, now, user_id=user_id)
         past_events = [event for event in events if event.end_time <= now]
         past_events.sort(key=lambda e: e.end_time)
         return past_events
+
+    def get_upcoming_events(
+        self, days: int = 7, *, user_id: str | None = None
+    ) -> list[CalendarEvent]:
+        now = datetime.now(UTC)
+        end = now + timedelta(days=days)
+        return self.get_events(now, end, user_id=user_id)
+
+    def get_all_events(self, *, user_id: str | None = None) -> list[CalendarEvent]:
+        validated = require_user_id(user_id)
+        return self._events_for(validated)
+
+    def get_past_events(
+        self,
+        hours: int = 72,
+        *,
+        now: datetime | None = None,
+        user_id: str | None = None,
+    ) -> list[CalendarEvent]:
+        """Get the user's events that ended within the specified time window.
+
+        Args:
+            hours: Look back this many hours for ended events.
+            now: Current time (defaults to UTC now).
+            user_id: Requesting user (required).
+
+        Returns:
+            List of events that ended within the window, sorted by end_time.
+        """
+        validated = require_user_id(user_id)
+        check_time = now or datetime.now(UTC)
+        window_start = check_time - timedelta(hours=hours)
+
+        events = self._events_for(validated)
+        past_events = [e for e in events if e.end_time <= check_time and e.end_time >= window_start]
+        past_events.sort(key=lambda e: e.end_time, reverse=True)
+        return past_events
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
 
     def create_event(
         self,
@@ -242,13 +578,24 @@ class CalendarService:
         attendees: Iterable[str] | None = None,
         description: str | None = None,
         all_day: bool = False,
+        user_id: str | None = None,
+        account_id: str | None = None,
     ) -> CalendarEvent:
         """
-        Create a new calendar event and persist it to mock storage.
+        Create a new calendar event in the requesting user's store.
+
+        Raises:
+            CalendarIdentityError: On missing or invalid identity.
+            CalendarAccountAccessError: When *account_id* is not available
+                to this user (unauthorized or nonexistent).
+            IntegrationNotConfiguredError: When accounts are configured but
+                none is available to this user (fail closed — never another
+                user's account).
         """
-        if not self.connected and self._events is None:
-            # Allow creation even if connect() was not explicitly called
-            self.connect()
+        validated = require_user_id(user_id)
+        store = self._get_store(validated, account_id)
+        if store is None:
+            raise IntegrationNotConfiguredError(_NOT_CONFIGURED_FOR_USER_MSG)
 
         event = CalendarEvent(
             event_id=str(uuid.uuid4()),
@@ -261,21 +608,35 @@ class CalendarService:
             all_day=all_day,
         )
 
-        events = self._load_events()
-        events.append(event)
-        events.sort(key=lambda e: e.start_time)
-        self._events = events
-        self._save_events(events)
+        store.events.append(event)
+        store.events.sort(key=lambda e: e.start_time)
+        self._save_store(store)
 
-        self._event_bus.publish("calendar.created", event.to_summary())
+        self._publish_user_event(
+            "calendar.created",
+            validated,
+            {"user_id": validated, "created": True},
+            {"user_id": validated, "created": True, "event": event.to_summary()},
+        )
         return event
 
-    def update_event(self, event_id: str, updates: dict[str, Any]) -> CalendarEvent | None:
+    def update_event(
+        self,
+        event_id: str,
+        updates: dict[str, Any],
+        *,
+        user_id: str | None = None,
+    ) -> CalendarEvent | None:
         """
-        Update an existing calendar event by id.
+        Update an event by id within the requesting user's store only.
         """
-        events = self._load_events()
-        for i, event in enumerate(events):
+        validated = require_user_id(user_id)
+        store = self._get_store(validated)
+        if store is None:
+            logger.warning("Calendar update refused: no account for user %r", validated)
+            return None
+
+        for i, event in enumerate(store.events):
             if event.event_id != event_id:
                 continue
 
@@ -297,40 +658,69 @@ class CalendarService:
                 if isinstance(att, (list, tuple)):
                     event.attendees = [str(a) for a in att]
 
-            events[i] = event
-            events.sort(key=lambda e: e.start_time)
-            self._events = events
-            self._save_events(events)
+            store.events[i] = event
+            store.events.sort(key=lambda e: e.start_time)
+            self._save_store(store)
 
-            self._event_bus.publish("calendar.updated", {"event": event.to_summary()})
+            self._publish_user_event(
+                "calendar.updated",
+                validated,
+                {"user_id": validated, "updated": True},
+                {"user_id": validated, "updated": True, "event": event.to_summary()},
+            )
             return event
 
         logger.warning("Event not found for update: %s", event_id)
-        self._event_bus.publish("calendar.updated", {"event_id": event_id, "updated": False})
+        self._publish_user_event(
+            "calendar.updated",
+            validated,
+            {"user_id": validated, "updated": False},
+        )
         return None
 
-    def delete_event(self, event_id: str) -> bool:
+    def delete_event(self, event_id: str, *, user_id: str | None = None) -> bool:
         """
-        Delete an event by id.
+        Delete an event by id within the requesting user's store only.
         """
-        events = self._load_events()
-        new_events = [e for e in events if e.event_id != event_id]
-        if len(new_events) == len(events):
-            logger.warning("Event not found for delete: %s", event_id)
-            self._event_bus.publish("calendar.deleted", {"event_id": event_id, "deleted": False})
+        validated = require_user_id(user_id)
+        store = self._get_store(validated)
+        if store is None:
+            logger.warning("Calendar delete refused: no account for user %r", validated)
             return False
 
-        self._events = new_events
-        self._save_events(new_events)
-        self._event_bus.publish("calendar.deleted", {"event_id": event_id, "deleted": True})
+        new_events = [e for e in store.events if e.event_id != event_id]
+        if len(new_events) == len(store.events):
+            logger.warning("Event not found for delete: %s", event_id)
+            self._publish_user_event(
+                "calendar.deleted",
+                validated,
+                {"user_id": validated, "deleted": False},
+            )
+            return False
+
+        store.events[:] = new_events
+        self._save_store(store)
+        self._publish_user_event(
+            "calendar.deleted",
+            validated,
+            {"user_id": validated, "deleted": True},
+            {"user_id": validated, "deleted": True, "event_id": event_id},
+        )
         return True
 
-    def detect_conflicts(self, event: CalendarEvent) -> list[CalendarEvent]:
+    # ------------------------------------------------------------------
+    # Conflict detection
+    # ------------------------------------------------------------------
+
+    def detect_conflicts(
+        self, event: CalendarEvent, *, user_id: str | None = None
+    ) -> list[CalendarEvent]:
         """
-        Detect conflicts between the provided event and existing events.
+        Detect conflicts between the provided event and the user's events.
         """
+        validated = require_user_id(user_id)
         conflicts: list[CalendarEvent] = []
-        for existing in self._load_events():
+        for existing in self._events_for(validated):
             if existing.event_id == event.event_id:
                 continue
             if existing.overlaps_with(event):
@@ -340,11 +730,14 @@ class CalendarService:
     def find_conflicts(
         self,
         events: list[CalendarEvent] | None = None,
+        *,
+        user_id: str | None = None,
     ) -> list[tuple[CalendarEvent, CalendarEvent]]:
         """
-        Find overlapping event pairs.
+        Find overlapping event pairs within the user's events.
         """
-        events_to_check = list(events) if events is not None else self._load_events()
+        validated = require_user_id(user_id)
+        events_to_check = list(events) if events is not None else self._events_for(validated)
         events_to_check.sort(key=lambda e: e.start_time)
 
         conflicts: list[tuple[CalendarEvent, CalendarEvent]] = []
@@ -354,27 +747,9 @@ class CalendarService:
                     conflicts.append((e1, e2))
         return conflicts
 
-    def get_upcoming_events(self, days: int = 7) -> list[CalendarEvent]:
-        now = datetime.now(UTC)
-        end = now + timedelta(days=days)
-        return self.get_events(now, end)
-
-    def get_all_events(self) -> list[CalendarEvent]:
-        return self._load_events()
-
-    def _load_events(self) -> list[CalendarEvent]:
-        if self._events is not None:
-            return list(self._events)
-
-        # Try storage path first (runtime copy), then seed path
-        for path in (self._storage_path, self._seed_path):
-            if path is not None and path.exists():
-                events = self._load_mock_events(path)
-                self._events = list(events)
-                return list(events)
-
-        self._events = []
-        return []
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
 
     def _load_mock_events(self, path: Path) -> list[CalendarEvent]:
         """
@@ -439,45 +814,24 @@ class CalendarService:
         events.sort(key=lambda e: e.start_time)
         return events
 
-    def _save_events(self, events: list[CalendarEvent]) -> None:
-        """Persist events to storage.
+    def _save_store(self, store: _EventStore) -> None:
+        """Persist a store to its own path (no-op for in-memory stores).
 
-        Writes only to ``_storage_path``.  When the service was created with
-        ``mock_events`` (in-memory mode), ``_storage_path`` is ``None`` and
-        this method is a no-op — the repo seed file is never modified.
+        The repo seed file is never modified.
         """
-        if self._storage_path is None:
+        if store.storage_path is None:
             return
 
         try:
-            self._storage_path.parent.mkdir(parents=True, exist_ok=True)
-            data = {"events": [e.to_summary() for e in events]}
-            self._storage_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        except Exception as e:
-            logger.error("Failed to save mock calendar data: %s", e, exc_info=True)
+            store.storage_path.parent.mkdir(parents=True, exist_ok=True)
+            data = {"events": [e.to_summary() for e in store.events]}
+            store.storage_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        except Exception as exc:
+            logger.error("Failed to save calendar data: %s", exc, exc_info=True)
 
-    def get_past_events(
-        self,
-        hours: int = 72,
-        *,
-        now: datetime | None = None,
-    ) -> list[CalendarEvent]:
-        """Get events that ended within the specified time window.
-
-        Args:
-            hours: Look back this many hours for ended events.
-            now: Current time (defaults to UTC now).
-
-        Returns:
-            List of events that ended within the window, sorted by end_time.
-        """
-        check_time = now or datetime.now(UTC)
-        window_start = check_time - timedelta(hours=hours)
-
-        events = self._load_events()
-        past_events = [e for e in events if e.end_time <= check_time and e.end_time >= window_start]
-        past_events.sort(key=lambda e: e.end_time, reverse=True)
-        return past_events
+    # ------------------------------------------------------------------
+    # Follow-up cues
+    # ------------------------------------------------------------------
 
     def generate_followup_cues(
         self,
@@ -487,7 +841,7 @@ class CalendarService:
         expire_hours: int = 168,
         now: datetime | None = None,
     ) -> int:
-        """Generate follow-up cues from recent past calendar events.
+        """Generate follow-up cues from the user's recent past events.
 
         Creates cues for events that have ended within the lookback window.
         Skips:
@@ -496,7 +850,7 @@ class CalendarService:
         - Events with 'no-followup' in metadata/description
 
         Args:
-            user_id: User ID to create cues for.
+            user_id: User ID whose events are read and whose cues are created.
             lookback_hours: Only consider events ended within this many hours.
             expire_hours: Hours until the cue expires.
             now: Current time (defaults to UTC now).
@@ -504,6 +858,7 @@ class CalendarService:
         Returns:
             Number of cues created.
         """
+        validated = require_user_id(user_id)
         try:
             from rex.cue_store import get_cue_store
         except ImportError:
@@ -511,13 +866,13 @@ class CalendarService:
             return 0
 
         check_time = now or datetime.now(UTC)
-        past_events = self.get_past_events(hours=lookback_hours, now=check_time)
+        past_events = self.get_past_events(hours=lookback_hours, now=check_time, user_id=validated)
         cue_store = get_cue_store()
 
         created_count = 0
         for event in past_events:
             # Skip if cue already exists for this event
-            if cue_store.has_cue_for_source(user_id, "calendar", event.event_id):
+            if cue_store.has_cue_for_source(validated, "calendar", event.event_id):
                 continue
 
             # Skip all-day events that look like holidays
@@ -531,7 +886,7 @@ class CalendarService:
             # Create the cue
             prompt = f"How did '{event.title}' go?"
             cue_store.add_cue(
-                user_id=user_id,
+                user_id=validated,
                 source_type="calendar",
                 source_id=event.event_id,
                 title=event.title,
@@ -617,70 +972,51 @@ def get_calendar_service(
 ) -> CalendarService:
     """Get the global calendar service instance.
 
-    When ``config`` contains ``calendar.backend = "ics"``, the service is
-    backed by an :class:`~rex.calendar_backends.ics_backend.ICSCalendarBackend`.
-    Otherwise the existing stub/mock behaviour is used.
+    The returned service enforces per-user account ownership internally;
+    every operation requires a validated ``user_id``.  Accounts come from
+    ``calendar.accounts`` plus the legacy global calendar configuration
+    (``calendar.backend = "ics"`` / ``calendar.provider``), which is usable
+    only by the explicit ``default`` profile.
+
+    Raises:
+        IntegrationNotConfiguredError: when no calendar accounts are
+            configured at all.
     """
     global _calendar_service
     if _calendar_service is not None:
         return _calendar_service
 
-    # Determine backend from config
-    backend_name = "stub"
-    cal_cfg: dict = {}
-    if config:
-        cal_cfg = config.get("calendar", {})
-        backend_name = cal_cfg.get("backend", "stub")
-
-    if not config:
-        # Try loading from disk
-        try:
-            _config_path = Path("config/rex_config.json")
-            project_root = Path(__file__).resolve().parent.parent
-            cfg_file = project_root / _config_path
-            if cfg_file.exists():
-                import json as _json
-
-                disk_config = _json.loads(cfg_file.read_text(encoding="utf-8"))
-                cal_cfg = disk_config.get("calendar", {})
-                backend_name = cal_cfg.get("backend", "stub")
-        except Exception:
-            pass
-
-    if backend_name == "ics":
-        _calendar_service = _create_ics_backed_service(cal_cfg, event_bus)
+    if config is not None:
+        resolver = CalendarAccountResolver.from_raw_config(config)
+        injected: CalendarAccountResolver | None = resolver
     else:
+        resolver = CalendarAccountResolver.load()
+        # No resolver is injected: the service reloads it when the config
+        # file changes, so account revocations take effect in long-lived
+        # processes without a restart.
+        injected = None
+
+    if not resolver.has_configured_accounts():
         raise IntegrationNotConfiguredError("Calendar: not configured")
 
+    service = CalendarService(event_bus=event_bus, account_resolver=injected)
+
+    # Legacy compatibility: when the default profile resolves to an ICS
+    # account, connect it eagerly so misconfigured sources fail fast (the
+    # pre-#303 behaviour).
+    try:
+        default_definition = resolver.resolve_account(DEFAULT_PROFILE)
+    except PermissionError:
+        default_definition = None
+    if default_definition is not None and default_definition.provider == "ics":
+        if not service.connect(user_id=DEFAULT_PROFILE):
+            raise IntegrationNotConfiguredError("Calendar ICS backend failed to connect")
+
+    _calendar_service = service
     return _calendar_service
 
 
-def _create_ics_backed_service(
-    cal_cfg: dict,
-    event_bus: EventBus | None = None,
-) -> CalendarService:
-    """Create a CalendarService whose events come from an ICS backend."""
-    from rex.calendar_backends.ics_backend import ICSCalendarBackend
-
-    ics_cfg = cal_cfg.get("ics", {})
-    source = ics_cfg.get("source", "")
-    url_timeout = int(ics_cfg.get("url_timeout", 15))
-
-    if not source:
-        raise IntegrationNotConfiguredError("Calendar: not configured")
-
-    backend = ICSCalendarBackend(source=source, url_timeout=url_timeout)
-    ok = backend.connect()
-    if not ok:
-        raise IntegrationNotConfiguredError("Calendar ICS backend failed to connect")
-
-    events = backend.fetch_events()
-    svc = CalendarService(event_bus=event_bus, mock_events=events)
-    svc.connected = True
-    return svc
-
-
-def set_calendar_service(service: CalendarService) -> None:
+def set_calendar_service(service: CalendarService | None) -> None:
     """Set the global calendar service instance (for testing)."""
     global _calendar_service
     _calendar_service = service

--- a/rex/cli.py
+++ b/rex/cli.py
@@ -86,6 +86,7 @@ from rex.commands._epilog import CLI_EPILOG  # noqa: E402
 # ---------------------------------------------------------------------------
 from rex.commands._helpers import (  # noqa: E402,F401
     _get_version,
+    _load_calendar_resolver_safe,
     _load_email_config_safe,
     _load_email_resolver_safe,
     _parse_datetime_strict,
@@ -123,6 +124,7 @@ from rex.commands.dashboard import (  # noqa: E402,F401
 )
 from rex.commands.devtools import cmd_browser, cmd_code, cmd_gh, cmd_os  # noqa: E402,F401
 from rex.commands.email_calendar import (  # noqa: E402,F401
+    _cmd_calendar_accounts,
     _cmd_calendar_test_connection,
     _cmd_email_accounts,
     _cmd_email_send,

--- a/rex/commands/_helpers.py
+++ b/rex/commands/_helpers.py
@@ -41,6 +41,16 @@ def _load_email_resolver_safe():
         return None
 
 
+def _load_calendar_resolver_safe():
+    """Load the per-user CalendarAccountResolver, returning None on failure."""
+    try:
+        from rex.calendar_accounts import CalendarAccountResolver
+
+        return CalendarAccountResolver.load()
+    except Exception:
+        return None
+
+
 def _resolve_cli_user(args: argparse.Namespace) -> str | None:
     """Resolve active user context for commands that accept ``--user``."""
     from rex.identity import resolve_active_user

--- a/rex/commands/email_calendar.py
+++ b/rex/commands/email_calendar.py
@@ -416,78 +416,88 @@ def _cmd_calendar_accounts(args: argparse.Namespace, user: str) -> int:
     resolver = _cli()._load_calendar_resolver_safe()
 
     if accounts_cmd == "list":
-        accounts = [] if resolver is None else resolver.accounts_for_user(user)
-        if resolver is None or not accounts:
-            print(f"No calendar accounts configured for user '{user}'.")
-            print()
-            print("To configure accounts, add a 'calendar' section to config/rex_config.json")
-            print(f"and assign them to this user under users.{user}.calendar_accounts.")
-            print("See docs/calendar.md for details.")
-            return 0
-
-        print(f"Calendar Accounts for user '{user}'")
-        print("=" * 60)
-        print()
-
-        default_id = resolver.default_account_id_for_user(user)
-        for acct in accounts:
-            is_default = " (default)" if acct.id == default_id else ""
-            print(f"  {acct.id}{is_default}")
-            if acct.label:
-                print(f"    Label:    {acct.label}")
-            print(f"    Provider: {acct.provider}")
-            if acct.provider == "ics" and acct.ics_source:
-                print(f"    Source:   {acct.ics_source}")
-            print()
-
-        print(f"Total: {len(accounts)} account(s)")
-        return 0
+        return _cmd_calendar_accounts_list(resolver, user)
 
     if accounts_cmd == "set-active":
-        account_id = getattr(args, "account_id", None)
-        if not account_id:
-            print("Error: --account-id is required")
-            return 1
-
-        if resolver is None:
-            print("Error: No calendar configuration found")
-            return 1
-
-        owned = resolver.account_ids_for_user(user)
-        if account_id not in owned:
-            # Foreign and nonexistent accounts are indistinguishable; only
-            # the requesting user's own accounts are ever revealed.
-            print(f"Error: Account '{account_id}' is not available for user '{user}'.")
-            if owned:
-                print(f"Available: {', '.join(owned)}")
-            return 1
-
-        # Update only this user's default; never another user's routing and
-        # never the legacy global default.
-        try:
-            import json as _json
-
-            config_path = Path("config/rex_config.json")
-            if config_path.exists():
-                config_data = _json.loads(config_path.read_text(encoding="utf-8"))
-            else:
-                config_data = {}
-
-            users_block = config_data.setdefault("users", {})
-            user_entry = users_block.setdefault(user, {})
-            if not isinstance(user_entry, dict):
-                print("Error: Invalid users section in config")
-                return 1
-            user_entry["default_calendar_account_id"] = account_id
-            config_path.write_text(_json.dumps(config_data, indent=2) + "\n", encoding="utf-8")
-            print(f"Default calendar account for user '{user}' set to '{account_id}'")
-            return 0
-        except Exception as exc:
-            print(f"Error updating config: {exc}")
-            return 1
+        return _cmd_calendar_accounts_set_active(args, resolver, user)
 
     print("Unknown accounts subcommand. Use 'rex calendar accounts --help'")
     return 1
+
+
+def _cmd_calendar_accounts_list(resolver, user: str) -> int:
+    """List the selected user's own calendar accounts (never foreign ones)."""
+    accounts = [] if resolver is None else resolver.accounts_for_user(user)
+    if resolver is None or not accounts:
+        print(f"No calendar accounts configured for user '{user}'.")
+        print()
+        print("To configure accounts, add a 'calendar' section to config/rex_config.json")
+        print(f"and assign them to this user under users.{user}.calendar_accounts.")
+        print("See docs/calendar.md for details.")
+        return 0
+
+    print(f"Calendar Accounts for user '{user}'")
+    print("=" * 60)
+    print()
+
+    default_id = resolver.default_account_id_for_user(user)
+    for acct in accounts:
+        is_default = " (default)" if acct.id == default_id else ""
+        print(f"  {acct.id}{is_default}")
+        if acct.label:
+            print(f"    Label:    {acct.label}")
+        print(f"    Provider: {acct.provider}")
+        if acct.provider == "ics" and acct.ics_source:
+            print(f"    Source:   {acct.ics_source}")
+        print()
+
+    print(f"Total: {len(accounts)} account(s)")
+    return 0
+
+
+def _cmd_calendar_accounts_set_active(args: argparse.Namespace, resolver, user: str) -> int:
+    """Set the selected user's default calendar account (that user only)."""
+    account_id = getattr(args, "account_id", None)
+    if not account_id:
+        print("Error: --account-id is required")
+        return 1
+
+    if resolver is None:
+        print("Error: No calendar configuration found")
+        return 1
+
+    owned = resolver.account_ids_for_user(user)
+    if account_id not in owned:
+        # Foreign and nonexistent accounts are indistinguishable; only
+        # the requesting user's own accounts are ever revealed.
+        print(f"Error: Account '{account_id}' is not available for user '{user}'.")
+        if owned:
+            print(f"Available: {', '.join(owned)}")
+        return 1
+
+    # Update only this user's default; never another user's routing and
+    # never the legacy global default.
+    try:
+        import json as _json
+
+        config_path = Path("config/rex_config.json")
+        if config_path.exists():
+            config_data = _json.loads(config_path.read_text(encoding="utf-8"))
+        else:
+            config_data = {}
+
+        users_block = config_data.setdefault("users", {})
+        user_entry = users_block.setdefault(user, {})
+        if not isinstance(user_entry, dict):
+            print("Error: Invalid users section in config")
+            return 1
+        user_entry["default_calendar_account_id"] = account_id
+        config_path.write_text(_json.dumps(config_data, indent=2) + "\n", encoding="utf-8")
+        print(f"Default calendar account for user '{user}' set to '{account_id}'")
+        return 0
+    except Exception as exc:
+        print(f"Error updating config: {exc}")
+        return 1
 
 
 def _cmd_calendar_test_connection(args: argparse.Namespace, user: str) -> int:

--- a/rex/commands/email_calendar.py
+++ b/rex/commands/email_calendar.py
@@ -305,23 +305,64 @@ def _cmd_email_test_connection(args: argparse.Namespace, user: str) -> int:
     return 0
 
 
+_NO_CALENDAR_USER_MSG = (
+    "Error: No active user for calendar.\n"
+    "Set one with: rex identify --user <id>\n"
+    "Or pass one explicitly: rex calendar ... --user <id>"
+)
+
+
+def _resolve_calendar_user(args: argparse.Namespace) -> str | None:
+    """Resolve the requesting user for calendar commands, failing closed.
+
+    Uses ``--user`` when given, otherwise the standard identity chain.
+    Never silently falls back to the ``default`` profile — single-user
+    setups select it explicitly with ``--user default`` or
+    ``rex identify --user default``.
+    """
+    try:
+        user = _cli()._resolve_cli_user(args)
+        return str(user) if user else None
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return None
+
+
 def cmd_calendar(args: argparse.Namespace) -> int:
-    """Manage calendar."""
-    _ = _cli()._resolve_cli_user(args)
-    calendar_service = _cli().get_calendar_service()
+    """Manage calendar.  Every subcommand runs as one validated user."""
+    from rex.assistant_errors import IntegrationNotConfiguredError
+
+    user = _resolve_calendar_user(args)
+    if not user:
+        print(_NO_CALENDAR_USER_MSG)
+        return 1
+
     subcommand = args.calendar_command
 
+    if subcommand == "accounts":
+        return _cmd_calendar_accounts(args, user)
+
     if subcommand == "test-connection":
-        return _cmd_calendar_test_connection()
+        return _cmd_calendar_test_connection(args, user)
 
     if subcommand == "upcoming":
+        try:
+            calendar_service = _cli().get_calendar_service()
+        except IntegrationNotConfiguredError:
+            print("Calendar integration not configured. Add a calendar account in config.")
+            return 1
+
         if not calendar_service.connected:
-            if not calendar_service.connect():
+            if not calendar_service.connect(user):
                 print("Error: Failed to connect to calendar service")
                 return 1
 
         days = getattr(args, "days", None) or 7
-        events = calendar_service.get_upcoming_events(days=days)
+        try:
+            events = calendar_service.get_upcoming_events(days=days, user_id=user)
+        except PermissionError as exc:
+            print(f"Error: {exc}")
+            return 1
 
         print(f"Upcoming Events (next {days} days)")
         print("=" * 80)
@@ -355,7 +396,7 @@ def cmd_calendar(args: argparse.Namespace) -> int:
         print(f"Total: {len(events)} events")
 
         if getattr(args, "conflicts", False):
-            conflicts = calendar_service.find_conflicts(events)
+            conflicts = calendar_service.find_conflicts(events, user_id=user)
             if conflicts:
                 print()
                 print("Conflicts Detected:")
@@ -369,24 +410,150 @@ def cmd_calendar(args: argparse.Namespace) -> int:
     return 1
 
 
-def _cmd_calendar_test_connection() -> int:
-    """Verify calendar backend configuration."""
-    from rex.calendar_backends.factory import create_calendar_backend
+def _cmd_calendar_accounts(args: argparse.Namespace, user: str) -> int:
+    """Handle 'rex calendar accounts' subcommands for one validated user."""
+    accounts_cmd = getattr(args, "accounts_command", "list")
+    resolver = _cli()._load_calendar_resolver_safe()
 
-    backend = create_calendar_backend()
-    ok, message = backend.test_connection()
-    name = backend.backend_name
+    if accounts_cmd == "list":
+        accounts = [] if resolver is None else resolver.accounts_for_user(user)
+        if resolver is None or not accounts:
+            print(f"No calendar accounts configured for user '{user}'.")
+            print()
+            print("To configure accounts, add a 'calendar' section to config/rex_config.json")
+            print(f"and assign them to this user under users.{user}.calendar_accounts.")
+            print("See docs/calendar.md for details.")
+            return 0
 
-    if ok:
-        print(f"Calendar backend '{name}': OK")
-        if message:
-            print(f"  {message}")
+        print(f"Calendar Accounts for user '{user}'")
+        print("=" * 60)
+        print()
+
+        default_id = resolver.default_account_id_for_user(user)
+        for acct in accounts:
+            is_default = " (default)" if acct.id == default_id else ""
+            print(f"  {acct.id}{is_default}")
+            if acct.label:
+                print(f"    Label:    {acct.label}")
+            print(f"    Provider: {acct.provider}")
+            if acct.provider == "ics" and acct.ics_source:
+                print(f"    Source:   {acct.ics_source}")
+            print()
+
+        print(f"Total: {len(accounts)} account(s)")
         return 0
-    else:
-        print(f"Calendar backend '{name}': FAILED")
+
+    if accounts_cmd == "set-active":
+        account_id = getattr(args, "account_id", None)
+        if not account_id:
+            print("Error: --account-id is required")
+            return 1
+
+        if resolver is None:
+            print("Error: No calendar configuration found")
+            return 1
+
+        owned = resolver.account_ids_for_user(user)
+        if account_id not in owned:
+            # Foreign and nonexistent accounts are indistinguishable; only
+            # the requesting user's own accounts are ever revealed.
+            print(f"Error: Account '{account_id}' is not available for user '{user}'.")
+            if owned:
+                print(f"Available: {', '.join(owned)}")
+            return 1
+
+        # Update only this user's default; never another user's routing and
+        # never the legacy global default.
+        try:
+            import json as _json
+
+            config_path = Path("config/rex_config.json")
+            if config_path.exists():
+                config_data = _json.loads(config_path.read_text(encoding="utf-8"))
+            else:
+                config_data = {}
+
+            users_block = config_data.setdefault("users", {})
+            user_entry = users_block.setdefault(user, {})
+            if not isinstance(user_entry, dict):
+                print("Error: Invalid users section in config")
+                return 1
+            user_entry["default_calendar_account_id"] = account_id
+            config_path.write_text(_json.dumps(config_data, indent=2) + "\n", encoding="utf-8")
+            print(f"Default calendar account for user '{user}' set to '{account_id}'")
+            return 0
+        except Exception as exc:
+            print(f"Error updating config: {exc}")
+            return 1
+
+    print("Unknown accounts subcommand. Use 'rex calendar accounts --help'")
+    return 1
+
+
+def _cmd_calendar_test_connection(args: argparse.Namespace, user: str) -> int:
+    """Verify calendar configuration for one validated user's own account."""
+    account_id = getattr(args, "account_id", None)
+
+    resolver = _cli()._load_calendar_resolver_safe()
+    if resolver is None or not resolver.has_configured_accounts():
+        print("No calendar accounts configured. Using stub backend.")
+        print("Connection test: OK (stub mode)")
+        return 0
+
+    owned = resolver.account_ids_for_user(user)
+    try:
+        resolved_id = resolver.resolve_account_id(user, account_id)
+    except PermissionError:
+        resolved_id = None
+    acct = resolver.get_account_definition(resolved_id) if resolved_id else None
+    if acct is None:
+        # Only the requesting user's own accounts are ever revealed.
+        if owned:
+            print(f"Error: Account not available. Available for user '{user}': {', '.join(owned)}")
+        else:
+            print(f"Error: No calendar accounts configured for user '{user}'.")
+        return 1
+
+    print(f"Testing connection for calendar account '{acct.id}' (provider: {acct.provider})...")
+
+    if acct.provider == "ics":
+        from rex.calendar_backends.ics_backend import ICSCalendarBackend
+
+        backend = ICSCalendarBackend(source=acct.ics_source, url_timeout=acct.ics_url_timeout)
+        ok, message = backend.test_connection()
+        if ok:
+            print("Calendar backend 'ics': OK")
+            if message:
+                print(f"  {message}")
+            return 0
+        print("Calendar backend 'ics': FAILED")
         if message:
             print(f"  {message}")
         return 1
+
+    if acct.provider == "stub":
+        print("Calendar backend 'stub': OK")
+        return 0
+
+    if acct.provider == "google":
+        # Check token presence only — never print the credential reference
+        # or its value.
+        import os
+
+        token = os.environ.get(acct.credential_ref, "") if acct.credential_ref else ""
+        if not token:
+            print("  Credential: NOT FOUND")
+            print()
+            print("Error: No credentials available for this account.")
+            print("Set this account's token environment variable (see docs/calendar.md).")
+            return 1
+        print("  Credential: available")
+        print()
+        print("Connection test passed.")
+        return 0
+
+    print(f"Calendar provider '{acct.provider}' is not supported for connection tests.")
+    return 1
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -528,12 +695,65 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     calendar_upcoming.add_argument(
         "-v", "--verbose", action="store_true", help="Show detailed event information"
     )
+    calendar_upcoming.add_argument(
+        "--user", type=str, default=None, help="User context for this command"
+    )
     calendar_upcoming.set_defaults(func=_cli().cmd_calendar, calendar_command="upcoming")
+
+    # calendar accounts
+    calendar_accounts = calendar_subparsers.add_parser(
+        "accounts",
+        help="Manage calendar accounts",
+        description="List and manage configured calendar accounts.",
+    )
+    calendar_accounts_sub = calendar_accounts.add_subparsers(
+        title="accounts commands",
+        dest="accounts_command",
+        metavar="COMMAND",
+    )
+
+    calendar_accounts_list = calendar_accounts_sub.add_parser(
+        "list",
+        help="List the selected user's calendar accounts",
+    )
+    calendar_accounts_list.add_argument(
+        "--user", type=str, default=None, help="User context for this command"
+    )
+    calendar_accounts_list.set_defaults(
+        func=cmd_calendar, calendar_command="accounts", accounts_command="list"
+    )
+
+    calendar_accounts_set_active = calendar_accounts_sub.add_parser(
+        "set-active",
+        help="Set the selected user's default calendar account",
+    )
+    calendar_accounts_set_active.add_argument(
+        "--account-id",
+        type=str,
+        required=True,
+        help="Account ID to set as this user's default",
+    )
+    calendar_accounts_set_active.add_argument(
+        "--user", type=str, default=None, help="User context for this command"
+    )
+    calendar_accounts_set_active.set_defaults(
+        func=cmd_calendar, calendar_command="accounts", accounts_command="set-active"
+    )
+
+    calendar_accounts.set_defaults(
+        func=_cli().cmd_calendar, calendar_command="accounts", accounts_command="list"
+    )
 
     calendar_test_conn = calendar_subparsers.add_parser(
         "test-connection",
-        help="Verify calendar backend configuration",
-        description="Check that the configured calendar backend can connect and parse events.",
+        help="Verify calendar account configuration",
+        description="Check that the selected user's calendar account can connect and parse events.",
+    )
+    calendar_test_conn.add_argument(
+        "--account-id", type=str, default=None, help="Account ID to test"
+    )
+    calendar_test_conn.add_argument(
+        "--user", type=str, default=None, help="User context for this command"
     )
     calendar_test_conn.set_defaults(func=_cli().cmd_calendar, calendar_command="test-connection")
 

--- a/rex/followup_engine.py
+++ b/rex/followup_engine.py
@@ -218,7 +218,17 @@ class FollowupEngine:
             if not hasattr(calendar, "get_events"):
                 return
 
-            events = calendar.get_events(start, now)
+            try:
+                events = calendar.get_events(start, now, user_id=user_id)
+            except TypeError:
+                # Calendar objects that do not accept a user scope cannot
+                # prove ownership of their events: fail closed rather than
+                # attributing shared events to this user.
+                logger.debug(
+                    "Calendar service does not accept user-scoped queries; "
+                    "skipping cue generation"
+                )
+                return
             for event in events:
                 end_time = getattr(event, "end_time", None)
                 title = getattr(event, "title", None)

--- a/rex/integrations/_setup.py
+++ b/rex/integrations/_setup.py
@@ -97,21 +97,56 @@ def setup_calendar_job() -> ScheduledJob:
     event_bus = get_event_bus()
 
     def sync_calendar(job: ScheduledJob) -> None:
-        """Sync calendar and publish event."""
+        """Sync calendars per configured owner and publish scoped events.
+
+        Each owner is processed in an isolated context: one owner's failure
+        never falls through to another owner's account.  Private event
+        fields are published only on the owner-scoped topic; the shared
+        ``calendar.update`` topic carries a safe envelope (count/user).
+        """
         logger.info("Running scheduled calendar sync")
         try:
-            calendar_service = get_calendar_service()
-            if not calendar_service.connected:
-                calendar_service.connect()
-            events = calendar_service.get_upcoming_events(days=7)
-            event = Event(
-                event_type="calendar.update",
-                payload={"count": len(events), "events": [e.model_dump() for e in events]},  # type: ignore[attr-defined]
-            )
-            event_bus.publish(event)
-            logger.info(f"Published calendar.update event with {len(events)} events")
+            from rex.calendar_accounts import CalendarAccountResolver
+
+            owners = CalendarAccountResolver.load().configured_user_ids()
         except Exception as e:
-            logger.error(f"Error syncing calendar: {e}", exc_info=True)
+            logger.error(f"Error resolving calendar owners: {e}", exc_info=True)
+            return
+        if not owners:
+            logger.debug("No calendar account owners configured; skipping scheduled sync")
+            return
+
+        try:
+            calendar_service = get_calendar_service()
+        except Exception as e:
+            logger.debug(f"Calendar service unavailable for scheduled sync: {e}")
+            return
+
+        for owner in owners:
+            try:
+                events = calendar_service.get_upcoming_events(days=7, user_id=owner)
+                event_bus.publish(
+                    Event(
+                        event_type=f"calendar.update.user.{owner}",
+                        payload={
+                            "count": len(events),
+                            "user_id": owner,
+                            "events": [e.to_summary() for e in events],
+                        },
+                    )
+                )
+                event_bus.publish(
+                    Event(
+                        event_type="calendar.update",
+                        payload={"count": len(events), "user_id": owner},
+                    )
+                )
+                logger.info(
+                    f"Published calendar.update event with {len(events)} events "
+                    f"for user {owner}"
+                )
+            except Exception as e:
+                logger.error(f"Error syncing calendar for user {owner}: {e}", exc_info=True)
 
     scheduler.register_callback("sync_calendar", sync_calendar)
     job = scheduler.add_job(

--- a/rex/integrations/calendar_service.py
+++ b/rex/integrations/calendar_service.py
@@ -137,10 +137,16 @@ class CalendarService:
     Args:
         calendar_provider: One of ``"none"`` or ``"google"``.
             Defaults to ``"none"`` (stub mode).
+        access_token: Explicit OAuth access token *value* for the provider
+            API.  When omitted, the legacy global environment token is used —
+            that path serves only the explicit ``default`` profile (issue
+            #303); named users must be constructed via
+            :func:`create_calendar_service_for_user` with their own token.
     """
 
-    def __init__(self, calendar_provider: str = "none") -> None:
+    def __init__(self, calendar_provider: str = "none", access_token: str | None = None) -> None:
         self._provider = calendar_provider.lower()
+        self._access_token = access_token
         logger.debug("CalendarService initialised with provider=%s", self._provider)
 
     # ------------------------------------------------------------------
@@ -243,7 +249,10 @@ class CalendarService:
     def _google_headers(self) -> dict[str, str]:
         import os
 
-        token = os.environ.get("GOOGLE_CALENDAR_ACCESS_TOKEN", "")
+        token = self._access_token
+        if token is None:
+            # Legacy global env token — default profile only (issue #303).
+            token = os.environ.get("GOOGLE_CALENDAR_ACCESS_TOKEN", "")
         return {"Authorization": f"Bearer {token}", "Accept": "application/json"}
 
     def _google_get_events(self, start: datetime, end: datetime) -> list[CalendarEvent]:
@@ -270,9 +279,11 @@ class CalendarService:
             parsed = [self._parse_google_event(item) for item in data.get("items", [])]
             return [e for e in parsed if e is not None and isinstance(e, CalendarEvent)]
         except Exception as exc:  # noqa: BLE001
+            # Fail closed: never substitute stub/fallback data for a live
+            # provider failure (issue #303 — stub data must stay isolated
+            # and provider errors must not be masked).
             logger.error("Google Calendar get_events failed: %s", exc)
-            events = _build_stub_events()
-            return [e for e in events if e.start < end and e.end > start]
+            return []
 
     def _google_create_event(self, event_data: EventData) -> CalendarEvent:
         try:
@@ -414,7 +425,81 @@ class CalendarService:
 
 
 # ---------------------------------------------------------------------------
+# Per-user construction (issue #303)
+# ---------------------------------------------------------------------------
+
+
+def create_calendar_service_for_user(
+    user_id: str, raw_config: dict | None = None
+) -> tuple[CalendarService | None, str]:
+    """Build the provider-API CalendarService for one validated user.
+
+    Provider selection is per-user via ``rex.calendar_accounts``:
+
+    - A ``google``-provider account assigned to the user is served with that
+      user's own token (read from the environment variable named by the
+      account's ``credential_ref``).
+    - The legacy global ``calendar.provider`` + ``GOOGLE_CALENDAR_ACCESS_TOKEN``
+      path is available only to the explicit ``default`` profile.  Named
+      users never inherit the global credentials.
+
+    Returns:
+        ``(service_or_None, provider)`` where *provider* is one of
+        ``"none"``, ``"google"``, or ``"outlook"``.  ``service`` is ``None``
+        when the user has no usable provider (or the provider is
+        unsupported).
+
+    Raises:
+        PermissionError: On missing or invalid *user_id* (fail closed,
+            before any credential is read).
+    """
+    import os
+
+    from rex.calendar_accounts import (
+        DEFAULT_PROFILE,
+        CalendarAccountResolver,
+        require_user_id,
+    )
+
+    validated = require_user_id(user_id)
+
+    if raw_config is None:
+        try:
+            from rex.config_manager import load_config
+
+            raw_config = load_config()
+        except Exception:
+            raw_config = {}
+
+    resolver = CalendarAccountResolver.from_raw_config(raw_config)
+    account = resolver.provider_account_for_user(validated)
+    if account is not None:
+        if account.provider == "outlook":
+            return None, "outlook"
+        if account.legacy:
+            # Legacy global provider config: default profile only, using the
+            # legacy environment token.
+            if validated != DEFAULT_PROFILE:
+                return None, "none"
+            return CalendarService(calendar_provider="google"), "google"
+        credential_ref = account.credential_ref or ""
+        token = os.environ.get(credential_ref, "") if credential_ref else ""
+        if not token:
+            # Audit metadata only: account and user.  Credential references
+            # are never logged (issue #303 legacy policy).
+            logger.warning(
+                "Calendar account %r for user %r has no token configured",
+                account.id,
+                validated,
+            )
+            return None, "none"
+        return CalendarService(calendar_provider="google", access_token=token), "google"
+
+    return None, "none"
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
-__all__ = ["CalendarService"]
+__all__ = ["CalendarService", "create_calendar_service_for_user"]

--- a/rex/local_tool_executor.py
+++ b/rex/local_tool_executor.py
@@ -154,12 +154,26 @@ def _handle_send_email(args: dict[str, Any]) -> str:
 
 
 def _handle_calendar_create_event(args: dict[str, Any]) -> str:
-    """Create a calendar event via CalendarService.  Accepts {title, start, end}."""
+    """Create a calendar event via CalendarService.
+
+    Accepts ``{title, start, end, _user_id}``.  Requires a validated
+    requesting user (``_user_id`` or ``user_id`` in *args*); fails closed
+    before any account or credential resolution, and creates the event only
+    in that user's own calendar store.
+    """
     from datetime import datetime, timedelta
 
     title: str = str(args.get("title") or args.get("summary") or "New Event").strip()
     start_raw: str = str(args.get("start") or "").strip()
     end_raw: str = str(args.get("end") or "").strip()
+    user_id = args.get("_user_id") or args.get("user_id")
+
+    from rex.calendar_accounts import require_user_id
+
+    try:
+        validated_user = require_user_id(user_id)
+    except PermissionError:
+        return "[calendar error: a valid user identity is required]"
 
     # Parse start time (ISO format); default to now + 1 hour if missing
     now = datetime.now(tz=UTC)
@@ -176,7 +190,9 @@ def _handle_calendar_create_event(args: dict[str, Any]) -> str:
 
     try:
         svc = CalendarService()
-        event = svc.create_event(title=title, start_time=start_dt, end_time=end_dt)
+        event = svc.create_event(
+            title=title, start_time=start_dt, end_time=end_dt, user_id=validated_user
+        )
     except Exception as exc:
         logger.warning("calendar_create_event failed: %s", exc)
         return f"[calendar error: {exc}]"

--- a/rex/notification.py
+++ b/rex/notification.py
@@ -635,26 +635,27 @@ class Notifier:
 
             bus = EventBridge()
 
-            # Subscribe to user-scoped email events.  The shared
-            # "email.unread" topic carries only a safe envelope (no private
-            # fields); full payloads are published per owner on
-            # "email.unread.user.<user_id>", so a wildcard subscription with
-            # a prefix filter is used here (this is a trusted system
-            # component, not a user surface).
+            # Subscribe to user-scoped email and calendar events.  The
+            # shared "email.unread" / "calendar.update" topics carry only a
+            # safe envelope (no private fields); full payloads are published
+            # per owner on "<topic>.user.<user_id>", so a wildcard
+            # subscription with a prefix filter is used here (this is a
+            # trusted system component, not a user surface).
             bus.subscribe("*", self._on_any_event)
-
-            # Subscribe to calendar events
-            bus.subscribe("calendar.update", self._on_calendar_update)
 
             logger.info("Notification system subscribed to event bus events")
         except Exception as e:
             logger.warning(f"Failed to subscribe to events: {e}")
 
     def _on_any_event(self, event) -> None:
-        """Route user-scoped email events to the email handler."""
+        """Route user-scoped email and calendar events to their handlers."""
         event_type = getattr(event, "event_type", "")
-        if isinstance(event_type, str) and event_type.startswith("email.unread.user."):
+        if not isinstance(event_type, str):
+            return
+        if event_type.startswith("email.unread.user."):
             self._on_email_unread(event)
+        elif event_type.startswith("calendar.update.user."):
+            self._on_calendar_update(event)
 
     def _on_email_unread(self, event) -> None:
         """Handle user-scoped email.unread events."""
@@ -680,10 +681,11 @@ class Notifier:
             logger.error(f"Error handling email.unread event: {e}")
 
     def _on_calendar_update(self, event) -> None:
-        """Handle calendar.update events."""
+        """Handle user-scoped calendar.update events."""
         try:
             payload = event.payload if hasattr(event, "payload") else event
             events = payload.get("events", [])
+            user_id = payload.get("user_id")
 
             # Notify about upcoming events (within 15 minutes)
             now = _utc_now()
@@ -702,7 +704,7 @@ class Notifier:
                         body=f"{cal_event.get('title', 'Event')} "
                         f"starts at {start_time.strftime('%I:%M %p')}",
                         channel_preferences=["dashboard", "ha_tts"],
-                        metadata={"event_id": cal_event.get("event_id")},
+                        metadata={"event_id": cal_event.get("event_id"), "user_id": user_id},
                     )
                     self.send(notification)
         except Exception as e:

--- a/rex/openclaw/tools/calendar_tool.py
+++ b/rex/openclaw/tools/calendar_tool.py
@@ -8,22 +8,22 @@ This is a *policy-gated* tool: in normal operation the policy engine
 requires approval before the event is created (MEDIUM risk).  The callable
 itself does not enforce policy — that is the caller's responsibility.
 
-When the ``openclaw`` package is not installed, :func:`register` logs a
-warning and returns ``None``.  The :func:`calendar_create` callable works
-independently of OpenClaw.
+Per-user isolation (issue #303): the dispatcher-injected ``_user_id`` is
+required and validated **before** any account or service resolution; missing
+or invalid identity fails closed.  The event is created only in the
+requesting user's own calendar store.
 
 Typical usage::
 
-    from rex.openclaw.tools.calendar_tool import calendar_create, register
+    from rex.openclaw.tools.calendar_tool import calendar_create
 
     result = calendar_create(
         title="Team standup",
         start_time="2026-03-23T09:00:00",
         end_time="2026-03-23T09:30:00",
+        _user_id="alice",
     )
     # {'ok': True, 'event_id': '...', 'title': 'Team standup'}
-
-    register()   # no-op if openclaw not installed
 """
 
 from __future__ import annotations
@@ -32,6 +32,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
+from rex.assistant_errors import IntegrationNotConfiguredError
 from rex.calendar_service import get_calendar_service as _get_calendar_service
 
 logger = logging.getLogger(__name__)
@@ -62,18 +63,23 @@ def _parse_dt(value: str | datetime) -> datetime:
 
 
 def calendar_create(
-    title: str,
-    start_time: str | datetime,
-    end_time: str | datetime,
+    title: str = "",
+    start_time: str | datetime = "",
+    end_time: str | datetime = "",
     location: str | None = None,
     description: str | None = None,
     context: dict[str, Any] | None = None,
+    account_id: str | None = None,
+    **kwargs: Any,
 ) -> dict[str, Any]:
-    """Create a calendar event via Rex's CalendarService.
+    """Create a calendar event via Rex's CalendarService as the dispatching user.
 
     Delegates to :func:`rex.calendar_service.get_calendar_service().create_event`.
-    In stub mode (no backend configured) the event is saved to a local mock
-    file and returned.
+    The dispatcher-injected ``_user_id`` is required and validated **before**
+    any account or credential resolution; missing or invalid identity fails
+    closed.  An optional ``account_id`` routes through a specific account
+    only after ownership validation — a named user can never fall back to
+    the global default or first configured account.
 
     .. note::
         This tool is policy-gated (MEDIUM risk).  Callers are responsible
@@ -87,22 +93,50 @@ def calendar_create(
         description: Optional event description.
         context:     Optional ambient context dict (unused; reserved for future
             timezone injection).
+        account_id:  Optional explicit account to create in (must belong to
+            the requesting user).
+        **kwargs:    Absorbs dispatcher-injected keys such as ``transcript``
+            and ``_user_id`` without raising TypeError.
 
     Returns:
-        A dict with keys ``ok`` (bool), ``event_id`` (str), and
-        ``title`` (str).
+        A dict with keys ``ok`` (bool), and on success ``event_id`` (str)
+        and ``title`` (str); on refusal ``error`` (str).
     """
+    from rex.calendar_accounts import require_user_id
+
+    try:
+        user_id = require_user_id(kwargs.get("_user_id"))
+    except PermissionError as exc:
+        logger.warning("calendar_create tool refused: %s", exc)
+        return {
+            "ok": False,
+            "error": "calendar_create requires a valid user identity",
+        }
+
     service = _get_calendar_service()
     start_dt = _parse_dt(start_time)
     end_dt = _parse_dt(end_time)
 
-    event = service.create_event(
-        title=title,
-        start_time=start_dt,
-        end_time=end_dt,
-        location=location,
-        description=description,
-    )
+    # Audit metadata: requesting user and selected account only — never
+    # event bodies, attendee lists, or credential references.
+    logger.info("calendar_create tool: user=%s account=%s", user_id, account_id or "(default)")
+    try:
+        event = service.create_event(
+            title=title,
+            start_time=start_dt,
+            end_time=end_dt,
+            location=location,
+            description=description,
+            user_id=user_id,
+            account_id=account_id,
+        )
+    except PermissionError as exc:
+        logger.warning("calendar_create tool refused for user=%s: %s", user_id, exc)
+        return {"ok": False, "error": str(exc)}
+    except IntegrationNotConfiguredError:
+        logger.warning("calendar_create tool: no calendar account for user=%s", user_id)
+        return {"ok": False, "error": "No calendar account is available for this user"}
+
     return {
         "ok": True,
         "event_id": event.event_id,

--- a/rex/routes/integrations.py
+++ b/rex/routes/integrations.py
@@ -100,21 +100,51 @@ def create_blueprint() -> Blueprint:
 
     @bp.route("/api/calendar/events", methods=["GET"])
     def _calendar_events() -> Any:
-        """Return calendar events from the configured provider."""
+        """Return calendar events for the resolved requesting user only.
+
+        Identity comes from an explicit ``?user=`` query parameter or the
+        standard identity chain; without a valid user the request fails
+        closed (no global-credential fallback for named users).
+        """
         from datetime import UTC, datetime, timedelta
 
         from flask import jsonify, request
 
-        from rex.config import load_config
-        from rex.integrations.calendar_service import CalendarService
+        from rex.identity import resolve_active_user
+        from rex.integrations.calendar_service import create_calendar_service_for_user
+
+        no_user_error = (
+            "No active user for calendar. Set one with 'rex identify --user <id>' "
+            "or pass an explicit ?user= parameter."
+        )
 
         try:
-            cfg = load_config()
-        except Exception:
-            return jsonify({"ok": True, "events": [], "configured": False}), 200
+            from rex.config_manager import load_config as _load_raw_config
 
-        provider = getattr(cfg, "calendar_provider", "none") or "none"
-        if str(provider).lower() == "outlook":
+            raw_config = _load_raw_config()
+        except Exception:
+            raw_config = {}
+
+        explicit = str(request.args.get("user") or "").strip() or None
+        try:
+            user_id = resolve_active_user(explicit, config=raw_config)
+        except ValueError:
+            user_id = None
+        if not user_id:
+            return (
+                jsonify({"ok": False, "events": [], "configured": False, "error": no_user_error}),
+                403,
+            )
+
+        try:
+            svc, provider = create_calendar_service_for_user(user_id, raw_config)
+        except PermissionError:
+            return (
+                jsonify({"ok": False, "events": [], "configured": False, "error": no_user_error}),
+                403,
+            )
+
+        if provider == "outlook":
             return (
                 jsonify(
                     {
@@ -131,7 +161,8 @@ def create_blueprint() -> Blueprint:
                 501,
             )
 
-        svc = CalendarService(calendar_provider=provider)
+        if svc is None:
+            return jsonify({"ok": True, "events": [], "configured": False}), 200
 
         try:
             start_str = request.args.get("start", "")
@@ -143,7 +174,7 @@ def create_blueprint() -> Blueprint:
             end = start + timedelta(days=30)
 
         events = svc.get_events(start, end)
-        configured = provider != "none"
+        configured = True
 
         def _event_to_dict(e: Any) -> dict:
             return {

--- a/rex/routes/integrations.py
+++ b/rex/routes/integrations.py
@@ -7,6 +7,112 @@ from typing import Any
 
 from flask import Blueprint
 
+_CALENDAR_NO_USER_ERROR = (
+    "No active user for calendar. Set one with 'rex identify --user <id>' "
+    "or pass an explicit ?user= parameter."
+)
+
+_OUTLOOK_CALENDAR_UNSUPPORTED = (
+    "Outlook calendar sync is not implemented yet. The current Outlook "
+    "settings only store app credentials; Rex cannot read or write "
+    "Outlook events until Microsoft Graph OAuth token support is added."
+)
+
+
+def _calendar_events_response() -> Any:
+    """Build the /api/calendar/events response for the resolved user only.
+
+    Fails closed (403) without a valid identity; provider and credential
+    selection are per user via ``rex.calendar_accounts`` (issue #303).
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from flask import jsonify, request
+
+    from rex.identity import resolve_active_user
+    from rex.integrations.calendar_service import create_calendar_service_for_user
+
+    try:
+        from rex.config_manager import load_config as _load_raw_config
+
+        raw_config = _load_raw_config()
+    except Exception:
+        raw_config = {}
+
+    explicit = str(request.args.get("user") or "").strip() or None
+    try:
+        user_id = resolve_active_user(explicit, config=raw_config)
+    except ValueError:
+        user_id = None
+    if not user_id:
+        return (
+            jsonify(
+                {"ok": False, "events": [], "configured": False, "error": _CALENDAR_NO_USER_ERROR}
+            ),
+            403,
+        )
+
+    try:
+        svc, provider = create_calendar_service_for_user(user_id, raw_config)
+    except PermissionError:
+        return (
+            jsonify(
+                {"ok": False, "events": [], "configured": False, "error": _CALENDAR_NO_USER_ERROR}
+            ),
+            403,
+        )
+
+    if provider == "outlook":
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "events": [],
+                    "configured": True,
+                    "error": _OUTLOOK_CALENDAR_UNSUPPORTED,
+                }
+            ),
+            501,
+        )
+
+    if svc is None:
+        return jsonify({"ok": True, "events": [], "configured": False}), 200
+
+    try:
+        start_str = request.args.get("start", "")
+        end_str = request.args.get("end", "")
+        start = datetime.fromisoformat(start_str) if start_str else datetime.now(UTC)
+        end = datetime.fromisoformat(end_str) if end_str else start + timedelta(days=30)
+    except ValueError:
+        start = datetime.now(UTC)
+        end = start + timedelta(days=30)
+
+    events = svc.get_events(start, end)
+
+    def _event_to_dict(e: Any) -> dict:
+        return {
+            "id": e.id,
+            "title": e.title,
+            "start": e.start.isoformat(),
+            "end": e.end.isoformat(),
+            "location": e.location,
+            "description": e.description,
+            "attendees": list(e.attendees),
+            "source": e.source,
+            "is_all_day": e.is_all_day,
+        }
+
+    return (
+        jsonify(
+            {
+                "ok": True,
+                "events": [_event_to_dict(e) for e in events],
+                "configured": True,
+            }
+        ),
+        200,
+    )
+
 
 def create_blueprint() -> Blueprint:
     """Return the integrations and capabilities Blueprint."""
@@ -106,99 +212,7 @@ def create_blueprint() -> Blueprint:
         standard identity chain; without a valid user the request fails
         closed (no global-credential fallback for named users).
         """
-        from datetime import UTC, datetime, timedelta
-
-        from flask import jsonify, request
-
-        from rex.identity import resolve_active_user
-        from rex.integrations.calendar_service import create_calendar_service_for_user
-
-        no_user_error = (
-            "No active user for calendar. Set one with 'rex identify --user <id>' "
-            "or pass an explicit ?user= parameter."
-        )
-
-        try:
-            from rex.config_manager import load_config as _load_raw_config
-
-            raw_config = _load_raw_config()
-        except Exception:
-            raw_config = {}
-
-        explicit = str(request.args.get("user") or "").strip() or None
-        try:
-            user_id = resolve_active_user(explicit, config=raw_config)
-        except ValueError:
-            user_id = None
-        if not user_id:
-            return (
-                jsonify({"ok": False, "events": [], "configured": False, "error": no_user_error}),
-                403,
-            )
-
-        try:
-            svc, provider = create_calendar_service_for_user(user_id, raw_config)
-        except PermissionError:
-            return (
-                jsonify({"ok": False, "events": [], "configured": False, "error": no_user_error}),
-                403,
-            )
-
-        if provider == "outlook":
-            return (
-                jsonify(
-                    {
-                        "ok": False,
-                        "events": [],
-                        "configured": True,
-                        "error": (
-                            "Outlook calendar sync is not implemented yet. The current Outlook "
-                            "settings only store app credentials; Rex cannot read or write "
-                            "Outlook events until Microsoft Graph OAuth token support is added."
-                        ),
-                    }
-                ),
-                501,
-            )
-
-        if svc is None:
-            return jsonify({"ok": True, "events": [], "configured": False}), 200
-
-        try:
-            start_str = request.args.get("start", "")
-            end_str = request.args.get("end", "")
-            start = datetime.fromisoformat(start_str) if start_str else datetime.now(UTC)
-            end = datetime.fromisoformat(end_str) if end_str else start + timedelta(days=30)
-        except ValueError:
-            start = datetime.now(UTC)
-            end = start + timedelta(days=30)
-
-        events = svc.get_events(start, end)
-        configured = True
-
-        def _event_to_dict(e: Any) -> dict:
-            return {
-                "id": e.id,
-                "title": e.title,
-                "start": e.start.isoformat(),
-                "end": e.end.isoformat(),
-                "location": e.location,
-                "description": e.description,
-                "attendees": list(e.attendees),
-                "source": e.source,
-                "is_all_day": e.is_all_day,
-            }
-
-        return (
-            jsonify(
-                {
-                    "ok": True,
-                    "events": [_event_to_dict(e) for e in events],
-                    "configured": configured,
-                }
-            ),
-            200,
-        )
+        return _calendar_events_response()
 
     @bp.route("/api/email/inbox", methods=["GET"])
     def _email_inbox() -> Any:

--- a/rex/services.py
+++ b/rex/services.py
@@ -66,7 +66,7 @@ def initialize_services(
 
     # Register scheduler handlers
     scheduler.register_handler("email_triage", lambda job: _run_email_triage(email))
-    scheduler.register_handler("calendar_sync", lambda job: calendar.refresh_upcoming())  # type: ignore[arg-type]
+    scheduler.register_handler("calendar_sync", lambda job: _run_calendar_sync(calendar))
     scheduler.register_handler("flush_digests", lambda job: notifier.flush_digests())  # type: ignore[arg-type]
     scheduler.register_handler(
         "check_escalations", lambda job: _check_escalations(notifier, escalation_manager)
@@ -129,6 +129,42 @@ def _run_email_triage(email: EmailService) -> None:
             email.triage_unread(user_id=owner)
         except Exception as exc:
             logger.warning("Scheduled email triage failed for user %r: %s", owner, exc)
+
+
+def _calendar_sync_owners() -> list[str]:
+    """Return the owners scheduled calendar sync runs for.
+
+    Owners are users with explicit calendar account assignments (plus the
+    ``default`` profile for legacy/unassigned accounts).  When nothing is
+    configured, the legacy job runs only as the distinct ``default`` profile
+    — stub-only, never another user's real calendar.
+    """
+    try:
+        from rex.calendar_accounts import DEFAULT_PROFILE, CalendarAccountResolver
+
+        owners = CalendarAccountResolver.load().configured_user_ids()
+        return owners or [DEFAULT_PROFILE]
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).warning("Failed to resolve calendar sync owners: %s", exc)
+        return []
+
+
+def _run_calendar_sync(calendar: CalendarService) -> None:
+    """Run scheduled calendar sync per owner, in isolated owner contexts.
+
+    One owner's failure is logged and never falls through to (or exposes)
+    another owner's account.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    for owner in _calendar_sync_owners():
+        try:
+            calendar.refresh_upcoming(user_id=owner)
+        except Exception as exc:
+            logger.warning("Scheduled calendar sync failed for user %r: %s", owner, exc)
 
 
 def _check_escalations(notifier: Notifier, escalation_manager: EscalationManager) -> None:

--- a/tests/test_calendar_accounts.py
+++ b/tests/test_calendar_accounts.py
@@ -1,0 +1,236 @@
+"""Unit tests for rex.calendar_accounts (issue #303).
+
+Covers the canonical per-user calendar account authorization and routing
+model: identity validation, ownership checks, generic unauthorized errors,
+per-user defaults, deterministic routing, legacy-account policy, and owner
+enumeration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rex.calendar_accounts import (
+    ACCOUNT_UNAVAILABLE_MSG,
+    DEFAULT_PROFILE,
+    LEGACY_ICS_ACCOUNT_ID,
+    CalendarAccountAccessError,
+    CalendarAccountResolver,
+    CalendarIdentityError,
+    require_user_id,
+)
+
+ALICE = "alice"
+BOB = "bob"
+
+
+def _two_user_raw_config() -> dict:
+    return {
+        "calendar": {
+            "accounts": [
+                {
+                    "id": "alice-cal",
+                    "label": "Alice calendar",
+                    "provider": "ics",
+                    "ics": {"source": "https://example.com/alice.ics"},
+                },
+                {
+                    "id": "bob-cal",
+                    "label": "Bob calendar",
+                    "provider": "google",
+                    "credential_ref": "GOOGLE_CALENDAR_TOKEN_BOB",
+                },
+            ],
+        },
+        "users": {
+            ALICE: {"calendar_accounts": [{"account_id": "alice-cal"}]},
+            BOB: {"calendar_accounts": [{"account_id": "bob-cal"}]},
+        },
+    }
+
+
+def _legacy_only_raw_config() -> dict:
+    return {
+        "calendar": {
+            "backend": "ics",
+            "ics": {"source": "https://example.com/legacy.ics", "url_timeout": 10},
+            "provider": "google",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Identity validation
+# ---------------------------------------------------------------------------
+
+
+class TestRequireUserId:
+    @pytest.mark.parametrize(
+        "bad",
+        [None, "", "   ", 42, b"alice", "../../etc/passwd", "..", "a/b", "a\\b", "user id"],
+    )
+    def test_invalid_identities_fail_closed(self, bad):
+        with pytest.raises(CalendarIdentityError):
+            require_user_id(bad)
+
+    def test_valid_identity_returned(self):
+        assert require_user_id("alice") == "alice"
+        assert require_user_id("default") == "default"
+
+    def test_error_is_permission_error(self):
+        with pytest.raises(PermissionError):
+            require_user_id(None)
+
+
+# ---------------------------------------------------------------------------
+# Ownership and enumeration
+# ---------------------------------------------------------------------------
+
+
+class TestOwnership:
+    def test_users_see_only_their_own_accounts(self):
+        resolver = CalendarAccountResolver.from_raw_config(_two_user_raw_config())
+        assert resolver.account_ids_for_user(ALICE) == ["alice-cal"]
+        assert resolver.account_ids_for_user(BOB) == ["bob-cal"]
+
+    def test_unassigned_named_user_has_no_accounts(self):
+        resolver = CalendarAccountResolver.from_raw_config(_two_user_raw_config())
+        assert resolver.account_ids_for_user("charlie") == []
+
+    def test_foreign_explicit_account_raises_generic_error(self):
+        resolver = CalendarAccountResolver.from_raw_config(_two_user_raw_config())
+        with pytest.raises(CalendarAccountAccessError) as exc:
+            resolver.resolve_account_id(ALICE, "bob-cal")
+        assert str(exc.value) == ACCOUNT_UNAVAILABLE_MSG.format(account_id="bob-cal", user_id=ALICE)
+
+    def test_nonexistent_account_indistinguishable_from_foreign(self):
+        resolver = CalendarAccountResolver.from_raw_config(_two_user_raw_config())
+        with pytest.raises(CalendarAccountAccessError) as foreign:
+            resolver.resolve_account_id(ALICE, "bob-cal")
+        with pytest.raises(CalendarAccountAccessError) as missing:
+            resolver.resolve_account_id(ALICE, "no-such-account")
+        # Same message shape: only the requested ID varies.
+        assert str(foreign.value).replace("bob-cal", "X") == str(missing.value).replace(
+            "no-such-account", "X"
+        )
+
+    def test_check_account_access_requires_valid_identity(self):
+        resolver = CalendarAccountResolver.from_raw_config(_two_user_raw_config())
+        with pytest.raises(CalendarIdentityError):
+            resolver.check_account_access("../evil", "alice-cal")
+
+    def test_configured_user_ids_are_deterministic_and_valid(self):
+        raw = _two_user_raw_config()
+        raw["users"]["../bad"] = {"calendar_accounts": [{"account_id": "alice-cal"}]}
+        resolver = CalendarAccountResolver.from_raw_config(raw)
+        assert resolver.configured_user_ids() == [ALICE, BOB]
+
+    def test_unassigned_accounts_belong_to_default_profile(self):
+        raw = _two_user_raw_config()
+        raw["calendar"]["accounts"].append(
+            {"id": "orphan-cal", "provider": "ics", "ics": {"source": "x.ics"}}
+        )
+        resolver = CalendarAccountResolver.from_raw_config(raw)
+        assert "orphan-cal" in resolver.account_ids_for_user(DEFAULT_PROFILE)
+        assert "orphan-cal" not in resolver.account_ids_for_user(ALICE)
+        assert "orphan-cal" not in resolver.account_ids_for_user(BOB)
+
+
+# ---------------------------------------------------------------------------
+# Legacy policy
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyPolicy:
+    def test_legacy_accounts_belong_only_to_default(self):
+        resolver = CalendarAccountResolver.from_raw_config(_legacy_only_raw_config())
+        default_ids = resolver.account_ids_for_user(DEFAULT_PROFILE)
+        assert LEGACY_ICS_ACCOUNT_ID in default_ids
+        assert resolver.account_ids_for_user(ALICE) == []
+
+    def test_named_user_cannot_claim_legacy_account_even_explicitly(self):
+        raw = _legacy_only_raw_config()
+        raw["users"] = {ALICE: {"calendar_accounts": [{"account_id": LEGACY_ICS_ACCOUNT_ID}]}}
+        resolver = CalendarAccountResolver.from_raw_config(raw)
+        assert resolver.account_ids_for_user(ALICE) == []
+        with pytest.raises(CalendarAccountAccessError):
+            resolver.resolve_account_id(ALICE, LEGACY_ICS_ACCOUNT_ID)
+
+    def test_legacy_provider_account_synthesized_for_default(self):
+        resolver = CalendarAccountResolver.from_raw_config(_legacy_only_raw_config())
+        providers = {a.provider for a in resolver.accounts_for_user(DEFAULT_PROFILE)}
+        assert providers == {"ics", "google"}
+
+    def test_empty_ics_source_is_not_configured(self):
+        resolver = CalendarAccountResolver.from_raw_config(
+            {"calendar": {"backend": "ics", "ics": {"source": ""}}}
+        )
+        assert not resolver.has_configured_accounts()
+
+    def test_stub_backend_is_not_configured(self):
+        resolver = CalendarAccountResolver.from_raw_config({"calendar": {"backend": "stub"}})
+        assert not resolver.has_configured_accounts()
+
+    def test_legacy_global_default_applies_only_to_default_profile(self):
+        raw = _two_user_raw_config()
+        raw["calendar"]["default_account_id"] = "alice-cal"
+        # alice-cal is assigned to alice, so the default profile does not own
+        # it and the legacy default must be ignored even for `default`.
+        resolver = CalendarAccountResolver.from_raw_config(raw)
+        assert resolver.default_account_id_for_user(DEFAULT_PROFILE) is None
+        # Named users are unaffected by the legacy global default.
+        assert resolver.default_account_id_for_user(BOB) is None
+        assert resolver.resolve_account_id(BOB) == "bob-cal"
+
+
+# ---------------------------------------------------------------------------
+# Per-user defaults and routing
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsAndRouting:
+    def test_per_user_defaults_are_independent(self):
+        raw = _two_user_raw_config()
+        raw["users"][ALICE]["calendar_accounts"].append({"account_id": "alice-cal-2"})
+        raw["calendar"]["accounts"].append(
+            {"id": "alice-cal-2", "provider": "ics", "ics": {"source": "y.ics"}}
+        )
+        raw["users"][ALICE]["default_calendar_account_id"] = "alice-cal-2"
+        raw["users"][BOB]["default_calendar_account_id"] = "bob-cal"
+        resolver = CalendarAccountResolver.from_raw_config(raw)
+        assert resolver.resolve_account_id(ALICE) == "alice-cal-2"
+        assert resolver.resolve_account_id(BOB) == "bob-cal"
+
+    def test_foreign_default_is_ignored_fail_closed(self):
+        raw = _two_user_raw_config()
+        raw["users"][ALICE]["default_calendar_account_id"] = "bob-cal"
+        resolver = CalendarAccountResolver.from_raw_config(raw)
+        # Falls back to Alice's own first account, never to Bob's.
+        assert resolver.resolve_account_id(ALICE) == "alice-cal"
+
+    def test_first_assigned_account_fallback_is_deterministic(self):
+        raw = _two_user_raw_config()
+        raw["calendar"]["accounts"].append(
+            {"id": "alice-cal-2", "provider": "ics", "ics": {"source": "y.ics"}}
+        )
+        raw["users"][ALICE]["calendar_accounts"].append({"account_id": "alice-cal-2"})
+        resolver = CalendarAccountResolver.from_raw_config(raw)
+        assert resolver.resolve_account_id(ALICE) == "alice-cal"
+
+    def test_no_accounts_resolves_to_none(self):
+        resolver = CalendarAccountResolver.from_raw_config(_two_user_raw_config())
+        assert resolver.resolve_account_id("charlie") is None
+
+    def test_resolution_requires_identity(self):
+        resolver = CalendarAccountResolver.from_raw_config(_two_user_raw_config())
+        with pytest.raises(CalendarIdentityError):
+            resolver.resolve_account_id(None)  # type: ignore[arg-type]
+        with pytest.raises(CalendarIdentityError):
+            resolver.resolve_account_id("")
+
+    def test_provider_account_for_user_respects_ownership(self):
+        resolver = CalendarAccountResolver.from_raw_config(_two_user_raw_config())
+        assert resolver.provider_account_for_user(ALICE) is None  # ics only
+        bob_account = resolver.provider_account_for_user(BOB)
+        assert bob_account is not None and bob_account.id == "bob-cal"
+        assert resolver.provider_account_for_user("charlie") is None

--- a/tests/test_calendar_ics_backend.py
+++ b/tests/test_calendar_ics_backend.py
@@ -407,7 +407,8 @@ class TestCalendarServiceICSIntegration:
             svc = get_calendar_service(config=config)
             assert isinstance(svc, CalendarService)
             assert svc.connected is True
-            events = svc.get_all_events()
+            # Legacy global ICS config belongs to the explicit default profile.
+            events = svc.get_all_events(user_id="default")
             assert len(events) == 4
         finally:
             set_calendar_service(None)
@@ -433,7 +434,7 @@ class TestCalendarServiceICSIntegration:
             # Query a range that includes Team Standup (2026-02-20 14:00 UTC)
             start = datetime(2026, 2, 20, 0, 0, tzinfo=UTC)
             end = datetime(2026, 2, 21, 0, 0, tzinfo=UTC)
-            day_events = svc.get_events(start, end)
+            day_events = svc.get_events(start, end, user_id="default")
             titles = [e.title for e in day_events]
             assert "Team Standup" in titles
             assert "1-on-1 with Manager" in titles

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -162,13 +162,14 @@ def test_calendar_conflict_detection_and_publish() -> None:
         end_time=start + timedelta(hours=1, minutes=30),
     )
 
-    conflicts = service.detect_conflicts(new_event)  # type: ignore[attr-defined]
+    conflicts = service.detect_conflicts(new_event, user_id="default")  # type: ignore[attr-defined]
     assert conflicts == [existing]
 
     created = service.create_event(
         "Planning",
         start + timedelta(days=1),
         start + timedelta(days=1, hours=1),
+        user_id="default",
     )
 
     assert created.title == "Planning"
@@ -594,18 +595,20 @@ def test_mock_events_mode_does_not_write_to_disk(tmp_path: Path) -> None:
 
     service = CalendarService(bus, mock_events=[seed])
 
-    # Mutate: create, update, delete
+    # Mutate: create, update, delete (as the owning default profile)
     created = service.create_event(
         "New",
         start + timedelta(days=1),
         start + timedelta(days=1, hours=1),
+        user_id="default",
     )
-    service.update_event(created.event_id, {"title": "Renamed"})
-    service.delete_event(created.event_id)
+    service.update_event(created.event_id, {"title": "Renamed"}, user_id="default")
+    service.delete_event(created.event_id, user_id="default")
 
-    # The repo seed file must not have been created or modified
-    # The key assertion: _storage_path is None in mock_events mode
-    assert service._storage_path is None
+    # The repo seed file must not have been created or modified.
+    # The key assertion: in-memory stores have no storage path.
+    stores = list(service._stores.values())
+    assert stores and all(store.storage_path is None for store in stores)
 
 
 def test_explicit_path_writes_only_to_that_path(tmp_path: Path) -> None:
@@ -614,19 +617,20 @@ def test_explicit_path_writes_only_to_that_path(tmp_path: Path) -> None:
     cal_file.write_text("[]", encoding="utf-8")
 
     service = CalendarService(mock_data_path=cal_file)
-    service.connect()
+    service.connect(user_id="default")
 
     start = datetime(2024, 6, 1, 10, 0, tzinfo=UTC)
     service.create_event(
         "Meeting",
         start,
         start + timedelta(hours=1),
+        user_id="default",
     )
 
     # Written to the explicit path
     data = json.loads(cal_file.read_text(encoding="utf-8"))
     assert any(e["title"] == "Meeting" for e in data["events"])
 
-    # Repo seed file untouched
-    assert service._storage_path == cal_file
-    assert service._seed_path == cal_file
+    # The owner's store is backed by exactly the explicit path
+    store = service._stores[("default", "")]
+    assert store.storage_path == cal_file

--- a/tests/test_calendar_surfaces_isolation.py
+++ b/tests/test_calendar_surfaces_isolation.py
@@ -1,0 +1,435 @@
+"""Calendar surface isolation tests: GUI route, bridge, OpenClaw tool,
+local tool executor, and scheduler (issue #303).
+
+Each surface must resolve one validated user, fail closed without identity,
+and never route through another user's account, provider, or credentials.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from rex.calendar_accounts import CalendarAccountResolver
+
+ALICE = "alice"
+BOB = "bob"
+
+
+# ---------------------------------------------------------------------------
+# GUI route: /api/calendar/events
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def flask_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("REX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("REX_JWT_SECRET", "test-cal-303-secret")
+    from rex.gui_app import _create_flask_app
+
+    app = _create_flask_app(ui_enabled=False)
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+class TestCalendarRoute:
+    def test_rejects_missing_identity(self, flask_client, monkeypatch):
+        """Regression: the base implementation served the global provider
+        calendar to any caller with no identity at all."""
+        monkeypatch.setattr("rex.identity.resolve_active_user", lambda *a, **k: None)
+        resp = flask_client.get("/api/calendar/events")
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert data["ok"] is False
+        assert data["events"] == []
+
+    def test_rejects_malformed_explicit_user(self, flask_client):
+        resp = flask_client.get("/api/calendar/events?user=..%2F..%2Fevil")
+        assert resp.status_code == 403
+        assert resp.get_json()["ok"] is False
+
+    def test_named_user_without_assignment_gets_not_configured(self, flask_client, monkeypatch):
+        """A named user never inherits the legacy global provider/token."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "global-token")
+        monkeypatch.setattr(
+            "rex.config_manager.load_config",
+            lambda *a, **k: {"calendar": {"provider": "google"}},
+        )
+        resp = flask_client.get("/api/calendar/events?user=james")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert data["configured"] is False
+        assert data["events"] == []
+
+    def test_resolved_user_is_passed_to_service_factory(self, flask_client, monkeypatch):
+        captured: dict[str, Any] = {}
+
+        def fake_factory(user_id, raw_config=None):
+            captured["user_id"] = user_id
+            return None, "none"
+
+        monkeypatch.setattr(
+            "rex.integrations.calendar_service.create_calendar_service_for_user",
+            fake_factory,
+        )
+        resp = flask_client.get("/api/calendar/events?user=alice")
+        assert resp.status_code == 200
+        assert captured["user_id"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Electron bridge: bridge/rex_calendar_bridge.py
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarBridge:
+    def test_missing_user_fails_closed(self, monkeypatch):
+        import bridge.rex_calendar_bridge as bridge_mod
+
+        monkeypatch.setattr(bridge_mod, "_resolve_user", lambda payload: None)
+        called = {"factory": False}
+
+        def fake_factory(user_id):
+            called["factory"] = True
+            return None, "none"
+
+        monkeypatch.setattr(bridge_mod, "_service_for_user", fake_factory)
+
+        import io
+        import sys as _sys
+
+        monkeypatch.setattr(_sys, "stdin", io.StringIO(json.dumps({"command": "list"})))
+        out = io.StringIO()
+        monkeypatch.setattr(_sys, "stdout", out)
+        bridge_mod.main()
+        result = json.loads(out.getvalue())
+        assert result["ok"] is False
+        assert "No active user" in result["error"]
+        assert called["factory"] is False
+
+    def test_list_passes_resolved_user_to_factory(self, monkeypatch):
+        import bridge.rex_calendar_bridge as bridge_mod
+
+        captured: dict[str, Any] = {}
+
+        def fake_factory(user_id):
+            captured["user_id"] = user_id
+            return None, "none"
+
+        monkeypatch.setattr(bridge_mod, "_service_for_user", fake_factory)
+        result = bridge_mod._handle_list(ALICE, "", "")
+        assert result == {"ok": True, "events": [], "configured": False}
+        assert captured["user_id"] == ALICE
+
+    def test_create_without_account_fails_closed(self, monkeypatch):
+        import bridge.rex_calendar_bridge as bridge_mod
+
+        monkeypatch.setattr(bridge_mod, "_service_for_user", lambda user_id: (None, "none"))
+        result = bridge_mod._handle_create(ALICE, {"title": "x"})
+        assert result["ok"] is False
+        assert result["configured"] is False
+
+    def test_malformed_explicit_user_resolves_to_none(self):
+        import bridge.rex_calendar_bridge as bridge_mod
+
+        assert bridge_mod._resolve_user({"user": "../evil"}) is None
+
+
+# ---------------------------------------------------------------------------
+# OpenClaw tool: calendar_create
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarCreateTool:
+    def test_requires_user_identity(self):
+        """Regression: the base implementation created events with no user
+        identity at all."""
+        from rex.openclaw.tools.calendar_tool import calendar_create
+
+        result = calendar_create(
+            title="Standup",
+            start_time="2027-03-23T09:00:00",
+            end_time="2027-03-23T09:30:00",
+        )
+        assert result["ok"] is False
+        assert "user identity" in result["error"]
+
+    @pytest.mark.parametrize("bad", ["", "  ", "../evil", ".."])
+    def test_invalid_user_identity_fails_closed(self, bad):
+        from rex.openclaw.tools.calendar_tool import calendar_create
+
+        result = calendar_create(
+            title="Standup",
+            start_time="2027-03-23T09:00:00",
+            end_time="2027-03-23T09:30:00",
+            _user_id=bad,
+        )
+        assert result["ok"] is False
+
+    def test_creates_in_dispatching_users_store(self, monkeypatch):
+        from rex.calendar_service import CalendarService
+        from rex.openclaw.tools import calendar_tool
+
+        svc = CalendarService(mock_events=[], owner_user_id=ALICE)
+        monkeypatch.setattr(calendar_tool, "_get_calendar_service", lambda: svc)
+
+        result = calendar_tool.calendar_create(
+            title="Standup",
+            start_time="2027-03-23T09:00:00",
+            end_time="2027-03-23T09:30:00",
+            _user_id=ALICE,
+            transcript="create a standup meeting",
+        )
+        assert result["ok"] is True
+        assert [e.title for e in svc.get_all_events(user_id=ALICE)] == ["Standup"]
+        assert svc.get_all_events(user_id=BOB) == []
+
+    def test_foreign_account_id_gets_generic_error(self, monkeypatch, tmp_path):
+        from rex.calendar_service import CalendarService
+        from rex.openclaw.tools import calendar_tool
+
+        resolver = CalendarAccountResolver.from_raw_config(
+            {
+                "calendar": {
+                    "accounts": [
+                        {"id": "bob-cal", "provider": "stub"},
+                    ]
+                },
+                "users": {BOB: {"calendar_accounts": [{"account_id": "bob-cal"}]}},
+            }
+        )
+        svc = CalendarService(account_resolver=resolver)
+        monkeypatch.setattr(calendar_tool, "_get_calendar_service", lambda: svc)
+
+        result = calendar_tool.calendar_create(
+            title="Standup",
+            start_time="2027-03-23T09:00:00",
+            end_time="2027-03-23T09:30:00",
+            _user_id=ALICE,
+            account_id="bob-cal",
+        )
+        assert result["ok"] is False
+        assert "not available for user" in result["error"]
+
+    def test_arbitrary_credential_reference_kwarg_is_ignored(self, monkeypatch):
+        """Callers cannot inject credential references through tool kwargs."""
+        from rex.calendar_service import CalendarService
+        from rex.openclaw.tools import calendar_tool
+
+        svc = CalendarService(mock_events=[], owner_user_id=ALICE)
+        monkeypatch.setattr(calendar_tool, "_get_calendar_service", lambda: svc)
+
+        result = calendar_tool.calendar_create(
+            title="Standup",
+            start_time="2027-03-23T09:00:00",
+            end_time="2027-03-23T09:30:00",
+            _user_id=ALICE,
+            credential_ref="EVIL_TOKEN_ENV",
+            credentials_key="EVIL_TOKEN_ENV",
+        )
+        assert result["ok"] is True  # absorbed and ignored, not honored
+
+
+# ---------------------------------------------------------------------------
+# Local tool executor: calendar_create_event
+# ---------------------------------------------------------------------------
+
+
+class TestLocalToolExecutor:
+    @pytest.fixture(autouse=True)
+    def _isolated(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "appdata"))
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "appdata"))
+        empty = CalendarAccountResolver.from_raw_config({})
+        monkeypatch.setattr(CalendarAccountResolver, "load", classmethod(lambda cls: empty))
+
+    def test_missing_user_fails_closed(self):
+        """Regression: the base implementation created events without any
+        user identity."""
+        from rex.local_tool_executor import execute_tool
+
+        result = execute_tool("calendar_create_event", {"title": "Standup"})
+        assert "a valid user identity is required" in result
+
+    def test_invalid_user_fails_closed(self):
+        from rex.local_tool_executor import execute_tool
+
+        result = execute_tool("calendar_create_event", {"title": "Standup", "_user_id": "../evil"})
+        assert "a valid user identity is required" in result
+
+    def test_creates_in_requesting_users_store_only(self):
+        from rex.calendar_service import CalendarService
+        from rex.local_tool_executor import execute_tool
+
+        result = execute_tool(
+            "calendar_create_event",
+            {
+                "title": "Alice tool event",
+                "start": "2027-03-23T09:00:00",
+                "end": "2027-03-23T09:30:00",
+                "_user_id": ALICE,
+            },
+        )
+        assert "Calendar event created" in result
+
+        svc = CalendarService()
+        alice_titles = [e.title for e in svc.get_all_events(user_id=ALICE)]
+        bob_titles = [e.title for e in svc.get_all_events(user_id=BOB)]
+        assert "Alice tool event" in alice_titles
+        assert "Alice tool event" not in bob_titles
+
+
+# ---------------------------------------------------------------------------
+# Scheduler
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerIsolation:
+    def test_run_calendar_sync_runs_per_stored_owner(self, monkeypatch):
+        from rex import services
+
+        resolver = CalendarAccountResolver.from_raw_config(
+            {
+                "calendar": {
+                    "accounts": [
+                        {"id": "alice-cal", "provider": "stub"},
+                        {"id": "bob-cal", "provider": "stub"},
+                    ]
+                },
+                "users": {
+                    ALICE: {"calendar_accounts": [{"account_id": "alice-cal"}]},
+                    BOB: {"calendar_accounts": [{"account_id": "bob-cal"}]},
+                },
+            }
+        )
+        monkeypatch.setattr(CalendarAccountResolver, "load", classmethod(lambda cls: resolver))
+
+        calendar = MagicMock()
+        services._run_calendar_sync(calendar)
+        users = [c.kwargs["user_id"] for c in calendar.refresh_upcoming.call_args_list]
+        assert users == [ALICE, BOB]
+
+    def test_one_owner_failure_does_not_fall_through(self, monkeypatch):
+        from rex import services
+
+        resolver = CalendarAccountResolver.from_raw_config(
+            {
+                "calendar": {
+                    "accounts": [
+                        {"id": "alice-cal", "provider": "stub"},
+                        {"id": "bob-cal", "provider": "stub"},
+                    ]
+                },
+                "users": {
+                    ALICE: {"calendar_accounts": [{"account_id": "alice-cal"}]},
+                    BOB: {"calendar_accounts": [{"account_id": "bob-cal"}]},
+                },
+            }
+        )
+        monkeypatch.setattr(CalendarAccountResolver, "load", classmethod(lambda cls: resolver))
+
+        calendar = MagicMock()
+
+        def refresh(*, user_id):
+            if user_id == ALICE:
+                raise RuntimeError("alice backend down")
+            return []
+
+        calendar.refresh_upcoming.side_effect = refresh
+        services._run_calendar_sync(calendar)  # must not raise
+        users = [c.kwargs["user_id"] for c in calendar.refresh_upcoming.call_args_list]
+        assert users == [ALICE, BOB]
+
+    def test_ownerless_setup_never_touches_named_users(self, monkeypatch):
+        """With nothing configured, the legacy sync runs only as the
+        explicit default profile — never as a named user."""
+        from rex import services
+
+        empty = CalendarAccountResolver.from_raw_config({})
+        monkeypatch.setattr(CalendarAccountResolver, "load", classmethod(lambda cls: empty))
+
+        calendar = MagicMock()
+        services._run_calendar_sync(calendar)
+        users = [c.kwargs["user_id"] for c in calendar.refresh_upcoming.call_args_list]
+        assert users == ["default"]
+
+    def test_scheduled_job_publishes_safe_envelope_per_owner(self, monkeypatch):
+        from rex.integrations import _setup
+
+        resolver = CalendarAccountResolver.from_raw_config(
+            {
+                "calendar": {"accounts": [{"id": "alice-cal", "provider": "stub"}]},
+                "users": {ALICE: {"calendar_accounts": [{"account_id": "alice-cal"}]}},
+            }
+        )
+        monkeypatch.setattr(CalendarAccountResolver, "load", classmethod(lambda cls: resolver))
+
+        callbacks: dict[str, Any] = {}
+        scheduler = MagicMock()
+        scheduler.register_callback.side_effect = lambda name, fn: callbacks.__setitem__(name, fn)
+        published: list[Any] = []
+        bus = MagicMock()
+        bus.publish.side_effect = published.append
+        monkeypatch.setattr(_setup, "get_scheduler", lambda: scheduler)
+        monkeypatch.setattr(_setup, "get_event_bus", lambda: bus)
+
+        from rex.calendar_service import CalendarEvent
+
+        start = datetime.now(UTC) + timedelta(hours=1)
+        event = CalendarEvent(
+            title="Alice secret sync event",
+            start_time=start,
+            end_time=start + timedelta(hours=1),
+            attendees=["private@example.com"],
+            location="Secret site",
+        )
+        calendar = MagicMock()
+        calendar.get_upcoming_events.return_value = [event]
+        monkeypatch.setattr(_setup, "get_calendar_service", lambda: calendar)
+
+        _setup.setup_calendar_job()
+        callbacks["sync_calendar"](MagicMock())
+
+        assert calendar.get_upcoming_events.call_args.kwargs["user_id"] == ALICE
+
+        by_topic = {e.event_type: e.payload for e in published}
+        assert f"calendar.update.user.{ALICE}" in by_topic
+        assert "calendar.update" in by_topic
+        shared = by_topic["calendar.update"]
+        assert set(shared) == {"count", "user_id"}
+        assert "secret" not in str(shared).lower()
+        private = by_topic[f"calendar.update.user.{ALICE}"]
+        assert private["events"][0]["title"] == "Alice secret sync event"
+
+    def test_scheduled_job_skips_when_no_owners(self, monkeypatch):
+        from rex.integrations import _setup
+
+        empty = CalendarAccountResolver.from_raw_config({})
+        monkeypatch.setattr(CalendarAccountResolver, "load", classmethod(lambda cls: empty))
+
+        callbacks: dict[str, Any] = {}
+        scheduler = MagicMock()
+        scheduler.register_callback.side_effect = lambda name, fn: callbacks.__setitem__(name, fn)
+        bus = MagicMock()
+        service_touched = {"value": False}
+
+        def get_service():
+            service_touched["value"] = True
+            return MagicMock()
+
+        monkeypatch.setattr(_setup, "get_scheduler", lambda: scheduler)
+        monkeypatch.setattr(_setup, "get_event_bus", lambda: bus)
+        monkeypatch.setattr(_setup, "get_calendar_service", get_service)
+
+        _setup.setup_calendar_job()
+        callbacks["sync_calendar"](MagicMock())
+
+        assert service_touched["value"] is False
+        bus.publish.assert_not_called()

--- a/tests/test_calendar_user_isolation.py
+++ b/tests/test_calendar_user_isolation.py
@@ -1,0 +1,550 @@
+"""Per-user calendar account and credential isolation tests (issue #303).
+
+These tests reproduce and lock down the cross-user calendar defects present
+on the pre-#303 implementation (they fail against that base):
+
+1. All users shared one global calendar store: any user saw and mutated
+   every other user's events.
+2. Real calendar operations ran without any validated user identity.
+3. The provider-API service (rex.integrations.calendar_service) served any
+   caller with the global ``GOOGLE_CALENDAR_ACCESS_TOKEN`` and fell back to
+   shared stub data on provider failures (fail open).
+4. Full private event payloads (titles, attendees, locations, descriptions)
+   were published on shared event-bus topics.
+5. Account revocation had no effect in long-lived processes.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from rex.assistant_errors import IntegrationNotConfiguredError
+from rex.calendar_accounts import (
+    CalendarAccountAccessError,
+    CalendarAccountResolver,
+    CalendarIdentityError,
+)
+from rex.calendar_service import CalendarEvent, CalendarService
+
+ALICE = "alice"
+BOB = "bob"
+
+# Marker substring used to detect credential leakage in any output.
+SECRET_MARKER = "s3cr3t-cal-t0ken"  # pragma: allowlist secret
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _event(title: str, hours_from_now: float = 1.0) -> CalendarEvent:
+    start = datetime.now(UTC) + timedelta(hours=hours_from_now)
+    return CalendarEvent(
+        title=title,
+        start_time=start,
+        end_time=start + timedelta(hours=1),
+        attendees=["private@example.com"],
+        location="Private location",
+        description="Private description",
+    )
+
+
+def _ics_file(tmp_path, name: str, summary: str) -> str:
+    path = tmp_path / name
+    path.write_text(
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//Test//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        f"UID:{name}-1\r\n"
+        f"SUMMARY:{summary}\r\n"
+        "DTSTART:20270101T100000Z\r\n"
+        "DTEND:20270101T110000Z\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _two_user_ics_resolver(tmp_path) -> CalendarAccountResolver:
+    return CalendarAccountResolver.from_raw_config(
+        {
+            "calendar": {
+                "accounts": [
+                    {
+                        "id": "alice-cal",
+                        "provider": "ics",
+                        "ics": {"source": _ics_file(tmp_path, "alice.ics", "Alice Meeting")},
+                    },
+                    {
+                        "id": "bob-cal",
+                        "provider": "ics",
+                        "ics": {"source": _ics_file(tmp_path, "bob.ics", "Bob Meeting")},
+                    },
+                ],
+            },
+            "users": {
+                ALICE: {"calendar_accounts": [{"account_id": "alice-cal"}]},
+                BOB: {"calendar_accounts": [{"account_id": "bob-cal"}]},
+            },
+        }
+    )
+
+
+class RecordingBus:
+    """Fake event bus recording (topic, payload) publishes."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, topic: str, payload: dict[str, Any]) -> None:
+        self.published.append((topic, payload))
+
+    def topics(self) -> list[str]:
+        return [topic for topic, _ in self.published]
+
+    def payloads_for(self, topic: str) -> list[dict[str, Any]]:
+        return [payload for t, payload in self.published if t == topic]
+
+
+@pytest.fixture()
+def isolated_storage(tmp_path, monkeypatch):
+    """Point per-user runtime calendar storage at a temp directory."""
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "appdata"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "appdata"))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Identity validation (fails before any account/credential lookup)
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityRequired:
+    def test_missing_user_fails_closed(self):
+        svc = CalendarService(mock_events=[_event("X")], owner_user_id=ALICE)
+        with pytest.raises(CalendarIdentityError):
+            svc.get_all_events()
+        with pytest.raises(CalendarIdentityError):
+            svc.list_upcoming()
+        with pytest.raises(CalendarIdentityError):
+            svc.get_events(datetime.now(UTC), datetime.now(UTC) + timedelta(days=1))
+        with pytest.raises(CalendarIdentityError):
+            svc.create_event("t", datetime.now(UTC), datetime.now(UTC) + timedelta(hours=1))
+        with pytest.raises(CalendarIdentityError):
+            svc.update_event("id", {"title": "x"})
+        with pytest.raises(CalendarIdentityError):
+            svc.delete_event("id")
+        with pytest.raises(CalendarIdentityError):
+            svc.find_conflicts()
+
+    @pytest.mark.parametrize("bad", ["", "   ", "../../etc", "..", "a/b"])
+    def test_invalid_and_traversal_user_ids_fail_closed(self, bad):
+        svc = CalendarService(mock_events=[_event("X")], owner_user_id=ALICE)
+        with pytest.raises(CalendarIdentityError):
+            svc.get_all_events(user_id=bad)
+
+    def test_missing_identity_fails_before_backend_resolution(self, tmp_path):
+        """Identity errors are raised before any account/backend lookup."""
+        resolver = _two_user_ics_resolver(tmp_path)
+        svc = CalendarService(account_resolver=resolver)
+        with pytest.raises(CalendarIdentityError):
+            svc.get_all_events(user_id=None)
+        # No backend was built for anyone.
+        assert svc._user_backends == {}
+
+    def test_connect_fails_closed_without_identity(self):
+        svc = CalendarService(mock_events=[_event("X")], owner_user_id=ALICE)
+        assert svc.connect() is False
+        assert svc.connect(user_id="../evil") is False
+
+
+# ---------------------------------------------------------------------------
+# Store isolation (defect 1 on base: shared global store)
+# ---------------------------------------------------------------------------
+
+
+class TestStoreIsolation:
+    def test_in_memory_events_are_owner_bound(self):
+        svc = CalendarService(mock_events=[_event("Alice private event")], owner_user_id=ALICE)
+        assert [e.title for e in svc.get_all_events(user_id=ALICE)] == ["Alice private event"]
+        # Bob sees an isolated, empty store — never Alice's events.
+        assert svc.get_all_events(user_id=BOB) == []
+
+    def test_created_event_not_visible_to_other_user(self):
+        svc = CalendarService(mock_events=[], owner_user_id=ALICE)
+        svc.create_event(
+            "Alice meeting",
+            datetime.now(UTC) + timedelta(hours=1),
+            datetime.now(UTC) + timedelta(hours=2),
+            user_id=ALICE,
+        )
+        assert [e.title for e in svc.get_all_events(user_id=ALICE)] == ["Alice meeting"]
+        assert svc.get_all_events(user_id=BOB) == []
+        assert svc.list_upcoming(user_id=BOB) == []
+
+    def test_update_cannot_cross_users(self):
+        svc = CalendarService(mock_events=[], owner_user_id=ALICE)
+        event = svc.create_event(
+            "Alice meeting",
+            datetime.now(UTC) + timedelta(hours=1),
+            datetime.now(UTC) + timedelta(hours=2),
+            user_id=ALICE,
+        )
+        assert svc.update_event(event.event_id, {"title": "Hacked"}, user_id=BOB) is None
+        assert svc.get_all_events(user_id=ALICE)[0].title == "Alice meeting"
+
+    def test_delete_cannot_cross_users(self):
+        svc = CalendarService(mock_events=[], owner_user_id=ALICE)
+        event = svc.create_event(
+            "Alice meeting",
+            datetime.now(UTC) + timedelta(hours=1),
+            datetime.now(UTC) + timedelta(hours=2),
+            user_id=ALICE,
+        )
+        assert svc.delete_event(event.event_id, user_id=BOB) is False
+        assert len(svc.get_all_events(user_id=ALICE)) == 1
+
+    def test_stub_disk_stores_are_isolated_per_user(self, isolated_storage, monkeypatch):
+        """Stub-mode (no accounts configured) keeps separate per-user files."""
+        empty = CalendarAccountResolver.from_raw_config({})
+        svc = CalendarService(account_resolver=empty)
+        svc.create_event(
+            "Alice stub event",
+            datetime.now(UTC) + timedelta(hours=1),
+            datetime.now(UTC) + timedelta(hours=2),
+            user_id=ALICE,
+        )
+        titles_alice = [e.title for e in svc.get_all_events(user_id=ALICE)]
+        titles_bob = [e.title for e in svc.get_all_events(user_id=BOB)]
+        assert "Alice stub event" in titles_alice
+        assert "Alice stub event" not in titles_bob
+
+        # A fresh service instance (fresh process) sees the same isolation.
+        svc2 = CalendarService(account_resolver=empty)
+        assert "Alice stub event" in [e.title for e in svc2.get_all_events(user_id=ALICE)]
+        assert "Alice stub event" not in [e.title for e in svc2.get_all_events(user_id=BOB)]
+
+    def test_explicit_account_id_in_stub_mode_is_generic_error(self):
+        svc = CalendarService(mock_events=[], owner_user_id=ALICE)
+        assert svc.get_all_events(user_id=ALICE) == []  # sanity: works without account
+        with pytest.raises(CalendarAccountAccessError):
+            svc.list_upcoming(user_id=ALICE, account_id="any-account")
+
+
+# ---------------------------------------------------------------------------
+# Account-backed isolation (ICS backends per user)
+# ---------------------------------------------------------------------------
+
+
+class TestAccountBackedIsolation:
+    def test_users_get_only_their_own_ics_events(self, tmp_path):
+        svc = CalendarService(account_resolver=_two_user_ics_resolver(tmp_path))
+        alice_titles = [e.title for e in svc.get_all_events(user_id=ALICE)]
+        bob_titles = [e.title for e in svc.get_all_events(user_id=BOB)]
+        assert alice_titles == ["Alice Meeting"]
+        assert bob_titles == ["Bob Meeting"]
+
+    def test_backend_for_alice_is_not_reused_for_bob(self, tmp_path):
+        svc = CalendarService(account_resolver=_two_user_ics_resolver(tmp_path))
+        svc.get_all_events(user_id=ALICE)
+        svc.get_all_events(user_id=BOB)
+        keys = set(svc._user_backends)
+        assert (ALICE, "alice-cal") in keys
+        assert (BOB, "bob-cal") in keys
+        assert svc._user_backends[(ALICE, "alice-cal")] is not svc._user_backends[(BOB, "bob-cal")]
+
+    def test_same_user_backend_reuse_is_safe(self, tmp_path):
+        svc = CalendarService(account_resolver=_two_user_ics_resolver(tmp_path))
+        svc.get_all_events(user_id=ALICE)
+        backend_first = svc._user_backends[(ALICE, "alice-cal")]
+        svc.get_all_events(user_id=ALICE)
+        assert svc._user_backends[(ALICE, "alice-cal")] is backend_first
+        assert len([k for k in svc._user_backends if k[0] == ALICE]) == 1
+
+    def test_explicit_foreign_account_raises_generic_error(self, tmp_path):
+        svc = CalendarService(account_resolver=_two_user_ics_resolver(tmp_path))
+        with pytest.raises(CalendarAccountAccessError) as foreign:
+            svc.list_upcoming(user_id=ALICE, account_id="bob-cal")
+        with pytest.raises(CalendarAccountAccessError) as missing:
+            svc.list_upcoming(user_id=ALICE, account_id="no-such")
+        assert str(foreign.value).replace("bob-cal", "X") == str(missing.value).replace(
+            "no-such", "X"
+        )
+        # Bob's backend was never built for Alice's request.
+        assert (ALICE, "bob-cal") not in svc._user_backends
+
+    def test_unassigned_named_user_fails_closed_not_first_account(self, tmp_path):
+        """A named user with no assignment gets nothing — not the global or
+        first configured account."""
+        svc = CalendarService(account_resolver=_two_user_ics_resolver(tmp_path))
+        assert svc.get_all_events(user_id="charlie") == []
+        with pytest.raises(IntegrationNotConfiguredError):
+            svc.create_event(
+                "x",
+                datetime.now(UTC) + timedelta(hours=1),
+                datetime.now(UTC) + timedelta(hours=2),
+                user_id="charlie",
+            )
+        assert svc.connect(user_id="charlie") is False
+
+    def test_followup_cues_read_only_own_events(self, tmp_path, monkeypatch):
+        """generate_followup_cues() consumes only the requesting user's events."""
+        created: list[tuple[str, str]] = []
+
+        class FakeCueStore:
+            def has_cue_for_source(self, user_id, source_type, source_id):
+                return False
+
+            def add_cue(self, *, user_id, title, **kwargs):
+                created.append((user_id, title))
+
+        import rex.cue_store as cue_store_mod
+
+        monkeypatch.setattr(cue_store_mod, "get_cue_store", lambda: FakeCueStore())
+
+        past = _event("Bob past event", hours_from_now=-2)
+        svc = CalendarService(mock_events=[past], owner_user_id=BOB)
+        # Alice generates cues: none of Bob's events may leak into her cues.
+        assert svc.generate_followup_cues(ALICE) == 0
+        assert created == []
+        # Bob gets his own cue.
+        assert svc.generate_followup_cues(BOB) == 1
+        assert created == [(BOB, "Bob past event")]
+
+
+# ---------------------------------------------------------------------------
+# Revocation without restart
+# ---------------------------------------------------------------------------
+
+
+class TestRevocation:
+    def test_revoking_assignment_takes_effect_without_restart(self, tmp_path, monkeypatch):
+        resolver_with_alice = _two_user_ics_resolver(tmp_path)
+        resolver_revoked = CalendarAccountResolver.from_raw_config(
+            {
+                "calendar": {
+                    "accounts": [
+                        {
+                            "id": "bob-cal",
+                            "provider": "ics",
+                            "ics": {"source": _ics_file(tmp_path, "bob2.ics", "Bob Meeting")},
+                        }
+                    ]
+                },
+                "users": {BOB: {"calendar_accounts": [{"account_id": "bob-cal"}]}},
+            }
+        )
+
+        state = {"stamp": 1, "resolver": resolver_with_alice}
+        import rex.calendar_accounts as ca_mod
+
+        monkeypatch.setattr(ca_mod, "config_stamp", lambda: state["stamp"])
+        monkeypatch.setattr(
+            CalendarAccountResolver, "load", classmethod(lambda cls: state["resolver"])
+        )
+
+        svc = CalendarService()  # long-lived, config-backed resolver
+        assert [e.title for e in svc.get_all_events(user_id=ALICE)] == ["Alice Meeting"]
+
+        # Revoke Alice's assignment; the config stamp changes.
+        state["resolver"] = resolver_revoked
+        state["stamp"] = 2
+
+        assert svc.get_all_events(user_id=ALICE) == []
+        with pytest.raises(IntegrationNotConfiguredError):
+            svc.create_event(
+                "x",
+                datetime.now(UTC) + timedelta(hours=1),
+                datetime.now(UTC) + timedelta(hours=2),
+                user_id=ALICE,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Event-bus topics (defect 4 on base: private payloads on shared topics)
+# ---------------------------------------------------------------------------
+
+#: Fields that must never appear on shared topics.
+_PRIVATE_KEYS = {"events", "event", "title", "attendees", "location", "description"}
+
+
+class TestEventBusIsolation:
+    def test_shared_topics_carry_only_safe_envelopes(self):
+        bus = RecordingBus()
+        svc = CalendarService(
+            bus, mock_events=[_event("Alice secret meeting")], owner_user_id=ALICE
+        )
+        svc.connect(user_id=ALICE)
+        svc.list_upcoming(user_id=ALICE)
+        event = svc.create_event(
+            "Another secret",
+            datetime.now(UTC) + timedelta(hours=1),
+            datetime.now(UTC) + timedelta(hours=2),
+            user_id=ALICE,
+        )
+        svc.update_event(event.event_id, {"title": "Renamed secret"}, user_id=ALICE)
+        svc.delete_event(event.event_id, user_id=ALICE)
+        svc.get_events(datetime.now(UTC), datetime.now(UTC) + timedelta(days=1), user_id=ALICE)
+
+        shared = [(topic, payload) for topic, payload in bus.published if ".user." not in topic]
+        assert shared, "expected shared envelope events"
+        for topic, payload in shared:
+            leaked = _PRIVATE_KEYS.intersection(payload)
+            assert not leaked, f"shared topic {topic} leaked private fields: {leaked}"
+            blob = str(payload)
+            assert "secret" not in blob.lower()
+            assert "private@example.com" not in blob
+
+    def test_private_payloads_go_to_user_scoped_topics(self):
+        bus = RecordingBus()
+        svc = CalendarService(
+            bus, mock_events=[_event("Alice secret meeting")], owner_user_id=ALICE
+        )
+        svc.list_upcoming(user_id=ALICE)
+        user_payloads = bus.payloads_for(f"calendar.upcoming.user.{ALICE}")
+        assert user_payloads
+        assert user_payloads[0]["events"][0]["title"] == "Alice secret meeting"
+        # No other user's topic ever received Alice's payload.
+        assert not [t for t in bus.topics() if ".user." in t and not t.endswith(f".user.{ALICE}")]
+
+
+# ---------------------------------------------------------------------------
+# Provider-API service (rex.integrations.calendar_service)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderServiceIsolation:
+    def _raw_config(self) -> dict:
+        return {
+            "calendar": {
+                "provider": "google",
+                "accounts": [
+                    {
+                        "id": "alice-google",
+                        "provider": "google",
+                        "credential_ref": "GOOGLE_CALENDAR_TOKEN_ALICE",
+                    },
+                    {
+                        "id": "bob-google",
+                        "provider": "google",
+                        "credential_ref": "GOOGLE_CALENDAR_TOKEN_BOB",
+                    },
+                ],
+            },
+            "users": {
+                ALICE: {"calendar_accounts": [{"account_id": "alice-google"}]},
+                BOB: {"calendar_accounts": [{"account_id": "bob-google"}]},
+            },
+        }
+
+    def test_named_user_gets_own_token_never_bobs(self, monkeypatch):
+        from rex.integrations.calendar_service import create_calendar_service_for_user
+
+        monkeypatch.setenv("GOOGLE_CALENDAR_TOKEN_ALICE", f"alice-{SECRET_MARKER}")
+        monkeypatch.setenv("GOOGLE_CALENDAR_TOKEN_BOB", f"bob-{SECRET_MARKER}")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", f"global-{SECRET_MARKER}")
+
+        svc, provider = create_calendar_service_for_user(ALICE, self._raw_config())
+        assert provider == "google" and svc is not None
+        auth = svc._google_headers()["Authorization"]
+        assert auth == f"Bearer alice-{SECRET_MARKER}"
+        assert "bob-" not in auth and "global-" not in auth
+
+    def test_named_user_never_inherits_global_env_token(self, monkeypatch):
+        from rex.integrations.calendar_service import create_calendar_service_for_user
+
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", f"global-{SECRET_MARKER}")
+        raw = {"calendar": {"provider": "google"}}
+        svc, provider = create_calendar_service_for_user("james", raw)
+        assert svc is None
+        assert provider == "none"
+
+    def test_default_profile_keeps_legacy_global_provider(self, monkeypatch):
+        from rex.integrations.calendar_service import create_calendar_service_for_user
+
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", f"global-{SECRET_MARKER}")
+        raw = {"calendar": {"provider": "google"}}
+        svc, provider = create_calendar_service_for_user("default", raw)
+        assert provider == "google" and svc is not None
+        assert svc._google_headers()["Authorization"] == f"Bearer global-{SECRET_MARKER}"
+
+    def test_identity_required_before_any_credential_read(self, monkeypatch):
+        """Missing/invalid identity raises before the resolver or any
+        environment token is consulted."""
+        from rex.integrations import calendar_service as provider_mod
+
+        consulted = {"resolver": False}
+
+        class BoomResolver:
+            @classmethod
+            def from_raw_config(cls, raw):
+                consulted["resolver"] = True
+                raise AssertionError("resolver must not be consulted without identity")
+
+        import rex.calendar_accounts as ca_mod
+
+        monkeypatch.setattr(ca_mod, "CalendarAccountResolver", BoomResolver)
+        with pytest.raises(PermissionError):
+            provider_mod.create_calendar_service_for_user("", self._raw_config())
+        with pytest.raises(PermissionError):
+            provider_mod.create_calendar_service_for_user("../evil", self._raw_config())
+        assert consulted["resolver"] is False
+
+    def test_missing_named_token_fails_closed_no_fallback(self, monkeypatch):
+        from rex.integrations.calendar_service import create_calendar_service_for_user
+
+        monkeypatch.delenv("GOOGLE_CALENDAR_TOKEN_ALICE", raising=False)
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", f"global-{SECRET_MARKER}")
+        svc, provider = create_calendar_service_for_user(ALICE, self._raw_config())
+        assert svc is None and provider == "none"
+
+    def test_google_failure_returns_empty_not_stub_data(self, monkeypatch):
+        """Regression: base implementation returned shared stub events on
+        provider errors (fail open)."""
+        from rex.integrations.calendar_service import CalendarService as ProviderCalendarService
+
+        svc = ProviderCalendarService(calendar_provider="google", access_token="bad-token")
+
+        def boom(*args, **kwargs):
+            raise OSError("network down")
+
+        monkeypatch.setattr("urllib.request.urlopen", boom)
+        events = svc.get_events(datetime.now(UTC), datetime.now(UTC) + timedelta(days=7))
+        assert events == []
+
+    def test_no_token_values_in_logs(self, monkeypatch, caplog):
+        from rex.integrations.calendar_service import create_calendar_service_for_user
+
+        monkeypatch.setenv("GOOGLE_CALENDAR_TOKEN_ALICE", f"alice-{SECRET_MARKER}")
+        with caplog.at_level(logging.DEBUG):
+            create_calendar_service_for_user(ALICE, self._raw_config())
+            create_calendar_service_for_user("charlie", self._raw_config())
+        assert SECRET_MARKER not in caplog.text
+
+    def test_arbitrary_credential_reference_injection_is_ignored(self, monkeypatch):
+        """Callers cannot supply their own credential reference: routing uses
+        only the authorized account definition's credential_ref."""
+        from rex.integrations.calendar_service import create_calendar_service_for_user
+
+        monkeypatch.setenv("GOOGLE_CALENDAR_TOKEN_ALICE", "alice-token")
+        monkeypatch.setenv("EVIL_REF", "evil-token")
+        raw = self._raw_config()
+        # A malicious per-user entry cannot switch the credential ref: the
+        # canonical definition in calendar.accounts is authoritative.
+        raw["users"][ALICE]["calendar_accounts"] = [
+            {
+                "account_id": "alice-google",
+                "credential_ref": "EVIL_REF",
+                "credentials_key": "EVIL_REF",
+            }
+        ]
+        svc, provider = create_calendar_service_for_user(ALICE, raw)
+        assert provider == "google" and svc is not None
+        assert svc._google_headers()["Authorization"] == "Bearer alice-token"

--- a/tests/test_cli_calendar_accounts.py
+++ b/tests/test_cli_calendar_accounts.py
@@ -1,0 +1,250 @@
+"""Tests for calendar account management CLI commands (issue #303).
+
+Covers: rex calendar accounts list, set-active, test-connection, upcoming —
+all user-scoped.  Every subcommand resolves one validated user, fails closed
+without identity, and reveals only that user's accounts.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rex.calendar_accounts import CalendarAccountResolver
+from rex.cli import cmd_calendar
+
+TWO_USER_RAW = {
+    "calendar": {
+        "accounts": [
+            {
+                "id": "alice-cal",
+                "label": "Alice calendar",
+                "provider": "ics",
+                "ics": {"source": "https://example.com/alice.ics"},
+            },
+            {
+                "id": "bob-cal",
+                "label": "Bob calendar",
+                "provider": "google",
+                "credential_ref": "GOOGLE_CALENDAR_TOKEN_BOB",
+            },
+        ],
+    },
+    "users": {
+        "alice": {"calendar_accounts": [{"account_id": "alice-cal"}]},
+        "bob": {"calendar_accounts": [{"account_id": "bob-cal"}]},
+    },
+}
+
+
+@pytest.fixture
+def mock_calendar_service():
+    with patch("rex.cli.get_calendar_service") as mock:
+        service = MagicMock()
+        service.connected = False
+        mock.return_value = service
+        yield service
+
+
+@pytest.fixture
+def _no_calendar_resolver():
+    with patch("rex.cli._load_calendar_resolver_safe", return_value=None):
+        yield
+
+
+@pytest.fixture
+def _two_user_resolver():
+    resolver = CalendarAccountResolver.from_raw_config(TWO_USER_RAW)
+    with patch("rex.cli._load_calendar_resolver_safe", return_value=resolver):
+        yield resolver
+
+
+def _args(**kwargs) -> MagicMock:
+    kwargs.setdefault("user", "alice")
+    return MagicMock(**kwargs)
+
+
+class TestCalendarRequiresUser:
+    def test_missing_identity_fails_closed(self, mock_calendar_service, capsys):
+        with patch("rex.cli._resolve_cli_user", return_value=None):
+            args = _args(calendar_command="upcoming", user=None)
+            result = cmd_calendar(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "No active user for calendar" in out
+        assert "rex identify" in out
+
+    def test_invalid_identity_fails_closed(self, mock_calendar_service, capsys):
+        args = _args(calendar_command="upcoming", user="../evil")
+        result = cmd_calendar(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "Error" in out
+
+    def test_upcoming_passes_resolved_user(self, mock_calendar_service, capsys):
+        mock_calendar_service.connected = True
+        mock_calendar_service.get_upcoming_events.return_value = []
+        args = _args(calendar_command="upcoming", days=7, conflicts=False, verbose=False)
+        result = cmd_calendar(args)
+        assert result == 0
+        kwargs = mock_calendar_service.get_upcoming_events.call_args.kwargs
+        assert kwargs["user_id"] == "alice"
+
+    def test_upcoming_connects_as_resolved_user(self, mock_calendar_service, capsys):
+        mock_calendar_service.connected = False
+        mock_calendar_service.connect.return_value = True
+        mock_calendar_service.get_upcoming_events.return_value = []
+        args = _args(calendar_command="upcoming", days=7, conflicts=False, verbose=False)
+        result = cmd_calendar(args)
+        assert result == 0
+        mock_calendar_service.connect.assert_called_once_with("alice")
+
+
+class TestCalendarAccountsList:
+    def test_no_accounts_configured(self, _no_calendar_resolver, capsys):
+        args = _args(calendar_command="accounts", accounts_command="list")
+        result = cmd_calendar(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No calendar accounts configured for user 'alice'" in out
+
+    def test_list_shows_only_own_accounts(self, _two_user_resolver, capsys):
+        args = _args(calendar_command="accounts", accounts_command="list", user="alice")
+        result = cmd_calendar(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "alice-cal" in out
+        # Bob's account and label are never revealed to Alice.
+        assert "bob-cal" not in out
+        assert "Bob calendar" not in out
+
+    def test_list_never_prints_credential_references(self, _two_user_resolver, capsys):
+        args = _args(calendar_command="accounts", accounts_command="list", user="bob")
+        result = cmd_calendar(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "bob-cal" in out
+        assert "GOOGLE_CALENDAR_TOKEN_BOB" not in out
+
+    def test_user_with_no_assignments_sees_nothing(self, _two_user_resolver, capsys):
+        args = _args(calendar_command="accounts", accounts_command="list", user="charlie")
+        result = cmd_calendar(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No calendar accounts configured for user 'charlie'" in out
+        assert "alice-cal" not in out
+        assert "bob-cal" not in out
+
+
+class TestCalendarAccountsSetActive:
+    def test_set_active_no_config(self, _no_calendar_resolver, capsys):
+        args = _args(
+            calendar_command="accounts", accounts_command="set-active", account_id="alice-cal"
+        )
+        result = cmd_calendar(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "Error" in out
+
+    def test_set_active_foreign_account_rejected(self, _two_user_resolver, capsys):
+        args = _args(
+            calendar_command="accounts",
+            accounts_command="set-active",
+            account_id="bob-cal",
+            user="alice",
+        )
+        result = cmd_calendar(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "not available for user 'alice'" in out
+
+    def test_set_active_nonexistent_matches_foreign(self, _two_user_resolver, capsys):
+        args = _args(
+            calendar_command="accounts",
+            accounts_command="set-active",
+            account_id="no-such",
+            user="alice",
+        )
+        result = cmd_calendar(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "not available for user 'alice'" in out
+
+    def test_set_active_updates_only_selected_users_default(
+        self, _two_user_resolver, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "rex_config.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps({"users": {"bob": {"default_calendar_account_id": "bob-cal"}}}),
+            encoding="utf-8",
+        )
+
+        args = _args(
+            calendar_command="accounts",
+            accounts_command="set-active",
+            account_id="alice-cal",
+            user="alice",
+        )
+        result = cmd_calendar(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "for user 'alice'" in out
+
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+        assert written["users"]["alice"]["default_calendar_account_id"] == "alice-cal"
+        # Bob's default and the legacy global default are untouched.
+        assert written["users"]["bob"]["default_calendar_account_id"] == "bob-cal"
+        assert "default_account_id" not in written.get("calendar", {})
+
+
+class TestCalendarTestConnection:
+    def test_no_accounts_stub(self, _no_calendar_resolver, capsys):
+        args = _args(calendar_command="test-connection", account_id=None)
+        result = cmd_calendar(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "stub" in out.lower()
+
+    def test_foreign_account_not_revealed(self, _two_user_resolver, capsys):
+        args = _args(calendar_command="test-connection", account_id="bob-cal", user="alice")
+        result = cmd_calendar(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "Available for user 'alice': alice-cal" in out
+        assert "GOOGLE_CALENDAR_TOKEN_BOB" not in out
+
+    def test_user_without_accounts_gets_generic_result(self, _two_user_resolver, capsys):
+        args = _args(calendar_command="test-connection", account_id=None, user="charlie")
+        result = cmd_calendar(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "No calendar accounts configured for user 'charlie'" in out
+        assert "alice-cal" not in out
+
+    def test_own_google_account_checks_own_credential_without_printing_ref(
+        self, _two_user_resolver, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("GOOGLE_CALENDAR_TOKEN_BOB", "bob-token-value")
+        args = _args(calendar_command="test-connection", account_id=None, user="bob")
+        result = cmd_calendar(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Connection test passed" in out
+        # Neither the credential reference nor the token value is echoed.
+        assert "GOOGLE_CALENDAR_TOKEN_BOB" not in out
+        assert "bob-token-value" not in out
+
+    def test_missing_credential_fails_without_leaking_ref(
+        self, _two_user_resolver, monkeypatch, capsys
+    ):
+        monkeypatch.delenv("GOOGLE_CALENDAR_TOKEN_BOB", raising=False)
+        args = _args(calendar_command="test-connection", account_id=None, user="bob")
+        result = cmd_calendar(args)
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "NOT FOUND" in out
+        assert "GOOGLE_CALENDAR_TOKEN_BOB" not in out

--- a/tests/test_cli_scheduler.py
+++ b/tests/test_cli_scheduler.py
@@ -73,7 +73,7 @@ def test_cli_calendar_upcoming(capsys, monkeypatch):
 
     reset_services()
     monkeypatch.setattr("rex.cli.get_calendar_service", lambda: CalendarService())
-    args = Namespace(calendar_command="upcoming")
+    args = Namespace(calendar_command="upcoming", user="default")
     assert cmd_calendar(args) == 0
     output = capsys.readouterr().out
     assert "Upcoming Events" in output

--- a/tests/test_cli_scheduler_email_calendar.py
+++ b/tests/test_cli_scheduler_email_calendar.py
@@ -277,7 +277,7 @@ class TestCalendarCLI:
         mock_calendar_service.get_upcoming_events.return_value = []
 
         args = MagicMock(
-            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user=None
+            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user="default"
         )
         result = cmd_calendar(args)
 
@@ -306,7 +306,7 @@ class TestCalendarCLI:
         mock_calendar_service.get_upcoming_events.return_value = [event]
 
         args = MagicMock(
-            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user=None
+            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user="default"
         )
         result = cmd_calendar(args)
 
@@ -337,7 +337,7 @@ class TestCalendarCLI:
         mock_calendar_service.get_upcoming_events.return_value = [event]
 
         args = MagicMock(
-            calendar_command="upcoming", days=7, conflicts=False, verbose=True, user=None
+            calendar_command="upcoming", days=7, conflicts=False, verbose=True, user="default"
         )
         result = cmd_calendar(args)
 
@@ -363,7 +363,7 @@ class TestCalendarCLI:
         mock_calendar_service.get_upcoming_events.return_value = [event]
 
         args = MagicMock(
-            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user=None
+            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user="default"
         )
         result = cmd_calendar(args)
 
@@ -398,7 +398,7 @@ class TestCalendarCLI:
         mock_calendar_service.find_conflicts.return_value = [(event1, event2)]
 
         args = MagicMock(
-            calendar_command="upcoming", days=7, conflicts=True, verbose=False, user=None
+            calendar_command="upcoming", days=7, conflicts=True, verbose=False, user="default"
         )
         result = cmd_calendar(args)
 
@@ -414,18 +414,20 @@ class TestCalendarCLI:
         mock_calendar_service.get_upcoming_events.return_value = []
 
         args = MagicMock(
-            calendar_command="upcoming", days=14, conflicts=False, verbose=False, user=None
+            calendar_command="upcoming", days=14, conflicts=False, verbose=False, user="default"
         )
         cmd_calendar(args)
 
-        mock_calendar_service.get_upcoming_events.assert_called_once_with(days=14)
+        mock_calendar_service.get_upcoming_events.assert_called_once_with(
+            days=14, user_id="default"
+        )
 
     def test_calendar_upcoming_connection_failure(self, mock_calendar_service, capsys):
         """Test calendar command when connection fails."""
         mock_calendar_service.connect.return_value = False
 
         args = MagicMock(
-            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user=None
+            calendar_command="upcoming", days=7, conflicts=False, verbose=False, user="default"
         )
         result = cmd_calendar(args)
 
@@ -435,7 +437,7 @@ class TestCalendarCLI:
 
     def test_calendar_unknown_command(self, mock_calendar_service, capsys):
         """Test unknown calendar subcommand."""
-        args = MagicMock(calendar_command="unknown", user=None)
+        args = MagicMock(calendar_command="unknown", user="default")
         result = cmd_calendar(args)
 
         assert result == 1

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -276,13 +276,13 @@ def test_notifier_event_subscription():
         notifier = Notifier()
         notifier.setup_event_subscriptions()
 
-        # Should subscribe to user-scoped email events (wildcard with a
-        # prefix filter) and calendar events via EventBridge
-        assert mock_bridge.subscribe.call_count == 2
+        # Should subscribe once via a wildcard: user-scoped email and
+        # calendar topics are routed through the prefix filter in
+        # _on_any_event (shared topics carry only safe envelopes).
+        assert mock_bridge.subscribe.call_count == 1
         calls = mock_bridge.subscribe.call_args_list
         event_types = [call[0][0] for call in calls]
-        assert "*" in event_types
-        assert "calendar.update" in event_types
+        assert event_types == ["*"]
 
 
 def test_notifier_email_unread_handler(notifier):

--- a/tests/test_openclaw_policy_gated_tools.py
+++ b/tests/test_openclaw_policy_gated_tools.py
@@ -175,11 +175,12 @@ class TestCalendarTool:
         with patch(
             "rex.openclaw.tools.calendar_tool._get_calendar_service", return_value=mock_service
         ):
-            result = calendar_create("Meeting", start, end)
+            result = calendar_create("Meeting", start, end, _user_id="default")
 
         mock_service.create_event.assert_called_once()
         call_kwargs = mock_service.create_event.call_args
         assert call_kwargs.kwargs["title"] == "Meeting"
+        assert call_kwargs.kwargs["user_id"] == "default"
         assert isinstance(call_kwargs.kwargs["start_time"], datetime)
         assert isinstance(call_kwargs.kwargs["end_time"], datetime)
         assert result["ok"] is True
@@ -200,7 +201,7 @@ class TestCalendarTool:
         with patch(
             "rex.openclaw.tools.calendar_tool._get_calendar_service", return_value=mock_service
         ):
-            result = calendar_create("Standup", start_dt, end_dt)
+            result = calendar_create("Standup", start_dt, end_dt, _user_id="default")
 
         assert result["ok"] is True
         assert result["title"] == "Standup"
@@ -216,7 +217,7 @@ class TestCalendarTool:
         with patch(
             "rex.openclaw.tools.calendar_tool._get_calendar_service", return_value=mock_service
         ):
-            calendar_create("X", "2026-04-01T10:00:00", "2026-04-01T11:00:00")
+            calendar_create("X", "2026-04-01T10:00:00", "2026-04-01T11:00:00", _user_id="default")
 
         start_arg = mock_service.create_event.call_args.kwargs["start_time"]
         assert start_arg.tzinfo is not None
@@ -238,6 +239,7 @@ class TestCalendarTool:
                 "2026-05-01T17:00:00",
                 location="London HQ",
                 description="Annual offsite",
+                _user_id="default",
             )
 
         kwargs = mock_service.create_event.call_args.kwargs

--- a/tests/test_outlook_integration_honesty.py
+++ b/tests/test_outlook_integration_honesty.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
 
 import rex_calendar_bridge
 import rex_email_bridge
 
-import rex.config
 from rex.config import build_app_config
 
 REPO = Path(__file__).parent.parent
@@ -41,13 +39,17 @@ def test_email_bridge_reports_outlook_as_unsupported(monkeypatch) -> None:
 
 
 def test_calendar_bridge_reports_outlook_list_as_unsupported(monkeypatch) -> None:
+    import rex.config_manager
+
     monkeypatch.setattr(
-        rex.config,
+        rex.config_manager,
         "load_config",
-        lambda: SimpleNamespace(calendar_provider="outlook"),
+        lambda *a, **k: {"calendar": {"provider": "outlook"}},
     )
 
-    result = rex_calendar_bridge._handle_list("", "")
+    # Legacy global provider config serves only the explicit default profile
+    # (issue #303); the honest "unsupported" answer is preserved for it.
+    result = rex_calendar_bridge._handle_list("default", "", "")
 
     assert result["ok"] is False
     assert result["configured"] is True
@@ -55,18 +57,21 @@ def test_calendar_bridge_reports_outlook_list_as_unsupported(monkeypatch) -> Non
 
 
 def test_calendar_bridge_reports_outlook_create_as_unsupported(monkeypatch) -> None:
+    import rex.config_manager
+
     monkeypatch.setattr(
-        rex.config,
+        rex.config_manager,
         "load_config",
-        lambda: SimpleNamespace(calendar_provider="outlook"),
+        lambda *a, **k: {"calendar": {"provider": "outlook"}},
     )
 
     result = rex_calendar_bridge._handle_create(
+        "default",
         {
             "title": "Doctor appointment",
             "start": "2026-04-22T10:00:00+00:00",
             "end": "2026-04-22T11:00:00+00:00",
-        }
+        },
     )
 
     assert result["ok"] is False

--- a/tests/test_tool_router.py
+++ b/tests/test_tool_router.py
@@ -251,6 +251,7 @@ class TestCalendarCreateEvent:
                     "title": "Team Meeting",
                     "start": "2026-04-01T10:00:00",
                     "end": "2026-04-01T11:00:00",
+                    "_user_id": "default",
                 },
             )
         assert "Calendar event created" in result
@@ -268,14 +269,16 @@ class TestCalendarCreateEvent:
         mock_svc = MagicMock()
         mock_svc.create_event.return_value = fake_event
         with patch("rex.local_tool_executor.CalendarService", return_value=mock_svc):
-            result = execute_tool("calendar_create_event", {"title": "Standup"})
+            result = execute_tool(
+                "calendar_create_event", {"title": "Standup", "_user_id": "default"}
+            )
         assert "Calendar event created" in result
 
     def test_exception_degraded_gracefully(self):
         with patch("rex.local_tool_executor.CalendarService", side_effect=RuntimeError("db error")):
             result = execute_tool(
                 "calendar_create_event",
-                {"title": "Broken", "start": "2026-04-01T10:00:00"},
+                {"title": "Broken", "start": "2026-04-01T10:00:00", "_user_id": "default"},
             )
         assert "[calendar error:" in result
         assert isinstance(result, str)
@@ -292,7 +295,9 @@ class TestCalendarCreateEvent:
         mock_svc = MagicMock()
         mock_svc.create_event.return_value = fake_event
         with patch("rex.local_tool_executor.CalendarService", return_value=mock_svc):
-            result = execute_tool("calendar_create_event", {"summary": "Weekly Sync"})
+            result = execute_tool(
+                "calendar_create_event", {"summary": "Weekly Sync", "_user_id": "default"}
+            )
         assert "Calendar event created" in result
 
 

--- a/tests/test_us013_calendar_no_mock.py
+++ b/tests/test_us013_calendar_no_mock.py
@@ -34,28 +34,28 @@ class TestNoHardcodedFakeEvents:
     def test_new_service_with_no_file_returns_empty_list(self, tmp_path):
         """CalendarService with a non-existent path returns [] — no fake events."""
         svc = CalendarService(mock_data_path=tmp_path / "does_not_exist.json")
-        svc.connect()
-        events = svc.get_all_events()
+        svc.connect(user_id="default")
+        events = svc.get_all_events(user_id="default")
         assert events == []
 
     def test_default_mode_no_seed_file_returns_empty(self, monkeypatch, tmp_path):
         """Without any seed file or runtime file, _load_events returns []."""
         svc = CalendarService(mock_data_path=tmp_path / "missing.json")
-        events = svc.get_all_events()
+        events = svc.get_all_events(user_id="default")
         assert events == []
 
     def test_no_product_sync_event_in_default_state(self, tmp_path):
         """'Product sync' hardcoded event must not appear in any default state."""
         svc = CalendarService(mock_data_path=tmp_path / "empty.json")
-        svc.connect()
-        titles = [e.title for e in svc.get_all_events()]
+        svc.connect(user_id="default")
+        titles = [e.title for e in svc.get_all_events(user_id="default")]
         assert "Product sync" not in titles
 
     def test_no_checkin_event_in_default_state(self, tmp_path):
         """'1:1 check-in' hardcoded event must not appear in any default state."""
         svc = CalendarService(mock_data_path=tmp_path / "empty.json")
-        svc.connect()
-        titles = [e.title for e in svc.get_all_events()]
+        svc.connect(user_id="default")
+        titles = [e.title for e in svc.get_all_events(user_id="default")]
         assert "1:1 check-in" not in titles
 
 
@@ -87,8 +87,8 @@ class TestConfiguredPath:
             end_time=now + timedelta(hours=2),
         )
         svc = CalendarService(mock_events=[real_event])
-        svc.connect()
-        events = svc.get_all_events()
+        svc.connect(user_id="default")
+        events = svc.get_all_events(user_id="default")
         assert len(events) == 1
         assert events[0].title == "Real Meeting"
 
@@ -114,8 +114,8 @@ class TestConfiguredPath:
             encoding="utf-8",
         )
         svc = CalendarService(mock_data_path=cal_file)
-        svc.connect()
-        events = svc.get_all_events()
+        svc.connect(user_id="default")
+        events = svc.get_all_events(user_id="default")
         assert len(events) == 1
         assert events[0].title == "File Event"
 

--- a/tests/test_us045_calendar_integration.py
+++ b/tests/test_us045_calendar_integration.py
@@ -31,7 +31,7 @@ def _make_service(tmp_path: Path) -> CalendarService:
     """Create an isolated CalendarService backed by a temp file."""
     cal_file = tmp_path / "calendar.json"
     svc = CalendarService(mock_data_path=cal_file)
-    svc.connect()
+    svc.connect(user_id="default")
     return svc
 
 
@@ -60,41 +60,51 @@ def reset_calendar_service():
 class TestEventsRetrieved:
     def test_connect_returns_true(self, tmp_path):
         svc = CalendarService(mock_data_path=tmp_path / "cal.json")
-        assert svc.connect() is True
+        assert svc.connect(user_id="default") is True
 
     def test_get_all_events_returns_list(self, tmp_path):
         svc = _make_service(tmp_path)
-        events = svc.get_all_events()
+        events = svc.get_all_events(user_id="default")
         assert isinstance(events, list)
 
     def test_get_events_in_range(self, tmp_path):
         svc = _make_service(tmp_path)
         now = _now()
-        svc.create_event("Future meeting", now + timedelta(hours=1), now + timedelta(hours=2))
-        events = svc.get_events(now, now + timedelta(hours=3))
+        svc.create_event(
+            "Future meeting", now + timedelta(hours=1), now + timedelta(hours=2), user_id="default"
+        )
+        events = svc.get_events(now, now + timedelta(hours=3), user_id="default")
         assert len(events) >= 1
         assert any(e.title == "Future meeting" for e in events)
 
     def test_list_upcoming_returns_future_events(self, tmp_path):
         svc = _make_service(tmp_path)
         now = _now()
-        svc.create_event("Soon", now + timedelta(hours=1), now + timedelta(hours=2))
-        upcoming = svc.list_upcoming(horizon_hours=48)
+        svc.create_event(
+            "Soon", now + timedelta(hours=1), now + timedelta(hours=2), user_id="default"
+        )
+        upcoming = svc.list_upcoming(horizon_hours=48, user_id="default")
         assert any(e.title == "Soon" for e in upcoming)
 
     def test_list_upcoming_excludes_past_events(self, tmp_path):
         svc = _make_service(tmp_path)
         now = _now()
-        svc.create_event("Old", now - timedelta(hours=10), now - timedelta(hours=9))
-        upcoming = svc.list_upcoming(horizon_hours=1)
+        svc.create_event(
+            "Old", now - timedelta(hours=10), now - timedelta(hours=9), user_id="default"
+        )
+        upcoming = svc.list_upcoming(horizon_hours=1, user_id="default")
         assert not any(e.title == "Old" for e in upcoming)
 
     def test_events_sorted_by_start_time(self, tmp_path):
         svc = _make_service(tmp_path)
         now = _now()
-        svc.create_event("Second", now + timedelta(hours=5), now + timedelta(hours=6))
-        svc.create_event("First", now + timedelta(hours=1), now + timedelta(hours=2))
-        events = svc.get_events(now, now + timedelta(hours=10))
+        svc.create_event(
+            "Second", now + timedelta(hours=5), now + timedelta(hours=6), user_id="default"
+        )
+        svc.create_event(
+            "First", now + timedelta(hours=1), now + timedelta(hours=2), user_id="default"
+        )
+        events = svc.get_events(now, now + timedelta(hours=10), user_id="default")
         starts = [e.start_time for e in events]
         assert starts == sorted(starts)
 
@@ -113,15 +123,20 @@ class TestEventsRetrieved:
         }
         cal_file.write_text(json.dumps(data), encoding="utf-8")
         svc = CalendarService(mock_data_path=cal_file)
-        svc.connect()
-        events = svc.get_all_events()
+        svc.connect(user_id="default")
+        events = svc.get_all_events(user_id="default")
         assert any(e.title == "Loaded Event" for e in events)
 
     def test_get_upcoming_events_by_days(self, tmp_path):
         svc = _make_service(tmp_path)
         now = _now()
-        svc.create_event("Next week", now + timedelta(days=3), now + timedelta(days=3, hours=1))
-        events = svc.get_upcoming_events(days=7)
+        svc.create_event(
+            "Next week",
+            now + timedelta(days=3),
+            now + timedelta(days=3, hours=1),
+            user_id="default",
+        )
+        events = svc.get_upcoming_events(days=7, user_id="default")
         assert any(e.title == "Next week" for e in events)
 
 
@@ -134,28 +149,36 @@ class TestEventsCreated:
     def test_create_event_returns_calendar_event(self, tmp_path):
         svc = _make_service(tmp_path)
         now = _now()
-        event = svc.create_event("Test Event", now + timedelta(hours=1), now + timedelta(hours=2))
+        event = svc.create_event(
+            "Test Event", now + timedelta(hours=1), now + timedelta(hours=2), user_id="default"
+        )
         assert isinstance(event, CalendarEvent)
         assert event.title == "Test Event"
 
     def test_created_event_has_unique_id(self, tmp_path):
         svc = _make_service(tmp_path)
         now = _now()
-        e1 = svc.create_event("A", now + timedelta(hours=1), now + timedelta(hours=2))
-        e2 = svc.create_event("B", now + timedelta(hours=3), now + timedelta(hours=4))
+        e1 = svc.create_event(
+            "A", now + timedelta(hours=1), now + timedelta(hours=2), user_id="default"
+        )
+        e2 = svc.create_event(
+            "B", now + timedelta(hours=3), now + timedelta(hours=4), user_id="default"
+        )
         assert e1.event_id != e2.event_id
 
     def test_created_event_persists_to_disk(self, tmp_path):
         cal_file = tmp_path / "cal.json"
         svc = CalendarService(mock_data_path=cal_file)
-        svc.connect()
+        svc.connect(user_id="default")
         now = _now()
-        svc.create_event("Persist me", now + timedelta(hours=1), now + timedelta(hours=2))
+        svc.create_event(
+            "Persist me", now + timedelta(hours=1), now + timedelta(hours=2), user_id="default"
+        )
 
         # New instance reads the same file
         svc2 = CalendarService(mock_data_path=cal_file)
-        svc2.connect()
-        events = svc2.get_all_events()
+        svc2.connect(user_id="default")
+        events = svc2.get_all_events(user_id="default")
         assert any(e.title == "Persist me" for e in events)
 
     def test_create_event_with_optional_fields(self, tmp_path):
@@ -165,6 +188,7 @@ class TestEventsCreated:
             "Detailed",
             now + timedelta(hours=1),
             now + timedelta(hours=2),
+            user_id="default",
             location="Room B",
             attendees=["alice@example.com"],
             description="Important meeting",
@@ -181,14 +205,17 @@ class TestEventsCreated:
             now.replace(hour=0, minute=0, second=0, microsecond=0),
             now.replace(hour=23, minute=59, second=59, microsecond=0),
             all_day=True,
+            user_id="default",
         )
         assert event.all_day is True
 
     def test_created_event_retrievable_via_get_events(self, tmp_path):
         svc = _make_service(tmp_path)
         now = _now()
-        event = svc.create_event("Retrievable", now + timedelta(hours=1), now + timedelta(hours=2))
-        events = svc.get_events(now, now + timedelta(hours=3))
+        event = svc.create_event(
+            "Retrievable", now + timedelta(hours=1), now + timedelta(hours=2), user_id="default"
+        )
+        events = svc.get_events(now, now + timedelta(hours=3), user_id="default")
         ids = [e.event_id for e in events]
         assert event.event_id in ids
 
@@ -202,14 +229,15 @@ class TestEventsCreated:
             )
         ]
         svc = CalendarService(mock_events=initial)
-        svc.connect()
+        svc.connect(user_id="default")
         new_event = svc.create_event(
             "New In Memory",
             now + timedelta(hours=3),
             now + timedelta(hours=4),
+            user_id="default",
         )
         assert new_event.title == "New In Memory"
-        all_events = svc.get_all_events()
+        all_events = svc.get_all_events(user_id="default")
         assert len(all_events) == 2
 
 
@@ -225,7 +253,7 @@ class TestErrorsHandled:
         svc = CalendarService(mock_data_path=cal_file)
         # Do not call connect(); _events is None
         now = _now()
-        events = svc.get_events(now, now + timedelta(hours=1))
+        events = svc.get_events(now, now + timedelta(hours=1), user_id="default")
         assert events == []
 
     def test_connect_with_invalid_json_returns_false(self, tmp_path):
@@ -233,19 +261,19 @@ class TestErrorsHandled:
         cal_file = tmp_path / "bad.json"
         cal_file.write_text("{not valid json", encoding="utf-8")
         svc = CalendarService(mock_data_path=cal_file)
-        result = svc.connect()
+        result = svc.connect(user_id="default")
         # May return False due to JSON error, or True with empty list — either is safe
         assert isinstance(result, bool)
 
     def test_delete_nonexistent_event_returns_false(self, tmp_path):
         svc = _make_service(tmp_path)
-        result = svc.delete_event("nonexistent-id-xyz")
+        result = svc.delete_event("nonexistent-id-xyz", user_id="default")
         assert result is False
 
     def test_update_nonexistent_event_returns_none(self, tmp_path):
         svc = _make_service(tmp_path)
         _now()
-        result = svc.update_event("nonexistent-id-xyz", {"title": "New Title"})
+        result = svc.update_event("nonexistent-id-xyz", {"title": "New Title"}, user_id="default")
         assert result is None
 
     def test_calendar_event_start_after_end_stored_as_is(self, tmp_path):
@@ -253,7 +281,9 @@ class TestErrorsHandled:
         svc = _make_service(tmp_path)
         now = _now()
         # Reversed times — should not raise
-        event = svc.create_event("Reversed", now + timedelta(hours=2), now + timedelta(hours=1))
+        event = svc.create_event(
+            "Reversed", now + timedelta(hours=2), now + timedelta(hours=1), user_id="default"
+        )
         assert event.title == "Reversed"
 
     def test_get_calendar_service_raises_when_unconfigured(self, tmp_path):
@@ -280,5 +310,5 @@ class TestErrorsHandled:
 
     def test_list_past_events_handled_safely(self, tmp_path):
         svc = _make_service(tmp_path)
-        result = svc.list_past_events(lookback_hours=24)
+        result = svc.list_past_events(lookback_hours=24, user_id="default")
         assert isinstance(result, list)

--- a/tests/test_us076_calendar_mock_removal.py
+++ b/tests/test_us076_calendar_mock_removal.py
@@ -75,7 +75,7 @@ class TestMockNeverLoadedInProduction:
             )
         ]
         svc = CalendarService(mock_events=events)
-        svc.connect()
+        svc.connect(user_id="default")
         assert svc.connected
 
     def test_get_calendar_service_never_returns_mock_without_config(self):


### PR DESCRIPTION
## Summary

Enforces per-user calendar account ownership and credential routing across every real calendar surface, mirroring the email-account model from #316. Part of #303 (does not close it).

## Defects reproduced (fail on the base implementation)

1. **One shared global calendar store** — `rex/calendar_service.py` had no user identity anywhere: any user saw and mutated every other user's events, and the same runtime file served everyone.
2. **Global Google token for any caller** — `rex/integrations/calendar_service.py` served any request with `GOOGLE_CALENDAR_ACCESS_TOKEN`, and on provider failures **fell back to shared stub events** (fail open).
3. **CLI resolved the user and threw it away** — `cmd_calendar` called `_resolve_cli_user` then used the global service.
4. **GUI route `/api/calendar/events` required no identity at all.**
5. **Electron calendar bridge accepted no user field** and used the global provider/token.
6. **OpenClaw `calendar_create` and the local `calendar_create_event` executor ran ownerless.**
7. **Scheduled calendar sync was ownerless** and published full private event payloads (titles, attendees, locations, descriptions) on the shared `calendar.update` topic.

Regression tests for these live in `tests/test_calendar_user_isolation.py` and `tests/test_calendar_surfaces_isolation.py`.

## Ownership model

New canonical module **`rex/calendar_accounts.py`** (mirrors `rex/email_accounts.py`):

- `calendar.accounts` in `config/rex_config.json`: canonical non-secret account definitions (provider `ics|google|outlook|stub`, ICS source, `credential_ref` = env-var *name*, never a secret).
- `users.{user_id}.calendar_accounts`: authoritative per-user assignments.
- `users.{user_id}.default_calendar_account_id`: per-user default (must be owned; foreign defaults are ignored, fail closed).
- Identity validation uses `rex.identity.validate_user_id`; missing/blank/malformed/traversal IDs raise `CalendarIdentityError` **before** any account or credential lookup.
- Unauthorized and nonexistent accounts raise `CalendarAccountAccessError` with an identical generic message (no enumeration).
- Routing order: explicit account (after ownership check) → user default → legacy global default (`default` profile only) → first assigned account → fail closed (documented not-configured result).
- Config-stamp-based resolver invalidation: revoking an assignment takes effect in long-lived processes without restart.

## Legacy policy

- Legacy `calendar.backend: ics` + `calendar.ics` and `calendar.provider` + `GOOGLE_CALENDAR_ACCESS_TOKEN` are synthesized into reserved legacy accounts owned **only** by the explicit `default` profile.
- Named users can never use legacy accounts — not even via an explicit assignment pointing at a legacy account ID.
- No secrets are copied or rewritten; existing single-user (`default` profile) setups keep working.
- Credential references are never printed by CLI output, API responses, events, or logs on the calendar surfaces.
- Admin assignment instructions documented in `docs/calendar.md`.

## Surfaces changed

- `rex/calendar_service.py` — per-user isolated stores keyed `(user_id, account_id)`; every operation requires a validated `user_id`; per-user runtime files (`rex-ai/calendar/<user>.json`; legacy `rex-ai/calendar.json` stays default-profile only); ICS backends cached per `(user, account)`; safe-envelope publishing (full payloads only on `{topic}.user.{user_id}`).
- `rex/integrations/calendar_service.py` — explicit `access_token` per user; `create_calendar_service_for_user()` factory; removed the stub-data fallback on Google API errors (now returns `[]`).
- `rex/routes/integrations.py` — `/api/calendar/events` resolves identity (`?user=` or identity chain), 403s without it, and routes per user.
- `bridge/rex_calendar_bridge.py` — resolves user per request (explicit `user` field or identity chain), fails closed.
- `rex/openclaw/tools/calendar_tool.py` — requires dispatcher `_user_id`; validates before service access; audits user + account only.
- `rex/local_tool_executor.py` — `calendar_create_event` requires `_user_id`.
- `rex/integrations/_setup.py`, `rex/services.py` — scheduled calendar sync iterates configured owners in isolated contexts; ownerless setups run only as the `default` profile; safe envelopes on shared topics.
- `rex/notification.py` — consumes user-scoped `calendar.update.user.*` topics.
- `rex/followup_engine.py` — calendar cue generation is user-scoped end to end; fail-closed fallback.
- `rex/commands/email_calendar.py` + `rex/cli.py` — `rex calendar` requires a resolved user; new `accounts list` / `accounts set-active` subcommands; user-scoped `test-connection`; no credential refs in output.
- `docs/calendar.md` — ownership model, config schema, admin assignment, event-topic policy.

## Tests

- New: `tests/test_calendar_accounts.py` (31), `tests/test_calendar_user_isolation.py` (31), `tests/test_calendar_surfaces_isolation.py` (24), `tests/test_cli_calendar_accounts.py` (17) — covering cross-user listing/use, credential routing, backend reuse, revocation without restart, per-user defaults, legacy policy, traversal IDs, generic errors, event-bus envelopes, secret-free logs, and per-surface fail-closed behavior.
- Updated existing calendar/CLI/tool tests that encoded the old shared-global behavior to run under the explicit `default` profile.

## Validation

- Full pytest suite: 7685 passed, 1 failed — the pre-existing environmental `test_us098_test_coverage.py::test_coverage_txt_exists` check, which requires the `coverage.txt` artifact produced by the CI coverage job (`pytest ... | tee coverage.txt`) and is absent in a fresh worktree.
- `ruff check`, `black --check` on changed files; `mypy rex --ignore-missing-imports` clean; `detect-secrets scan --baseline .secrets.baseline` clean.

## Out of scope / known gaps

- `rex/integrations.py` (root module shadowed by the `rex/integrations/` package, unreachable dead code) still contains the old ownerless sync — left untouched intentionally.
- Email CLI still prints email credential references (shipped #316 behavior; excluded from this PR's scope).
- Invitation accept/decline/tentative, free-busy sharing, and CalDAV are not implemented in the codebase; no surface to isolate.

Refs #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)
