### PR TITLE
fix(identity): fail closed on unsafe user IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,7 @@ Add a short rule here that would have prevented the mistake.
 - The repository dependency security gate must audit the local project explicitly with `pip-audit --strict .`; a bare `pip-audit` audits the runner environment and is not an acceptable project gate.
 - Python releases use `release-please-config.json` plus `.release-please-manifest.json` with the `python` release strategy. Keep the manifest and `pyproject.toml` package version synchronized.
 - Session/user state on long-lived components wired into `Assistant` (engines, caches, in-memory logs) must be keyed by `user_id` in a dict, never held as plain instance attributes — one `Assistant` serves multiple identified users per request via `_begin_request`. Mirror the `FollowupEngine`/`SuggestionEngine` pattern: every stateful public method takes an explicit `user_id`, validates it via `rex.identity.validate_user_id`, and fails closed (no-op, never a default-user fallback) on missing or invalid identity.
+- User IDs are authorization keys, not display strings. Validate them with `rex.identity.validate_user_id` before any path, cache, credential, database, or event access; never sanitize an invalid user ID into a valid one.
 
 ## OpenClaw Migration Status
 

--- a/Memory/README.md
+++ b/Memory/README.md
@@ -14,6 +14,31 @@ Memory/<user_id>/
     history_meta.json  # History metadata (generated at runtime)
 ```
 
+## User ID security policy
+
+User IDs are authorization keys, not display strings. Every profile, memory,
+history, voice embedding, credential, cache, database, and event access must
+validate the supplied ID with `rex.identity.validate_user_id` before using it.
+
+Allowed IDs are 1–64 ASCII letters, digits, dots, underscores, and hyphens,
+beginning with a letter or digit. IDs are not trimmed, lowercased, slugified,
+or otherwise repaired: an invalid ID is rejected rather than being mapped to a
+different profile.
+
+For cross-platform safety, Windows reserved device names are rejected
+case-insensitively: `CON`, `PRN`, `AUX`, `NUL`, `CLOCK$`, `COM1`–`COM9`, and
+`LPT1`–`LPT9`. An extension or trailing spaces/periods does not make those
+names safe; for example, `con.txt`, `NUL.json`, and `COM1...` are invalid.
+
+`default` is a valid, distinct profile only when a caller explicitly selects
+or resolves it through a trusted path. Missing or invalid identity never
+falls back to `default`, `rex`, a recent user, or a display/speaker label.
+
+Existing data under an ID that is now invalid is preserved but never opened,
+renamed, or reassigned automatically. Migrate it manually to a newly chosen,
+valid ID using an administrative process that keeps private data and secrets
+under the owner’s control.
+
 ## Policy — Do NOT Commit Memory Profile Subdirectories
 
 Memory profile files are **generated at runtime** by AskRex and contain personal

--- a/bridge/rex_quick_actions_bridge.py
+++ b/bridge/rex_quick_actions_bridge.py
@@ -29,25 +29,14 @@ _PYTHON_EXE = resolve_python()
 _REPO_ROOT = repo_root()
 
 
-def _resolve_user_id() -> str:
-    """Return the active user ID, falling back to config then 'default'."""
+def _resolve_user_id() -> str | None:
+    """Return a deliberately selected user ID, or ``None`` when missing."""
     try:
-        from rex.config import load_config
-
-        config = load_config()
-        runtime = getattr(config, "_raw", None)
-        if runtime is None:
-            # Try to get the user from config attributes directly
-            uid = getattr(config, "user_id", None) or getattr(config, "default_user", None)
-            if uid and str(uid) != "default":
-                return str(uid)
-        # Use rex.identity resolution chain
         from rex.identity import resolve_active_user
 
-        user = resolve_active_user()
-        return user if user else "default"
+        return resolve_active_user()
     except Exception:
-        return "default"
+        return None
 
 
 def _get_quick_actions(user_id: str) -> list[dict[str, Any]]:
@@ -76,6 +65,8 @@ def main() -> None:
     user_id = _resolve_user_id()
 
     try:
+        if user_id is None:
+            raise PermissionError("A valid active user is required for quick actions.")
         if command == "list":
             actions = _get_quick_actions(user_id)
             sys.stdout.write(json.dumps({"ok": True, "quick_actions": actions}))

--- a/rex/calendar_service.py
+++ b/rex/calendar_service.py
@@ -60,6 +60,7 @@ def _runtime_calendar_path(user_id: str) -> Path:
     single-user file (``rex-ai/calendar.json``) is preserved for the
     ``default`` profile only; named users get isolated per-user files.
     """
+    user_id = require_user_id(user_id)
     if os.name == "nt":
         base = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local")))
     else:

--- a/rex/commands/memory.py
+++ b/rex/commands/memory.py
@@ -28,7 +28,10 @@ def cmd_remember(args: argparse.Namespace) -> int:
     """Store or display a remembered fact for the active user."""
     from rex.user_facts import recall_all, store
 
-    user = getattr(args, "user", None) or "default"
+    user = _resolve_memory_user(args)
+    if user is None:
+        print(_NO_USER_MSG)
+        return 1
     fact_text: str | None = getattr(args, "fact", None)
 
     if fact_text:

--- a/rex/history_store.py
+++ b/rex/history_store.py
@@ -14,6 +14,8 @@ import threading
 from datetime import UTC, datetime
 from pathlib import Path
 
+from rex.identity import validate_user_id
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_DB_PATH = Path("data/history.db")
@@ -78,6 +80,7 @@ class HistoryStore:
             content:   Message text.
             timestamp: When the turn occurred.  Stored as UTC ISO-8601.
         """
+        user_id = validate_user_id(user_id)
         ts = timestamp.astimezone(UTC).isoformat()
         with self._lock:
             with self._connect() as conn:
@@ -97,6 +100,7 @@ class HistoryStore:
             List of dicts with keys ``id``, ``user_id``, ``role``,
             ``content``, ``timestamp``.
         """
+        user_id = validate_user_id(user_id)
         with self._lock:
             with self._connect() as conn:
                 cursor = conn.execute(
@@ -121,6 +125,7 @@ class HistoryStore:
         Args:
             user_id: Identifier for the user/session whose history to clear.
         """
+        user_id = validate_user_id(user_id)
         with self._lock:
             with self._connect() as conn:
                 conn.execute("DELETE FROM turns WHERE user_id = ?", (user_id,))
@@ -137,6 +142,7 @@ class HistoryStore:
         """
         from datetime import timedelta
 
+        user_id = validate_user_id(user_id)
         cutoff = datetime.now(UTC) - timedelta(days=keep_days)
         cutoff_ts = cutoff.isoformat()
         with self._lock:

--- a/rex/identity.py
+++ b/rex/identity.py
@@ -30,6 +30,15 @@ from .config import settings
 logger = logging.getLogger(__name__)
 
 _USER_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_WINDOWS_RESERVED_DEVICE_NAMES = {
+    "con",
+    "prn",
+    "aux",
+    "nul",
+    "clock$",
+    *(f"com{number}" for number in range(1, 10)),
+    *(f"lpt{number}" for number in range(1, 10)),
+}
 
 
 def validate_user_id(user_id: str) -> str:
@@ -46,6 +55,13 @@ def validate_user_id(user_id: str) -> str:
     if not isinstance(user_id, str) or not _USER_ID_PATTERN.fullmatch(user_id):
         raise ValueError(f"Invalid user_id: {user_id!r}")
     if user_id in {".", ".."}:
+        raise ValueError(f"Invalid user_id: {user_id!r}")
+    # Windows strips trailing spaces/periods and treats the portion before an
+    # extension as a device name. Apply that rule everywhere so a profile is
+    # never portable on one OS but unsafe on another.
+    normalized = user_id.rstrip(" .")
+    device_stem = normalized.split(".", 1)[0].rstrip(" .").casefold()
+    if device_stem in _WINDOWS_RESERVED_DEVICE_NAMES:
         raise ValueError(f"Invalid user_id: {user_id!r}")
     return user_id
 
@@ -117,7 +133,7 @@ def _save_session(data: dict) -> None:
 def get_session_user() -> str | None:
     """Return the active user from session state, or None."""
     session = _load_session()
-    return session.get("active_user")
+    return _validated_candidate(session.get("active_user"), source="session")
 
 
 def set_session_user(user_id: str) -> None:
@@ -158,7 +174,7 @@ def resolve_active_user(
         return validate_user_id(explicit_user)
 
     # 2. Session state. Invalid persisted state fails closed.
-    session_user = get_session_user()
+    session_user = _load_session().get("active_user")
     if session_user:
         return _validated_candidate(session_user, source="session")
 

--- a/rex/memory_utils.py
+++ b/rex/memory_utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from .assistant_errors import ConfigurationError
 from .config import load_config, settings
+from .identity import validate_user_id
 from .placeholder_voice import (
     DEFAULT_PLACEHOLDER_RELATIVE_PATH,
     ensure_placeholder_voice,
@@ -24,24 +25,9 @@ HISTORY_META = "history_meta.json"
 MAX_PATH_DEPTH = 10  # Maximum directory traversal depth
 
 
-def _sanitize_user_key(user_key: str) -> str:
-    """Sanitize user key to prevent path traversal attacks."""
-    if not user_key or not isinstance(user_key, str):
-        raise ConfigurationError("User key must be a non-empty string.")
-
-    # Remove any path separators and parent directory references
-    sanitized = user_key.strip().replace("..", "").replace("/", "").replace("\\", "")
-
-    # Only allow alphanumeric, dash, underscore
-    if not all(c.isalnum() or c in "-_" for c in sanitized):
-        raise ConfigurationError(
-            f"Invalid user key '{user_key}': must contain only alphanumeric, dash, or underscore."
-        )
-
-    if not sanitized:
-        raise ConfigurationError("User key cannot be empty after sanitization.")
-
-    return sanitized.lower()
+def _validate_user_key(user_key: str) -> str:
+    """Return a canonical user ID; never transform an unsafe identity."""
+    return validate_user_id(user_key)
 
 
 def _validate_path_within(path: Path, base: Path, *, max_depth: int = MAX_PATH_DEPTH) -> Path:
@@ -68,14 +54,14 @@ def _ensure_directory(path: Path) -> None:
 
 
 def _history_path(user_key: str, memory_root: Path) -> Path:
-    sanitized_key = _sanitize_user_key(user_key)
+    sanitized_key = _validate_user_key(user_key)
     user_dir = memory_root / sanitized_key
     _validate_path_within(user_dir, memory_root)
     return user_dir / HISTORY_FILENAME
 
 
 def _metadata_path(user_key: str, memory_root: Path) -> Path:
-    sanitized_key = _sanitize_user_key(user_key)
+    sanitized_key = _validate_user_key(user_key)
     user_dir = memory_root / sanitized_key
     _validate_path_within(user_dir, memory_root)
     return user_dir / HISTORY_META
@@ -91,7 +77,10 @@ def load_users_map(users_path: str | Path = USERS_PATH) -> dict[str, str]:
     mapping: dict[str, str] = {}
     for email, user in data.items():
         if isinstance(email, str) and isinstance(user, str):
-            mapping[email.lower()] = user.lower()
+            try:
+                mapping[email.lower()] = validate_user_id(user)
+            except ValueError:
+                continue
     return mapping
 
 
@@ -102,34 +91,33 @@ def resolve_user_key(
     memory_root: str | Path = MEMORY_ROOT,
     profiles: dict[str, dict] | None = None,
 ) -> str | None:
-    if not identifier:
+    if not isinstance(identifier, str) or not identifier:
         return None
 
-    key = identifier.strip().lower()
-    if profiles and key in profiles:
-        return key
+    try:
+        direct_id = validate_user_id(identifier)
+    except ValueError:
+        direct_id = None
+    if direct_id is not None:
+        if profiles and direct_id in profiles:
+            return direct_id
+        if direct_id in users_map.values():
+            return direct_id
+        if Path(memory_root, direct_id).is_dir():
+            return direct_id
 
-    if key in users_map.values():
-        return key
-
-    mapped = users_map.get(key)
+    mapped = users_map.get(identifier.casefold())
     if mapped:
-        return mapped
-
-    if profiles:
-        for candidate, profile in profiles.items():
-            name = profile.get("name") if isinstance(profile, dict) else None
-            if isinstance(name, str) and name.strip().lower() == key:
-                return candidate
-
-    if Path(memory_root, key).is_dir():
-        return key
+        try:
+            return validate_user_id(mapped)
+        except ValueError:
+            return None
 
     return None
 
 
 def load_memory_profile(user_key: str, memory_root: str | Path = MEMORY_ROOT) -> dict:
-    sanitized_key = _sanitize_user_key(user_key)
+    sanitized_key = _validate_user_key(user_key)
     memory_root_path = Path(memory_root)
     core_path = memory_root_path / sanitized_key / "core.json"
 
@@ -165,8 +153,8 @@ def load_all_profiles(memory_root: str | Path = MEMORY_ROOT) -> dict[str, dict]:
 
         # Validate entry name is safe
         try:
-            sanitized = _sanitize_user_key(entry)
-        except ConfigurationError:
+            sanitized = _validate_user_key(entry)
+        except ValueError:
             # Skip directories with invalid names
             continue
 
@@ -281,7 +269,7 @@ def append_history_entry(
     if "role" not in entry or "text" not in entry:
         raise ConfigurationError("History entries require 'role' and 'text' fields.")
 
-    sanitized_key = _sanitize_user_key(user_key)
+    sanitized_key = _validate_user_key(user_key)
     memory_root_path = Path(memory_root)
     user_dir = memory_root_path / sanitized_key
     _validate_path_within(user_dir, memory_root_path)
@@ -339,7 +327,7 @@ def export_transcript(
     if not cfg.transcripts_enabled:
         raise ConfigurationError("Transcript export is disabled in configuration.")
 
-    sanitized_key = _sanitize_user_key(user_key)
+    sanitized_key = _validate_user_key(user_key)
     transcripts_base = Path(transcripts_dir or cfg.transcripts_dir)
     transcripts_root = transcripts_base / sanitized_key
     _validate_path_within(transcripts_root, transcripts_base)

--- a/rex/openclaw/agent.py
+++ b/rex/openclaw/agent.py
@@ -28,6 +28,7 @@ from collections.abc import Generator
 from typing import Any
 
 from rex.config import AppConfig, load_config
+from rex.identity import validate_user_id
 from rex.llm_client import LanguageModel
 from rex.openclaw.errors import OpenClawAPIError, OpenClawAuthError, OpenClawConnectionError
 from rex.openclaw.http_client import get_openclaw_client, stream_sentences
@@ -220,6 +221,8 @@ class RexAgent:
         """
         if not prompt or not prompt.strip():
             raise ValueError("prompt must not be empty")
+        if user_key is not None:
+            user_key = validate_user_id(user_key)
 
         messages: list[dict[str, str]] = [
             {"role": "system", "content": self.system_prompt},
@@ -289,6 +292,8 @@ class RexAgent:
         """
         if not prompt or not prompt.strip():
             raise ValueError("prompt must not be empty")
+        if user_key is not None:
+            user_key = validate_user_id(user_key)
 
         messages: list[dict[str, str]] = [
             {"role": "system", "content": self.system_prompt},

--- a/rex/openclaw/identity_adapter.py
+++ b/rex/openclaw/identity_adapter.py
@@ -128,7 +128,8 @@ class IdentityAdapter:
         accumulated correctly across multiple voice turns.
 
         Priority: *explicit_user* → session state → config active_user →
-        config user_id → ``"rex"`` (safe default).
+        config user_id. Missing identity fails closed; OpenClaw must not be
+        given an implicit private-user key.
 
         Args:
             explicit_user: Optional override (e.g. from a ``--user`` flag).
@@ -140,8 +141,7 @@ class IdentityAdapter:
         resolved = resolve_active_user(explicit_user, config=self._config)
         if resolved:
             return resolved
-        user_id = self._config.get("user_id") if self._config else None
-        return str(user_id) if user_id else "rex"
+        raise PermissionError("A valid user identity is required for OpenClaw access.")
 
     # ------------------------------------------------------------------
     # OpenClaw session context

--- a/rex/response_cache.py
+++ b/rex/response_cache.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import dataclass
 from threading import Lock
 
+from rex.identity import validate_user_id
+
 logger = logging.getLogger(__name__)
 
 # Patterns that indicate a time-sensitive query — bypass cache on match.
@@ -128,13 +130,16 @@ class ResponseCache:
     def get(self, message: str, *, user_id: str | None = None) -> str | None:
         """Return a cached response for *message*, or None on miss/bypass/expiry.
 
-        Entries are partitioned by *user_id*: a response stored for one user
-        is never returned for another.  ``None`` is its own partition.
+        Entries are partitioned by a validated *user_id*: a response stored
+        for one user is never returned for another. ``None`` is reserved for
+        callers that deliberately use the non-private shared cache.
         """
         if _should_bypass(message):
             logger.debug("[cache] bypass: %r", message[:60])
             return None
 
+        if user_id is not None:
+            user_id = validate_user_id(user_id)
         key = (user_id, _normalize(message))
         now = time.monotonic()
 
@@ -170,6 +175,8 @@ class ResponseCache:
         if _should_bypass(message):
             return
 
+        if user_id is not None:
+            user_id = validate_user_id(user_id)
         key = (user_id, _normalize(message))
         expires_at = time.monotonic() + self._ttl
 

--- a/rex/routes/users.py
+++ b/rex/routes/users.py
@@ -198,6 +198,12 @@ def _register_avatar_routes(bp: Blueprint, avatar_dir: Path) -> None:
         if err:
             return err
         assert user is not None
+        from rex.identity import validate_user_id
+
+        try:
+            user_id = validate_user_id(user["id"])
+        except ValueError:
+            return jsonify({"error": "invalid user identity"}), 400
 
         if "file" not in request.files:
             return jsonify({"error": "no file uploaded"}), 400
@@ -219,7 +225,7 @@ def _register_avatar_routes(bp: Blueprint, avatar_dir: Path) -> None:
         img = img.resize(_AVATAR_SIZE, Image.Resampling.LANCZOS)
 
         avatar_dir.mkdir(parents=True, exist_ok=True)
-        avatar_path = avatar_dir / f"{user['id']}.jpg"
+        avatar_path = avatar_dir / f"{user_id}.jpg"
         buf = io.BytesIO()
         img.save(buf, format="JPEG", quality=85)
         avatar_path.write_bytes(buf.getvalue())
@@ -235,7 +241,13 @@ def _register_avatar_routes(bp: Blueprint, avatar_dir: Path) -> None:
 
         user, _ = _require_auth()
         if user is not None:
-            avatar_path = avatar_dir / f"{user['id']}.jpg"
+            from rex.identity import validate_user_id
+
+            try:
+                user_id = validate_user_id(user["id"])
+            except ValueError:
+                return Response(_DEFAULT_AVATAR_SVG, mimetype="image/svg+xml")
+            avatar_path = avatar_dir / f"{user_id}.jpg"
             if avatar_path.is_file():
                 return send_file(str(avatar_path), mimetype="image/jpeg")
 

--- a/rex/user_facts.py
+++ b/rex/user_facts.py
@@ -31,9 +31,9 @@ def _facts_path(user: str, memory_root: Path | None = None) -> Path:
     validator prevents ambiguous filename sanitization where distinct IDs such
     as ``alice/bob`` and ``alice_bob`` could map to the same facts file.
     """
+    safe = validate_user_id(user)
     root = memory_root or _MEMORY_ROOT
     root.mkdir(parents=True, exist_ok=True)
-    safe = validate_user_id(user)
     return root / f"{safe}_facts.json"
 
 

--- a/rex/voice/builder.py
+++ b/rex/voice/builder.py
@@ -391,7 +391,7 @@ def build_voice_loop(
 
 
 def _resolve_voice_reference() -> str | None:
-    """Resolve voice reference for the default user.
+    """Resolve the selected user's voice reference.
 
     Returns:
         Path to voice sample file, or None if not configured
@@ -400,12 +400,13 @@ def _resolve_voice_reference() -> str | None:
         users_map = load_users_map()
         profiles = load_all_profiles()
 
-        # Get default user
-        default_user = _vl().settings.default_user or _vl().settings.user_id or "default"
-        user_key = resolve_user_key(default_user, users_map, profiles=profiles)
+        active_user = _vl().settings.default_user
+        if not active_user:
+            return None
+        user_key = resolve_user_key(active_user, users_map, profiles=profiles)
 
         if not user_key:
-            user_key = default_user
+            return None
 
         # Load profile and extract voice reference
         if user_key in profiles:

--- a/rex/voice_identity/embeddings_store.py
+++ b/rex/voice_identity/embeddings_store.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
-from pathlib import Path, PurePath
+from pathlib import Path
 
+from rex.identity import validate_user_id
 from rex.voice_identity.types import VoiceEmbedding
 
 logger = logging.getLogger(__name__)
@@ -94,7 +95,10 @@ class EmbeddingsStore:
         users: list[str] = []
         for entry in sorted(self._base_dir.iterdir()):
             if entry.is_dir() and (entry / _FILENAME).exists():
-                users.append(entry.name)
+                try:
+                    users.append(validate_user_id(entry.name))
+                except ValueError:
+                    logger.warning("Ignoring embedding stored under an invalid user ID")
         return users
 
     def load_all(self) -> dict[str, VoiceEmbedding]:
@@ -112,17 +116,4 @@ class EmbeddingsStore:
 
     def _path_for(self, user_id: str) -> Path:
         """Return the JSON file path for a given user."""
-        if not isinstance(user_id, str):
-            raise ValueError("user_id must be a string")
-
-        candidate = user_id.strip()
-        if not candidate:
-            raise ValueError("user_id must not be empty")
-
-        parts = PurePath(candidate).parts
-        if len(parts) != 1 or parts[0] != candidate:
-            raise ValueError("user_id must be a simple name without path separators")
-        if candidate in {".", ".."}:
-            raise ValueError("user_id must not be '.' or '..'")
-
-        return self._base_dir / candidate / _FILENAME
+        return self._base_dir / validate_user_id(user_id) / _FILENAME

--- a/rex/voice_identity/enrollment.py
+++ b/rex/voice_identity/enrollment.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import numpy as np
 
+from rex.identity import validate_user_id
 from rex.voice_identity.embedding_backends import SyntheticEmbeddingBackend
 from rex.voice_identity.embeddings_store import EmbeddingsStore
 from rex.voice_identity.types import VoiceEmbedding
@@ -58,6 +59,7 @@ def enroll_user(
         ValueError: If fewer than :data:`_MIN_SAMPLES` audio samples are
             provided.
     """
+    user_id = validate_user_id(user_id)
     if len(audio_samples) < _MIN_SAMPLES:
         raise ValueError(
             f"enroll_user requires at least {_MIN_SAMPLES} audio samples; "

--- a/rex/voice_identity/fallback_flow.py
+++ b/rex/voice_identity/fallback_flow.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 
-from rex.identity import resolve_active_user, set_session_user
+from rex.identity import resolve_active_user, set_session_user, validate_user_id
 from rex.voice_identity.types import RecognitionDecision, RecognitionResult
 
 logger = logging.getLogger(__name__)
@@ -48,13 +48,18 @@ def resolve_speaker_identity(
         The resolved user ID, or ``None`` if no user could be determined.
     """
     if result.decision == RecognitionDecision.RECOGNIZED and result.best_user_id:
+        try:
+            user_id = validate_user_id(result.best_user_id)
+        except ValueError:
+            logger.warning("Voice recognition returned an invalid user identity")
+            return None
         logger.info(
             "Speaker recognized as %s (score=%.3f)",
-            result.best_user_id,
+            user_id,
             result.score,
         )
-        set_session_user(result.best_user_id)
-        return result.best_user_id
+        set_session_user(user_id)
+        return user_id
 
     if result.decision == RecognitionDecision.REVIEW and result.best_user_id:
         # Check whether the existing identity chain already agrees

--- a/rex/voice_identity/ui_service.py
+++ b/rex/voice_identity/ui_service.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from rex.config import load_config
 from rex.config_manager import load_config as load_json_config
+from rex.identity import resolve_active_user, validate_user_id
 from rex.voice_identity.embeddings_store import EmbeddingsStore
 from rex.voice_identity.optional_deps import get_embedding_backend
 
@@ -18,11 +18,9 @@ _DEFAULT_MEMORY_DIR = Path(__file__).resolve().parents[2] / "Memory"
 _NPY_FILENAME = "voice_embedding.npy"
 
 
-def get_active_user_id() -> str:
+def get_active_user_id() -> str | None:
     """Return the active runtime user ID for UI enrollment flows."""
-    config = load_config()
-    active_user = getattr(config, "default_user", None) or getattr(config, "user_id", None)
-    return str(active_user or "default")
+    return resolve_active_user(config=load_json_config())
 
 
 def list_enrollments(*, base_dir: Path | str | None = None) -> list[dict[str, Any]]:
@@ -82,6 +80,7 @@ def enroll_from_samples(
 
 def delete_enrollment(user_id: str, *, base_dir: Path | str | None = None) -> bool:
     """Delete enrollment artifacts for *user_id*."""
+    user_id = validate_user_id(user_id)
     resolved_base_dir = _resolve_base_dir(base_dir)
     store = EmbeddingsStore(resolved_base_dir)
     deleted_json = store.delete(user_id)

--- a/tests/test_identity_hardening.py
+++ b/tests/test_identity_hardening.py
@@ -1,0 +1,133 @@
+"""Regression coverage for canonical identity-boundary hardening (issue #303)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from rex.calendar_accounts import CalendarIdentityError
+from rex.calendar_accounts import require_user_id as calendar_user
+from rex.email_accounts import EmailIdentityError
+from rex.email_accounts import require_user_id as email_user
+from rex.identity import get_user_profile, resolve_active_user, validate_user_id
+from rex.memory_utils import append_history_entry, export_transcript, resolve_user_key
+from rex.openclaw.identity_adapter import IdentityAdapter
+from rex.response_cache import ResponseCache
+from rex.user_facts import store as store_fact
+from rex.voice_identity.embeddings_store import EmbeddingsStore
+from rex.voice_identity.types import VoiceEmbedding
+
+
+@pytest.mark.parametrize(
+    "user_id",
+    [
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "CLOCK$",
+        *[f"COM{number}" for number in range(1, 10)],
+        *[f"LPT{number}" for number in range(1, 10)],
+        "con.txt",
+        "NUL.json",
+        "aux.profile",
+        "COM1.data",
+        "lpt9.backup",
+        "con.",
+        "nul ",
+        "COM1...",
+        "LPT1 .txt",
+    ],
+)
+def test_windows_reserved_user_ids_are_rejected_on_all_platforms(user_id: str) -> None:
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        validate_user_id(user_id)
+
+
+@pytest.mark.parametrize(
+    "user_id",
+    [
+        "console",
+        "contact",
+        "null",
+        "auxiliary",
+        "com0",
+        "com10",
+        "lpt0",
+        "lpt10",
+        "company1",
+        "connor",
+        "james",
+        "cole",
+        "default",
+    ],
+)
+def test_valid_near_matches_remain_accepted(user_id: str) -> None:
+    assert validate_user_id(user_id) == user_id
+
+
+def test_history_and_transcript_reject_instead_of_sanitizing_reserved_id(tmp_path) -> None:
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        append_history_entry("CON", {"role": "user", "text": "hello"}, memory_root=tmp_path)
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        export_transcript("CON", [], transcripts_dir=tmp_path / "transcripts")
+    assert not list(tmp_path.rglob("*"))
+
+
+def test_voice_embedding_save_rejects_reserved_id_before_creating_directory(tmp_path) -> None:
+    store = EmbeddingsStore(tmp_path)
+    embedding = VoiceEmbedding(vector=[1.0], model_id="test", sample_count=1, updated_at="")
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        store.save("NUL", embedding)
+    assert not list(tmp_path.iterdir())
+
+
+def test_profile_facts_history_and_cache_reject_reserved_ids_before_access(tmp_path) -> None:
+    from rex.history_store import HistoryStore
+
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        get_user_profile("COM1", memory_dir=tmp_path)
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        store_fact("LPT1", "key", "value", memory_root=tmp_path)
+    history = HistoryStore(tmp_path / "history.db")
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        history.load_history("AUX")
+    cache = ResponseCache()
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        cache.put("question", "answer", user_id="NUL")
+
+
+def test_invalid_persisted_or_configured_identity_fails_closed(tmp_path) -> None:
+    session_file = tmp_path / "session.json"
+    session_file.write_text('{"active_user": "CON"}', encoding="utf-8")
+    with patch("rex.identity._session_state_path", return_value=session_file):
+        assert resolve_active_user(config={"runtime": {"active_user": "james"}}) is None
+    assert resolve_active_user(config={"runtime": {"active_user": "COM1"}}) is None
+
+
+def test_display_name_is_not_reinterpreted_as_a_user_id(tmp_path) -> None:
+    profiles = {"james": {"name": "James Example"}}
+    assert resolve_user_key("James Example", {}, profiles=profiles, memory_root=tmp_path) is None
+    assert resolve_user_key("james", {}, profiles=profiles, memory_root=tmp_path) == "james"
+
+
+def test_email_and_calendar_resolvers_reject_reserved_identity_before_lookup() -> None:
+    with pytest.raises(EmailIdentityError):
+        email_user("CON")
+    with pytest.raises(CalendarIdentityError):
+        calendar_user("LPT9")
+
+
+def test_openclaw_adapter_missing_identity_never_becomes_rex() -> None:
+    adapter = IdentityAdapter()
+    with patch("rex.openclaw.identity_adapter.resolve_active_user", return_value=None):
+        with pytest.raises(PermissionError, match="identity"):
+            adapter.get_openclaw_user_key()
+
+
+def test_openclaw_adapter_invalid_identity_never_becomes_default_or_rex() -> None:
+    adapter = IdentityAdapter()
+    with patch("rex.openclaw.identity_adapter.resolve_active_user", return_value=None):
+        with pytest.raises(PermissionError, match="identity"):
+            adapter.get_openclaw_user_key("CON")

--- a/tests/test_openclaw_agent_http_respond.py
+++ b/tests/test_openclaw_agent_http_respond.py
@@ -48,6 +48,19 @@ def _chat_response(content: str) -> dict:
 
 
 class TestRespondHttpPath:
+    def test_missing_identity_fails_before_openclaw_request(self):
+        config = _make_config()
+        agent = _make_agent(config)
+        mock_client = MagicMock()
+
+        with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
+            import pytest
+
+            with pytest.raises(PermissionError, match="identity"):
+                agent.respond("Hello?")
+
+        mock_client.post.assert_not_called()
+
     def test_posts_to_chat_completions_when_gateway_configured(self):
         """respond() POSTs to /v1/chat/completions when gateway and flag are set."""
         config = _make_config()
@@ -57,7 +70,7 @@ class TestRespondHttpPath:
         mock_client.post.return_value = _chat_response("OpenClaw reply")
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            result = agent.respond("Hello?")
+            result = agent.respond("Hello?", user_key="james")
 
         mock_client.post.assert_called_once()
         (path,) = mock_client.post.call_args.args
@@ -73,7 +86,7 @@ class TestRespondHttpPath:
         mock_client.post.return_value = _chat_response("reply")
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            agent.respond("Test prompt")
+            agent.respond("Test prompt", user_key="james")
 
         payload = mock_client.post.call_args.kwargs["json"]
         assert payload["model"] == "openclaw:main"
@@ -87,15 +100,16 @@ class TestRespondHttpPath:
         mock_client.post.return_value = _chat_response("reply")
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            agent.respond("My question")
+            agent.respond("My question", user_key="james")
 
         payload = mock_client.post.call_args.kwargs["json"]
         messages = payload["messages"]
         roles = [m["role"] for m in messages]
         assert "system" in roles
         assert "user" in roles
-        user_content = next(m["content"] for m in messages if m["role"] == "user")
-        assert "My question" in user_content
+        assert any(
+            "My question" in message["content"] for message in messages if message["role"] == "user"
+        )
 
     def test_payload_contains_user_field_when_user_key_provided(self):
         """When user_key is given, the POST payload includes a 'user' field."""
@@ -139,7 +153,7 @@ class TestRespondHttpPath:
         mock_client.post.return_value = _chat_response("OpenClaw reply")
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            agent.respond("Question")
+            agent.respond("Question", user_key="james")
 
         agent.llm.generate.assert_not_called()
 
@@ -159,7 +173,7 @@ class TestRespondHttpFallback:
         mock_client.post.side_effect = OpenClawAPIError(500, "internal server error")
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            result = agent.respond("Test prompt")
+            result = agent.respond("Test prompt", user_key="james")
 
         agent.llm.generate.assert_called_once()
         assert result == "local fallback reply"
@@ -173,7 +187,7 @@ class TestRespondHttpFallback:
         mock_client.post.return_value = {"unexpected": "shape"}  # missing 'choices'
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            result = agent.respond("Prompt")
+            result = agent.respond("Prompt", user_key="james")
 
         agent.llm.generate.assert_called_once()
         assert result == "local result"

--- a/tests/test_openclaw_e2e_integration.py
+++ b/tests/test_openclaw_e2e_integration.py
@@ -100,7 +100,7 @@ class TestTextModeE2E:
         mock_client = _mock_client(_chat_response("The time is 3 pm."))
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            reply = agent.respond("What time is it?")
+            reply = agent.respond("What time is it?", user_key="james")
 
         assert reply == "The time is 3 pm."
         mock_client.post.assert_called_once()
@@ -130,7 +130,7 @@ class TestTextModeE2E:
         mock_client = _mock_client()
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            agent.respond("Hi")
+            agent.respond("Hi", user_key="james")
 
         messages = mock_client.post.call_args.kwargs["json"]["messages"]
         assert messages[0]["role"] == "system"
@@ -176,7 +176,7 @@ class TestToolCallE2E:
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=chat_client):
             # Simulate re-calling OpenClaw with the tool result embedded in the prompt.
             tool_result_text = f"Tool returned: {result['result']}"
-            reply = agent.respond(tool_result_text)
+            reply = agent.respond(tool_result_text, user_key="james")
 
         assert reply == follow_up_msg
 
@@ -229,7 +229,7 @@ class TestVoiceBridgeE2E:
         """Empty transcript returns empty string with no HTTP call."""
         cfg = _config()
         agent = RexAgent(llm=_mock_llm(), config=cfg, system_prompt="You are Rex.")
-        bridge = VoiceBridge(agent=agent)
+        bridge = VoiceBridge(agent=agent, user_key="james")
         mock_client = _mock_client()
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
@@ -242,7 +242,7 @@ class TestVoiceBridgeE2E:
         """voice_mode=True is accepted without error."""
         cfg = _config()
         agent = RexAgent(llm=_mock_llm(), config=cfg, system_prompt="You are Rex.")
-        bridge = VoiceBridge(agent=agent)
+        bridge = VoiceBridge(agent=agent, user_key="james")
         mock_client = _mock_client(_chat_response("Roger that."))
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
@@ -332,7 +332,7 @@ class TestFallbackE2E:
         error_client = _mock_client(post_side_effect=OpenClawAPIError(500, "internal error"))
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=error_client):
-            reply = agent.respond("What is the weather?")
+            reply = agent.respond("What is the weather?", user_key="james")
 
         assert reply == "local fallback answer"
         local_llm.generate.assert_called_once()
@@ -349,7 +349,7 @@ class TestFallbackE2E:
         )
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=error_client):
-            reply = agent.respond("Hello?")
+            reply = agent.respond("Hello?", user_key="james")
 
         assert reply == "fallback on connection error"
         local_llm.generate.assert_called_once()

--- a/tests/test_openclaw_identity_adapter.py
+++ b/tests/test_openclaw_identity_adapter.py
@@ -5,7 +5,7 @@ Verifies that IdentityAdapter correctly bridges Rex's identity system:
 - resolve_user priority chain
 - build_session produces the expected keys and reflects set_user
 - clear_user resets session state
-- get_openclaw_user_key returns consistent, non-empty values
+- get_openclaw_user_key requires an explicitly resolved identity
 """
 
 from __future__ import annotations
@@ -266,17 +266,13 @@ class TestGetOpenClawUserKey:
             result = adapter.get_openclaw_user_key()
         assert result == "session_user"
 
-    def test_falls_back_to_config_user_id(self) -> None:
-        adapter = IdentityAdapter(config={"user_id": "cfg_user"})
-        with patch("rex.openclaw.identity_adapter.resolve_active_user", return_value=None):
-            result = adapter.get_openclaw_user_key()
-        assert result == "cfg_user"
-
-    def test_falls_back_to_rex_default_when_no_user(self) -> None:
+    def test_missing_identity_fails_closed(self) -> None:
         adapter = _adapter()
         with patch("rex.openclaw.identity_adapter.resolve_active_user", return_value=None):
-            result = adapter.get_openclaw_user_key()
-        assert result == "rex"
+            import pytest
+
+            with pytest.raises(PermissionError, match="identity"):
+                adapter.get_openclaw_user_key()
 
     def test_returns_consistent_value_for_same_user(self) -> None:
         adapter = _adapter()
@@ -285,8 +281,10 @@ class TestGetOpenClawUserKey:
             key2 = adapter.get_openclaw_user_key()
         assert key1 == key2 == "james"
 
-    def test_never_returns_empty_string(self) -> None:
+    def test_never_substitutes_a_placeholder_identity(self) -> None:
         adapter = _adapter()
         with patch("rex.openclaw.identity_adapter.resolve_active_user", return_value=None):
-            result = adapter.get_openclaw_user_key()
-        assert result != ""
+            import pytest
+
+            with pytest.raises(PermissionError, match="identity"):
+                adapter.get_openclaw_user_key()

--- a/tests/test_openclaw_streaming.py
+++ b/tests/test_openclaw_streaming.py
@@ -96,7 +96,7 @@ class TestRespondStream:
         )
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            result = list(agent.respond_stream("What time is it?"))
+            result = list(agent.respond_stream("What time is it?", user_key="james"))
 
         assert result == ["It is 3pm.", "The weather is sunny."]
 
@@ -108,7 +108,7 @@ class TestRespondStream:
         mock_client.post_stream.return_value = iter(["Done."])
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            list(agent.respond_stream("Hello"))
+            list(agent.respond_stream("Hello", user_key="james"))
 
         payload = mock_client.post_stream.call_args.kwargs["json"]
         assert payload["stream"] is True
@@ -123,7 +123,7 @@ class TestRespondStream:
         )
 
         with patch("rex.openclaw.agent.get_openclaw_client", return_value=mock_client):
-            result = list(agent.respond_stream("Hello"))
+            result = list(agent.respond_stream("Hello", user_key="james"))
 
         assert result == ["local fallback"]
 

--- a/tests/test_voice_id_mvp.py
+++ b/tests/test_voice_id_mvp.py
@@ -271,7 +271,7 @@ class TestEnrollment:
         store = EmbeddingsStore(tmp_path)
         vector = SyntheticEmbeddingBackend(dim=4).embed(b"x")
 
-        with pytest.raises(ValueError, match="simple name"):
+        with pytest.raises(ValueError, match="Invalid user_id"):
             store.save(
                 "../evil", VoiceEmbedding(vector=vector, model_id="synthetic", sample_count=1)
             )


### PR DESCRIPTION
## Summary
- reject Windows reserved device-name user IDs consistently on every platform
- route profile, memory, history, voice, cache, calendar, CLI, bridge, and OpenClaw identity paths through canonical validation
- remove implicit OpenClaw rex and bridge default fallbacks; explicit default remains supported

## Verification
- focused identity/isolation/OpenClaw suite: 399 passed
- full pytest: 7687 passed, 111 skipped; 16 failures are reproduced identically on base b3d8888 (timezone-resolution cascade and fresh-worktree coverage.txt check)
- ruff, black, detect-secrets, and mypy rex --ignore-missing-imports pass in the worktree-local Python 3.11 environment

## Risk / Notes
- no legacy identity data is renamed, moved, or reassigned automatically
- references #303