### PR TITLE
feat(mobile): add authenticated mobile API gateway foundation (#323)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,6 +205,8 @@ SKIP_MIGRATION_CHECK=
 # =============================================================================
 
 # Secret key used to sign user session JWTs — REQUIRED
+# Also signs mobile API access tokens (python -m rex mobile-api), which
+# additionally require a minimum length of 32 characters.
 # The application raises RuntimeError at startup if this is not set.
 # Generate a strong value with:
 #   python -c "import secrets; print(secrets.token_hex(32))"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,7 +148,7 @@
         "filename": "config/rex_config.example.json",
         "hashed_secret": "1824173a4a5aacf3b0f3c42098a83de2fc3f1e32",
         "is_verified": false,
-        "line_number": 176
+        "line_number": 194
       }
     ],
     "docs/browser_os.md": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,11 @@ Entry points:
 - rex-agent -> rex.computers.agent_server:main  # backend service: optional remote PC control API
 - rex-tool-server -> rex.openclaw.tool_server:main  # backend service: OpenClaw tool adapter at /rex/tools/{tool_name}
 
+Mobile API gateway (issue #323) runs via the CLI, not a console script:
+
+- python -m rex mobile-api [--host HOST] [--port PORT]  # authenticated mobile gateway (default 127.0.0.1:8765)
+- python -m rex mobile-user create --username NAME      # safe mobile user creation (getpass prompts)
+
 ### Core components
 
 API: Flask (Flask-CORS, Flask-Limiter)
@@ -192,6 +197,7 @@ Bridge compatibility wrappers (17) — exec canonical `bridge/<name>.py` in thei
 - rex/identity.py
 - rex/voice_identity/
 - rex/computers/
+- rex/mobile_api/ — authenticated mobile API gateway (issue #323): injectable Flask app factory (`app.py`), typed config helpers, idempotent `users.db` migrations (`db.py`), per-device sessions + rotating hashed refresh tokens (`sessions.py`), short-lived access JWTs + request principal (`auth.py`), structured mobile errors (`errors.py`), truthful capabilities (`capabilities.py`), routes under `rex/mobile_api/routes/`. Session 1 implements auth only; chat/voice/TTS/HA routes are explicit 501 scaffolds.
 
 ### Assistant architecture
 
@@ -330,6 +336,14 @@ Runtime configuration → config/rex_config.json
 | `config.integrations` | `config.integrations.home_assistant_base_url`, `config.integrations.openclaw_gateway_url` |
 | `config.ui` | `config.ui.gui_port`, `config.ui.gui_host` |
 | `config.security` | `config.security.api_key_env`, `config.security.rate_limit_per_minute` |
+
+The mobile gateway adds an eighth typed group, `config.mobile_api`
+(`MobileApiConfig`, JSON group `mobile_api` in `config/rex_config.json`):
+host/port, token TTLs, body limits, deny-by-default CORS origins, and
+route-specific rate-limit strings. It is canonical nested config with no flat
+equivalents. The mobile JWT signing secret is `REX_JWT_SECRET` in `.env`
+(minimum 32 characters; the gateway fails closed without it). See
+`docs/mobile/MOBILE_API_SETUP_WINDOWS.md` for setup.
 
 Flat top-level fields (e.g. `config.llm_provider`, `config.tts_voice`) still work but emit
 `DeprecationWarning: Use config.<group>.<field> instead`. Migrate call sites to the nested path

--- a/config/rex_config.example.json
+++ b/config/rex_config.example.json
@@ -73,6 +73,24 @@
       "*"
     ]
   },
+  "mobile_api": {
+    "enabled": false,
+    "host": "127.0.0.1",
+    "port": 8765,
+    "allowed_origins": [],
+    "require_tls": false,
+    "api_version": "1.0",
+    "access_token_ttl_seconds": 900,
+    "refresh_token_ttl_days": 30,
+    "max_json_bytes": 1048576,
+    "max_audio_bytes": 15728640,
+    "max_audio_seconds": 60,
+    "rate_limit_default": "60 per minute",
+    "rate_limit_login": "10 per minute",
+    "rate_limit_refresh": "30 per minute",
+    "rate_limit_chat": "30 per minute",
+    "rate_limit_voice": "10 per minute"
+  },
   "calendar": {
     "backend": "stub",
     "ics": {

--- a/docs/mobile/MOBILE_API_SETUP_WINDOWS.md
+++ b/docs/mobile/MOBILE_API_SETUP_WINDOWS.md
@@ -1,0 +1,206 @@
+# Mobile API Gateway — Windows Setup and Troubleshooting
+
+This guide covers running the AskRex mobile API gateway (Session 1: foundation
+and authentication) on Windows 10/11 with PowerShell.
+
+The gateway serves `/mobile/*` only. Chat, streaming, WebSocket, voice, TTS,
+Home Assistant, notifications, approvals, tasks, workflows, audit-log, and
+settings routes exist as explicit HTTP 501 `NOT_IMPLEMENTED` scaffolds and are
+reported as `false` in `/mobile/capabilities` until they are really
+implemented.
+
+## 1. Prerequisites
+
+- Python 3.11 virtual environment with the project installed (`pip install .`).
+- The repository checked out (config lives in `config/rex_config.json`,
+  secrets in `.env`).
+
+## 2. Generate the JWT secret
+
+The gateway signs short-lived access tokens with `REX_JWT_SECRET` from `.env`.
+The secret must be at least 32 characters; the server fails closed without it.
+
+```powershell
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+Add the output to `.env` (never commit `.env`):
+
+```text
+REX_JWT_SECRET=<generated 64-hex-character value>
+```
+
+## 3. Create a mobile user
+
+```powershell
+python -m rex mobile-user create --username james
+```
+
+- The password is prompted twice with hidden input. It is never accepted on
+  the command line, echoed, or logged.
+- Users are stored in the canonical `data/users.db` with bcrypt hashes.
+- A generated UUID is the canonical user ID; the username is display/login
+  data only.
+- The first registered user is automatically granted `admin` (shown as the
+  `owner` role in the mobile app).
+
+## 4. Configuration (optional)
+
+Runtime settings live in `config/rex_config.json` under the `mobile_api`
+group. All values below are the defaults; add only what you need to change:
+
+```json
+{
+  "mobile_api": {
+    "enabled": false,
+    "host": "127.0.0.1",
+    "port": 8765,
+    "allowed_origins": [],
+    "require_tls": false,
+    "api_version": "1.0",
+    "access_token_ttl_seconds": 900,
+    "refresh_token_ttl_days": 30,
+    "max_json_bytes": 1048576,
+    "max_audio_bytes": 15728640,
+    "max_audio_seconds": 60,
+    "rate_limit_default": "60 per minute",
+    "rate_limit_login": "10 per minute",
+    "rate_limit_refresh": "30 per minute",
+    "rate_limit_chat": "30 per minute",
+    "rate_limit_voice": "10 per minute"
+  }
+}
+```
+
+Notes:
+
+- CORS is deny-by-default: `allowed_origins` is empty and `"*"` is rejected.
+  Native mobile clients do not need CORS.
+- The server never starts automatically because configuration exists; it runs
+  only when you start it explicitly.
+- Rate limiting uses in-memory storage — suitable only for this
+  single-process development server.
+
+## 5. Start the server
+
+Localhost (default, recommended):
+
+```powershell
+python -m rex mobile-api --host 127.0.0.1 --port 8765
+```
+
+Explicit LAN development (development-only, plain HTTP on a trusted network):
+
+```powershell
+python -m rex mobile-api --host 0.0.0.0 --port 8765
+```
+
+CLI flags override the `mobile_api` config values; otherwise the config is
+used, then the safe localhost defaults. The startup banner prints the bind
+address, status URL, and whether TLS is expected upstream — and warns when
+bound beyond loopback without TLS. Authentication and rate limiting stay
+enforced on LAN binds. Never expose this development server directly to the
+internet; public deployment requires TLS termination and a production server.
+
+## 6. Windows Firewall (LAN development only)
+
+Scope inbound access to the private profile and the specific port:
+
+```powershell
+New-NetFirewallRule -DisplayName "AskRex Mobile API (private)" `
+  -Direction Inbound -Action Allow -Protocol TCP -LocalPort 8765 `
+  -Profile Private
+```
+
+Remove it when finished:
+
+```powershell
+Remove-NetFirewallRule -DisplayName "AskRex Mobile API (private)"
+```
+
+Find your PC's LAN IP for the phone's server URL (`http://<PC-LAN-IP>:8765`):
+
+```powershell
+Get-NetIPAddress -AddressFamily IPv4 -PrefixOrigin Dhcp |
+  Select-Object IPAddress, InterfaceAlias
+```
+
+## 7. Verify with PowerShell
+
+Status (no authentication):
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8765/mobile/status
+Invoke-RestMethod http://127.0.0.1:8765/mobile/capabilities
+```
+
+Login (prompts for the password without echoing it):
+
+```powershell
+$cred = Get-Credential -UserName james -Message "AskRex mobile login"
+$body = @{
+  username = $cred.UserName
+  password = $cred.GetNetworkCredential().Password
+  device   = @{ device_id = [guid]::NewGuid().ToString(); name = "Dev PC"; platform = "windows"; app_version = "0.1.0" }
+} | ConvertTo-Json
+$login = Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8765/mobile/auth/login `
+  -ContentType "application/json" -Body $body
+```
+
+Current session:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8765/mobile/auth/session `
+  -Headers @{ Authorization = "Bearer $($login.access_token)" }
+```
+
+Refresh (rotates the refresh token — keep only the new one):
+
+```powershell
+$refresh = Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8765/mobile/auth/refresh `
+  -ContentType "application/json" `
+  -Body (@{ refresh_token = $login.refresh_token } | ConvertTo-Json)
+```
+
+Logout (revokes the current session; the access token stops working):
+
+```powershell
+Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8765/mobile/auth/logout `
+  -Headers @{ Authorization = "Bearer $($refresh.access_token)" }
+```
+
+## 8. Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `Error: REX_JWT_SECRET is not set` | Add the secret to `.env` (section 2) and restart. |
+| `REX_JWT_SECRET is too short` | The secret must be at least 32 characters; regenerate with `secrets.token_hex(32)`. |
+| `401 AUTH_INVALID_CREDENTIALS` on login | Wrong username or password (the error is deliberately identical for both), or the account is disabled. |
+| `401 AUTH_REFRESH_REUSED` | A refresh token was used twice. All sessions in that token family were revoked as a safety measure — log in again. Make sure the client always stores the newest refresh token. |
+| `401 AUTH_SESSION_REVOKED` | The session was logged out, revoked, or expired. Log in again. |
+| `401 AUTH_TOKEN_EXPIRED` | The access token passed its 15-minute lifetime — refresh, or the refresh token passed its 30-day lifetime — log in again. |
+| `429 RATE_LIMITED` | Too many requests; wait for the `Retry-After` seconds in the response. |
+| `501 NOT_IMPLEMENTED` | The route is a truthful scaffold — that feature is not built yet (see `/mobile/capabilities`). |
+| Phone cannot reach the server | Confirm the server is bound to `0.0.0.0`, the firewall rule targets the Private profile and correct port, both devices share the same network, and the phone uses `http://<PC-LAN-IP>:8765`. |
+| `port ... in use` | Another process owns the port. Pick another port with `--port`. |
+
+## 9. Security notes
+
+- Access tokens live 15 minutes; refresh tokens 30 days, rotate on every use,
+  and are stored as SHA-256 hashes only.
+- Reuse of a rotated refresh token revokes the whole token family and its
+  session, and the event is audited without logging token material.
+- Logout invalidates otherwise-unexpired access tokens through server-side
+  session checks; logout-all revokes only your own sessions.
+- Passwords, tokens, hashes, and request bodies never appear in server logs.
+- LAN binding without TLS is a development-only configuration for trusted
+  networks; public deployment is separately gated on TLS and reverse-proxy
+  work.
+
+## Validation record (Session 1)
+
+Local smoke performed on Windows 11 with PowerShell/loopback:
+status → capabilities → login → invalid login → session → refresh →
+refresh-reuse (family revoked) → scaffold 501 → logout → revoked session.
+Physical-iPhone and LAN validation have **not** been performed in Session 1
+and remain tracked under issue #323.

--- a/rex/cli.py
+++ b/rex/cli.py
@@ -71,6 +71,7 @@ from rex.commands import (  # noqa: E402
     identity,
     memory,
     messaging,
+    mobile,
     pc,
     reminders,
     scheduler,
@@ -141,6 +142,7 @@ from rex.commands.ha import (  # noqa: E402,F401
 from rex.commands.identity import cmd_identify, cmd_voice_id, cmd_whoami  # noqa: E402,F401
 from rex.commands.memory import cmd_kb, cmd_memory, cmd_remember  # noqa: E402,F401
 from rex.commands.messaging import cmd_msg, cmd_notify  # noqa: E402,F401
+from rex.commands.mobile import cmd_mobile_api, cmd_mobile_user  # noqa: E402,F401
 from rex.commands.pc import cmd_pc  # noqa: E402,F401
 from rex.commands.reminders import cmd_cues, cmd_reminders  # noqa: E402,F401
 from rex.commands.scheduler import cmd_scheduler  # noqa: E402,F401
@@ -193,6 +195,7 @@ def create_parser() -> argparse.ArgumentParser:
     ha.register(subparsers)
     identity.register_voice_id(subparsers)
     dashboard.register(subparsers)
+    mobile.register(subparsers)
 
     return parser
 

--- a/rex/commands/mobile.py
+++ b/rex/commands/mobile.py
@@ -1,0 +1,212 @@
+"""Mobile API gateway commands for the Rex CLI (issue #323).
+
+Commands:
+
+- ``rex mobile-api [--host HOST] [--port PORT]`` — run the authenticated
+  mobile API development server.
+- ``rex mobile-user create --username USERNAME`` — safely create a mobile
+  user reusing the canonical user store, profile, and permission bootstrap.
+
+Heavy imports (Flask, the mobile package) happen inside the handlers so
+``--help`` and module import stay lightweight.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+
+_LOOPBACK_HOSTS = {"localhost"}
+
+
+def _host_is_loopback(host: str) -> bool:
+    """Return True when *host* only accepts local connections."""
+    if host in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def cmd_mobile_api(args: argparse.Namespace) -> int:
+    """Run the mobile API development server."""
+    from rex.config import load_config
+    from rex.mobile_api.app import create_mobile_app
+    from rex.mobile_api.auth import MobileAuthConfigurationError
+
+    settings = load_config()
+    config = settings.mobile_api
+
+    # Precedence: explicit CLI flags > typed mobile_api config > safe defaults
+    # (the typed config already carries the safe localhost defaults).
+    host = args.host if args.host is not None else config.host
+    port = args.port if args.port is not None else config.port
+    if not 1 <= port <= 65535:
+        print(f"Error: invalid port {port}; must be between 1 and 65535.")
+        return 1
+    effective = config.model_copy(update={"host": host, "port": port})
+
+    try:
+        app = create_mobile_app(config=effective)
+    except MobileAuthConfigurationError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print("AskRex mobile API gateway")
+    print(f"  Bind:       {host}:{port}")
+    print(f"  Status URL: http://{host}:{port}/mobile/status")
+    print(f"  API version: {effective.api_version}")
+    print(f"  TLS expected upstream: {'yes' if effective.require_tls else 'no'}")
+    if not _host_is_loopback(host) and not effective.require_tls:
+        print(
+            "  WARNING: binding beyond loopback without TLS. This is a "
+            "development-only configuration for trusted local networks; "
+            "authentication and rate limiting stay enforced, but traffic "
+            "is not encrypted. Do not expose this bind to the internet."
+        )
+    print("  Press Ctrl+C to stop.")
+
+    app.run(host=host, port=port)
+    return 0
+
+
+def _create_mobile_user(username: str, password: str) -> dict:
+    """Create the user, matching profile, and first-user admin bootstrap.
+
+    Separated so tests can exercise the creation flow without prompts.
+    """
+    from rex.auth import create_user
+    from rex.identity import create_user_profile
+    from rex.mobile_api.db import default_users_db_path, migrate_users_db
+    from rex.permissions import bootstrap_admin_if_first_user, get_permissions
+
+    # Ensure the canonical schema (including mobile tables and the
+    # user-active column) exists before touching the store.
+    migrate_users_db(default_users_db_path())
+
+    user = create_user(username, password)
+    try:
+        create_user_profile(user["id"], name=username)
+    except FileExistsError:
+        # A profile keyed by this fresh UUID should not exist; if it somehow
+        # does, keep the existing profile rather than overwriting it.
+        pass
+    bootstrap_admin_if_first_user(user["id"])
+    user["permissions"] = get_permissions(user["id"])
+    return user
+
+
+def cmd_mobile_user(args: argparse.Namespace) -> int:
+    """Manage mobile users (currently: create)."""
+    if args.mobile_user_command != "create":
+        print("Error: unknown mobile-user command. Use: rex mobile-user create")
+        return 1
+
+    import getpass
+
+    username = args.username.strip()
+    if not username:
+        print("Error: --username must not be empty.")
+        return 1
+
+    # Passwords are prompted with getpass (twice), never accepted via argv
+    # and never echoed or logged.  An interrupted prompt creates nothing.
+    try:
+        password = getpass.getpass("Password: ")
+        confirm = getpass.getpass("Confirm password: ")
+    except (KeyboardInterrupt, EOFError):
+        print("\nCancelled. No user was created.")
+        return 1
+
+    if not password:
+        print("Error: password must not be empty. No user was created.")
+        return 1
+    if password != confirm:
+        print("Error: passwords do not match. No user was created.")
+        return 1
+
+    try:
+        user = _create_mobile_user(username, password)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"Created mobile user '{user['username']}'.")
+    print(f"  User ID: {user['id']}")
+    if "admin" in user.get("permissions", []):
+        print("  Granted: admin (first registered user)")
+    print("  Log in from the mobile app with this username and password.")
+    return 0
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register mobile gateway subcommands on the top-level subparsers."""
+    # mobile-api
+    api_parser = subparsers.add_parser(
+        "mobile-api",
+        help="Run the authenticated mobile API gateway (development server)",
+        description=(
+            "Run the AskRex mobile API gateway.\n\n"
+            "Defaults to 127.0.0.1:8765. Binding to 0.0.0.0 is an explicit,\n"
+            "development-only choice for trusted local networks and prints a\n"
+            "warning when TLS is not expected upstream.\n\n"
+            "Requires REX_JWT_SECRET in .env (at least 32 characters)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    api_parser.add_argument(
+        "--host",
+        type=str,
+        default=None,
+        help="Bind host (default: mobile_api.host config, then 127.0.0.1)",
+    )
+    api_parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Bind port (default: mobile_api.port config, then 8765)",
+    )
+    api_parser.set_defaults(func=cmd_mobile_api)
+
+    # mobile-user
+    user_parser = subparsers.add_parser(
+        "mobile-user",
+        help="Manage mobile users (create)",
+        description=(
+            "Manage users for the mobile API gateway.\n\n"
+            "Users are stored in the canonical data/users.db with bcrypt\n"
+            "password hashes. The first registered user is granted admin."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    user_subparsers = user_parser.add_subparsers(
+        title="mobile-user commands",
+        dest="mobile_user_command",
+        metavar="COMMAND",
+        required=True,
+    )
+    create_parser = user_subparsers.add_parser(
+        "create",
+        help="Create a mobile user (prompts for the password securely)",
+        description=(
+            "Create a mobile user. The password is prompted twice with\n"
+            "getpass and is never accepted on the command line, echoed,\n"
+            "or logged. A generated UUID is the canonical user ID."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    create_parser.add_argument(
+        "--username",
+        type=str,
+        required=True,
+        help="Username for login (display only; not an authorization key)",
+    )
+    create_parser.set_defaults(func=cmd_mobile_user)
+
+
+__all__ = [
+    "cmd_mobile_api",
+    "cmd_mobile_user",
+    "register",
+]

--- a/rex/config.py
+++ b/rex/config.py
@@ -19,7 +19,7 @@ import warnings
 
 from typing import ClassVar, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 try:
     from dotenv import load_dotenv, set_key
@@ -236,6 +236,97 @@ class SecurityConfig(BaseModel):
     allowed_origins: List[str] = ["*"]
 
 
+_RATE_LIMIT_PATTERN = r"^\d+\s*(?:per\s+|/)\s*\d*\s*(?:second|minute|hour|day|month|year)s?$"
+
+
+class MobileApiConfig(BaseModel):
+    """Typed configuration for the authenticated mobile API gateway (issue #323).
+
+    Canonical JSON group: ``mobile_api`` in ``config/rex_config.json``.
+    The JWT signing secret is NOT part of this model — it lives in ``.env``
+    as ``REX_JWT_SECRET`` (secrets never belong in runtime configuration).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 8765
+    allowed_origins: List[str] = []
+    require_tls: bool = False
+    api_version: str = "1.0"
+    access_token_ttl_seconds: int = 900
+    refresh_token_ttl_days: int = 30
+    max_json_bytes: int = 1_048_576
+    max_audio_bytes: int = 15_728_640
+    max_audio_seconds: int = 60
+    rate_limit_default: str = "60 per minute"
+    rate_limit_login: str = "10 per minute"
+    rate_limit_refresh: str = "30 per minute"
+    rate_limit_chat: str = "30 per minute"
+    rate_limit_voice: str = "10 per minute"
+
+    @field_validator("host", "api_version")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+    @field_validator("port")
+    @classmethod
+    def _valid_port(cls, value: int) -> int:
+        if not 1 <= value <= 65535:
+            raise ValueError("port must be between 1 and 65535")
+        return value
+
+    @field_validator(
+        "access_token_ttl_seconds",
+        "refresh_token_ttl_days",
+        "max_json_bytes",
+        "max_audio_bytes",
+        "max_audio_seconds",
+    )
+    @classmethod
+    def _positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("must be a positive integer")
+        return value
+
+    @field_validator(
+        "rate_limit_default",
+        "rate_limit_login",
+        "rate_limit_refresh",
+        "rate_limit_chat",
+        "rate_limit_voice",
+    )
+    @classmethod
+    def _valid_rate_limit(cls, value: str) -> str:
+        import re as _re  # noqa: PLC0415
+
+        value = value.strip()
+        if not _re.fullmatch(_RATE_LIMIT_PATTERN, value):
+            raise ValueError(f"invalid rate limit string {value!r}; expected e.g. '60 per minute'")
+        return value
+
+    @field_validator("allowed_origins")
+    @classmethod
+    def _valid_origins(cls, value: List[str]) -> List[str]:
+        cleaned: List[str] = []
+        for origin in value:
+            origin = str(origin).strip().rstrip("/")
+            if not origin:
+                continue
+            if origin == "*":
+                raise ValueError(
+                    "wildcard '*' is not allowed for mobile_api.allowed_origins; "
+                    "CORS is deny-by-default"
+                )
+            cleaned.append(origin)
+        return cleaned
+
+
 @dataclass
 class AppConfig:
     """Application configuration combining JSON config and environment secrets."""
@@ -444,6 +535,10 @@ class AppConfig:
     ui: Optional[UIConfig] = field(default=None, repr=False, compare=False)
     security: Optional[SecurityConfig] = field(default=None, repr=False, compare=False)
 
+    # Mobile API gateway (issue #323) — canonical nested group, parsed from the
+    # ``mobile_api`` JSON section (no flat-field equivalents).
+    mobile_api: MobileApiConfig = field(default_factory=MobileApiConfig, repr=False, compare=False)
+
     # ---------------------------------------------------------------------------
     # US-003 — Deprecated flat-field access map (ClassVar, not a dataclass field)
     # Maps flat field name → sub-config group name; used by __getattribute__
@@ -584,7 +679,16 @@ class AppConfig:
             warnings.simplefilter("ignore", DeprecationWarning)
             raw = asdict(self)
         # Remove nested sub-config objects (US-002) — derived views; not part of serialised output
-        for _key in ("audio", "voice", "llm", "tools", "integrations", "ui", "security"):
+        for _key in (
+            "audio",
+            "voice",
+            "llm",
+            "tools",
+            "integrations",
+            "ui",
+            "security",
+            "mobile_api",
+        ):
             raw.pop(_key, None)
         raw["transcripts_dir"] = str(self.transcripts_dir)
         raw["log_path"] = str(self.log_path)
@@ -929,6 +1033,23 @@ def _migrate_wake_word_section(json_config: dict) -> dict:
     return json_config
 
 
+def _parse_mobile_api_config(raw: object) -> MobileApiConfig:
+    """Parse and validate the ``mobile_api`` JSON group.
+
+    Raises:
+        ConfigurationError: If any mobile_api value fails validation, so that
+            startup fails before serving rather than running misconfigured.
+    """
+    if not isinstance(raw, dict):
+        if raw is not None:
+            raise ConfigurationError("Config group 'mobile_api' must be a JSON object.")
+        raw = {}
+    try:
+        return MobileApiConfig(**raw)
+    except Exception as exc:
+        raise ConfigurationError(f"Invalid 'mobile_api' configuration: {exc}") from exc
+
+
 def build_app_config(json_config: dict) -> AppConfig:
     """Build an AppConfig from a merged JSON configuration."""
     # Migrate legacy wake_word key to canonical wakeword key
@@ -1134,6 +1255,8 @@ def build_app_config(json_config: dict) -> AppConfig:
         require_confirm_system_changes=bool(
             _get_nested(json_config, "windows.require_confirm_system_changes", True)
         ),
+        # Mobile API gateway (issue #323)
+        mobile_api=_parse_mobile_api_config(json_config.get("mobile_api")),
     )
 
     return config

--- a/rex/config.py
+++ b/rex/config.py
@@ -679,17 +679,12 @@ class AppConfig:
             warnings.simplefilter("ignore", DeprecationWarning)
             raw = asdict(self)
         # Remove nested sub-config objects (US-002) — derived views; not part of serialised output
-        for _key in (
-            "audio",
-            "voice",
-            "llm",
-            "tools",
-            "integrations",
-            "ui",
-            "security",
-            "mobile_api",
-        ):
+        for _key in ("audio", "voice", "llm", "tools", "integrations", "ui", "security"):
             raw.pop(_key, None)
+        # mobile_api is canonical nested config with no flat equivalents, so it
+        # is serialised as its validated dictionary (it contains no secrets —
+        # the JWT secret lives in .env only).
+        raw["mobile_api"] = self.mobile_api.model_dump()
         raw["transcripts_dir"] = str(self.transcripts_dir)
         raw["log_path"] = str(self.log_path)
         raw["error_log_path"] = str(self.error_log_path)

--- a/rex/mobile_api/__init__.py
+++ b/rex/mobile_api/__init__.py
@@ -1,0 +1,23 @@
+"""Authenticated mobile API gateway for AskRex (issue #323).
+
+This package owns the mobile HTTP transport and security boundary:
+access-token validation, rotating refresh sessions, request IDs, structured
+errors, rate limits, body limits, and truthful capabilities.
+
+It deliberately does NOT own a second assistant, user directory, permission
+model, memory implementation, or policy engine — it reuses the canonical Rex
+services and ``data/users.db``.
+
+Importing this package must have no side effects (no listeners, no database
+mutation, no model loading, no secret reads).  Use
+:func:`rex.mobile_api.app.create_mobile_app` to build a configured Flask app.
+"""
+
+__all__ = ["create_mobile_app"]
+
+
+def create_mobile_app(*args, **kwargs):
+    """Lazily import and delegate to :func:`rex.mobile_api.app.create_mobile_app`."""
+    from rex.mobile_api.app import create_mobile_app as _factory
+
+    return _factory(*args, **kwargs)

--- a/rex/mobile_api/app.py
+++ b/rex/mobile_api/app.py
@@ -1,0 +1,159 @@
+"""Flask application factory for the AskRex mobile API gateway (issue #323).
+
+``create_mobile_app`` builds an injectable app with:
+
+- request IDs and privacy-safe request/response logging (no bodies, no tokens);
+- ``X-Request-ID`` and ``X-AskRex-API-Version`` headers on every response;
+- the nested mobile error envelope (with ``retryable`` and ``request_id``);
+- a global JSON body limit (413 before full processing);
+- deny-by-default CORS (no origins unless explicitly configured, never ``*``);
+- route-specific rate limiting (login/refresh have their own limits);
+- only ``/mobile/*`` routes — the Electron GUI/admin server is a separate app.
+
+Importing this module has no side effects; database migrations run when the
+factory is called.  In-memory rate-limit storage is suitable only for the
+single-process development server and is documented as such.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from flask import Flask, Response, g
+
+from rex.config import MobileApiConfig
+from rex.mobile_api import errors as merr
+from rex.mobile_api.db import migrate_users_db
+from rex.mobile_api.errors import install_mobile_error_handlers
+from rex.mobile_api.routes import (
+    build_auth_blueprint,
+    build_scaffolds_blueprint,
+    build_status_blueprint,
+)
+from rex.mobile_api.services import MobileApiServices
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_config(config: MobileApiConfig | None) -> MobileApiConfig:
+    if config is not None:
+        return config
+    try:
+        from rex.config import settings  # noqa: PLC0415
+
+        resolved = getattr(settings, "mobile_api", None)
+        if isinstance(resolved, MobileApiConfig):
+            return resolved
+    except Exception:  # pragma: no cover - config loading edge cases
+        logger.warning("Falling back to default mobile_api configuration")
+    return MobileApiConfig()
+
+
+def _install_rate_limiter(app: Flask, config: MobileApiConfig):
+    from flask import jsonify  # noqa: PLC0415
+    from flask_limiter import Limiter, RequestLimit  # noqa: PLC0415
+    from flask_limiter.util import get_remote_address  # noqa: PLC0415
+
+    def _on_breach(request_limit: RequestLimit):
+        import time as _time  # noqa: PLC0415
+
+        reset_at = getattr(request_limit, "reset_at", None)
+        if reset_at is not None:
+            retry_after = max(1, math.ceil(reset_at - _time.time()))
+        else:
+            retry_after = 60
+        body = {
+            "error": {
+                "code": merr.RATE_LIMITED,
+                "message": "Too many requests. Please slow down.",
+                "retryable": True,
+                "request_id": getattr(g, "request_id", None),
+            }
+        }
+        response = jsonify(body)
+        response.status_code = 429
+        response.headers["Retry-After"] = str(retry_after)
+        return response
+
+    limiter = Limiter(
+        key_func=get_remote_address,
+        app=app,
+        default_limits=[config.rate_limit_default],
+        # In-memory storage: single-process local development only.  A shared
+        # storage backend is required before any multi-process deployment.
+        storage_uri="memory://",
+        headers_enabled=True,
+        on_breach=_on_breach,
+    )
+    return limiter
+
+
+def _install_cors(app: Flask, config: MobileApiConfig) -> None:
+    """Deny-by-default CORS: only explicitly configured origins, never '*'."""
+    if not config.allowed_origins:
+        return
+    from flask_cors import CORS  # noqa: PLC0415
+
+    CORS(
+        app,
+        resources={r"/mobile/*": {"origins": list(config.allowed_origins)}},
+        supports_credentials=False,
+    )
+
+
+def create_mobile_app(
+    config: MobileApiConfig | None = None,
+    services: MobileApiServices | None = None,
+) -> Flask:
+    """Create a configured mobile API Flask application.
+
+    Args:
+        config: Typed mobile API configuration.  Defaults to the global
+            ``settings.mobile_api`` group, then safe library defaults.
+        services: Pre-built service container (tests inject temporary
+            database paths, fake clocks, and deterministic generators).
+
+    Raises:
+        MobileAuthConfigurationError: When ``REX_JWT_SECRET`` is missing or
+            too weak — the auth service fails closed before serving.
+    """
+    if services is None:
+        services = MobileApiServices.build(_resolve_config(config))
+    cfg = services.config
+
+    # Idempotent canonical users.db migration (sessions/refresh tables).
+    migrate_users_db(services.db_path)
+
+    app = Flask("rex_mobile_api")
+    app.config["MAX_CONTENT_LENGTH"] = cfg.max_json_bytes
+    app.extensions["mobile_api_services"] = services
+
+    # Reused canonical middleware: assigns g.request_id before authentication
+    # and logs method/path/status only — request and response bodies, tokens,
+    # and passwords are never logged.
+    from rex.request_logging import install_request_logging  # noqa: PLC0415
+
+    install_request_logging(app)
+    install_mobile_error_handlers(app)
+    _install_cors(app, cfg)
+    limiter = _install_rate_limiter(app, cfg)
+    app.extensions["mobile_api_limiter"] = limiter
+
+    @app.after_request
+    def _add_mobile_headers(response: Response) -> Response:
+        request_id = getattr(g, "request_id", None)
+        if request_id:
+            response.headers["X-Request-ID"] = request_id
+        response.headers["X-AskRex-API-Version"] = cfg.api_version
+        return response
+
+    app.register_blueprint(build_status_blueprint(services))
+    app.register_blueprint(build_auth_blueprint(services, limiter))
+    app.register_blueprint(build_scaffolds_blueprint(services))
+
+    logger.info("Mobile API app created (api_version=%s)", cfg.api_version)
+    return app
+
+
+__all__ = ["create_mobile_app"]

--- a/rex/mobile_api/auth.py
+++ b/rex/mobile_api/auth.py
@@ -1,0 +1,225 @@
+"""Mobile access-token (JWT) issuing/validation and the request principal.
+
+Access JWTs are short-lived (default 15 minutes) and carry ``iss``, ``aud``,
+``sub``, ``sid``, ``jti``, ``iat``, ``nbf``, and ``exp``.  Every authenticated
+request validates, in order: Bearer syntax, signature with the configured
+algorithm only, issuer, audience, time claims, required claims, canonical
+``sub`` (before any private lookup), session existence/ownership/status, and
+user existence/active status.  Display claims are never used for
+authorization — permissions are resolved live from the server-side store.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from functools import wraps
+from typing import TYPE_CHECKING, Any
+
+import jwt
+
+from rex.identity import get_user_profile, validate_user_id
+from rex.mobile_api import errors as merr
+from rex.mobile_api import users as musers
+from rex.mobile_api.db import connect
+from rex.mobile_api.errors import MobileApiError
+
+if TYPE_CHECKING:
+    from rex.mobile_api.services import MobileApiServices
+
+logger = logging.getLogger(__name__)
+
+JWT_ISSUER = "askrex-assistant"
+JWT_AUDIENCE = "askrex-mobile"
+JWT_ALGORITHM = "HS256"
+MIN_JWT_SECRET_LENGTH = 32
+
+_REQUIRED_CLAIMS = ["iss", "aud", "sub", "sid", "jti", "iat", "nbf", "exp"]
+
+
+class MobileAuthConfigurationError(RuntimeError):
+    """The auth service cannot start; the message never contains the secret."""
+
+
+def load_jwt_secret() -> str:
+    """Return the mobile JWT signing secret from ``REX_JWT_SECRET``.
+
+    Fails closed when the secret is missing or does not meet the documented
+    minimum length of 32 characters (use at least 32 random bytes — e.g.
+    ``python -c "import secrets; print(secrets.token_hex(32))"``).
+    """
+    secret = os.getenv("REX_JWT_SECRET") or ""
+    if not secret:
+        raise MobileAuthConfigurationError(
+            "REX_JWT_SECRET is not set. Add it to your .env file. Generate a "
+            'value with: python -c "import secrets; print(secrets.token_hex(32))"'
+        )
+    if len(secret) < MIN_JWT_SECRET_LENGTH:
+        raise MobileAuthConfigurationError(
+            f"REX_JWT_SECRET is too short (minimum {MIN_JWT_SECRET_LENGTH} "
+            "characters). Generate a value with: "
+            'python -c "import secrets; print(secrets.token_hex(32))"'
+        )
+    return secret
+
+
+@dataclass(frozen=True)
+class MobilePrincipal:
+    """Immutable per-request identity resolved from validated credentials.
+
+    ``role`` is a presentation projection; ``permissions`` is the live
+    server-side permission set at validation time.
+    """
+
+    user_id: str
+    session_id: str
+    username: str
+    display_name: str
+    role: str
+    permissions: frozenset[str]
+
+
+def issue_access_token(
+    *,
+    secret: str,
+    user_id: str,
+    session_id: str,
+    ttl_seconds: int,
+    now: datetime,
+    token_id: str,
+) -> str:
+    """Create a signed short-lived mobile access JWT."""
+    payload = {
+        "iss": JWT_ISSUER,
+        "aud": JWT_AUDIENCE,
+        "sub": user_id,
+        "sid": session_id,
+        "jti": token_id,
+        "iat": now,
+        "nbf": now,
+        "exp": now + timedelta(seconds=ttl_seconds),
+    }
+    return jwt.encode(payload, secret, algorithm=JWT_ALGORITHM)
+
+
+def decode_access_token(token: str, secret: str) -> dict[str, Any]:
+    """Decode and validate a mobile access JWT.
+
+    Raises:
+        MobileApiError: With ``AUTH_TOKEN_EXPIRED`` or ``AUTH_TOKEN_INVALID``.
+    """
+    try:
+        return jwt.decode(
+            token,
+            secret,
+            algorithms=[JWT_ALGORITHM],
+            issuer=JWT_ISSUER,
+            audience=JWT_AUDIENCE,
+            options={"require": _REQUIRED_CLAIMS},
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise MobileApiError(merr.AUTH_TOKEN_EXPIRED, "Access token expired.", 401) from exc
+    except jwt.InvalidTokenError as exc:
+        # Covers bad signature, wrong algorithm, wrong issuer/audience,
+        # future nbf, and missing required claims.  One non-enumerating error.
+        raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401) from exc
+
+
+def _bearer_token_from_request() -> str:
+    from flask import request  # noqa: PLC0415
+
+    header = request.headers.get("Authorization", "")
+    parts = header.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1].strip():
+        raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Missing or invalid authorization.", 401)
+    return parts[1].strip()
+
+
+def authenticate_request(services: MobileApiServices) -> MobilePrincipal:
+    """Authenticate the current Flask request and return its principal.
+
+    Raises:
+        MobileApiError: On any validation failure (fails closed).
+    """
+    token = _bearer_token_from_request()
+    claims = decode_access_token(token, services.jwt_secret)
+
+    # Canonical identity validation BEFORE any private lookup.
+    try:
+        user_id = validate_user_id(str(claims["sub"]))
+    except ValueError as exc:
+        raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401) from exc
+
+    session_id = str(claims["sid"])
+    store = services.session_store
+    session = store.get_session(session_id)
+    if session is None:
+        raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401)
+    if session["user_id"] != user_id:
+        # Token subject does not own this session; audit with safe IDs only.
+        logger.warning(
+            "Mobile session/subject mismatch: session=%s jti=%s",
+            session_id,
+            claims.get("jti"),
+        )
+        raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401)
+    if session["revoked_at"] is not None:
+        raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session has been revoked.", 401)
+    if not store.session_is_active(session, store.now()):
+        raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session has expired.", 401)
+
+    conn = connect(services.db_path)
+    try:
+        user = musers.get_user(conn, user_id)
+    finally:
+        conn.close()
+    if user is None or not musers.is_user_active(user):
+        raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session is no longer valid.", 401)
+
+    permissions = frozenset(musers.get_user_permissions(services.db_path, user_id))
+    username = str(user["username"])
+    display_name = username
+    profile = get_user_profile(user_id)
+    if profile and isinstance(profile.get("name"), str) and profile["name"].strip():
+        display_name = profile["name"].strip()
+
+    store.touch_session(session_id)
+    return MobilePrincipal(
+        user_id=user_id,
+        session_id=session_id,
+        username=username,
+        display_name=display_name,
+        role=musers.role_projection(permissions),
+        permissions=permissions,
+    )
+
+
+def require_mobile_auth(view: Any) -> Any:
+    """Decorator: authenticate the request and attach ``g.mobile_principal``."""
+
+    @wraps(view)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        from flask import current_app, g  # noqa: PLC0415
+
+        services = current_app.extensions["mobile_api_services"]
+        g.mobile_principal = authenticate_request(services)
+        return view(*args, **kwargs)
+
+    return wrapper
+
+
+__all__ = [
+    "JWT_ALGORITHM",
+    "JWT_AUDIENCE",
+    "JWT_ISSUER",
+    "MIN_JWT_SECRET_LENGTH",
+    "MobileAuthConfigurationError",
+    "MobilePrincipal",
+    "authenticate_request",
+    "decode_access_token",
+    "issue_access_token",
+    "load_jwt_secret",
+    "require_mobile_auth",
+]

--- a/rex/mobile_api/auth.py
+++ b/rex/mobile_api/auth.py
@@ -137,8 +137,17 @@ def _bearer_token_from_request() -> str:
     return parts[1].strip()
 
 
-def authenticate_request(services: MobileApiServices) -> MobilePrincipal:
+def authenticate_request(
+    services: MobileApiServices, *, allow_revoked_session: bool = False
+) -> MobilePrincipal:
     """Authenticate the current Flask request and return its principal.
+
+    ``allow_revoked_session`` exists solely so ``POST /mobile/auth/logout``
+    can be idempotent: every JWT check (algorithm, signature, issuer,
+    audience, required claims, nbf, exp), the canonical ``sub`` validation,
+    session existence/ownership, and user status still apply — only the
+    already-revoked-session rejection is skipped, and the session is never
+    reactivated or modified. Every other endpoint must use the default.
 
     Raises:
         MobileApiError: On any validation failure (fails closed).
@@ -165,9 +174,10 @@ def authenticate_request(services: MobileApiServices) -> MobilePrincipal:
             claims.get("jti"),
         )
         raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401)
-    if session["revoked_at"] is not None:
+    session_revoked = session["revoked_at"] is not None
+    if session_revoked and not allow_revoked_session:
         raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session has been revoked.", 401)
-    if not store.session_is_active(session, store.now()):
+    if not session_revoked and not store.session_is_active(session, store.now()):
         raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session has expired.", 401)
 
     conn = connect(services.db_path)
@@ -185,7 +195,9 @@ def authenticate_request(services: MobileApiServices) -> MobilePrincipal:
     if profile and isinstance(profile.get("name"), str) and profile["name"].strip():
         display_name = profile["name"].strip()
 
-    store.touch_session(session_id)
+    # Never modify an already-revoked session (logout-only path).
+    if not session_revoked:
+        store.touch_session(session_id)
     return MobilePrincipal(
         user_id=user_id,
         session_id=session_id,
@@ -196,18 +208,29 @@ def authenticate_request(services: MobileApiServices) -> MobilePrincipal:
     )
 
 
-def require_mobile_auth(view: Any) -> Any:
-    """Decorator: authenticate the request and attach ``g.mobile_principal``."""
+def require_mobile_auth(view: Any = None, *, allow_revoked_session: bool = False) -> Any:
+    """Decorator: authenticate the request and attach ``g.mobile_principal``.
 
-    @wraps(view)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        from flask import current_app, g  # noqa: PLC0415
+    ``allow_revoked_session=True`` is reserved for the idempotent logout
+    endpoint only (see :func:`authenticate_request`).
+    """
 
-        services = current_app.extensions["mobile_api_services"]
-        g.mobile_principal = authenticate_request(services)
-        return view(*args, **kwargs)
+    def decorate(fn: Any) -> Any:
+        @wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            from flask import current_app, g  # noqa: PLC0415
 
-    return wrapper
+            services = current_app.extensions["mobile_api_services"]
+            g.mobile_principal = authenticate_request(
+                services, allow_revoked_session=allow_revoked_session
+            )
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    if view is not None:
+        return decorate(view)
+    return decorate
 
 
 __all__ = [

--- a/rex/mobile_api/capabilities.py
+++ b/rex/mobile_api/capabilities.py
@@ -1,0 +1,67 @@
+"""Truthful mobile capability reporting (issue #323, Session 1).
+
+A feature is ``true`` only when its real backend path and automated tests
+exist.  Configuration alone never makes a capability true, and the response
+must never expose secrets, file paths, model paths, account IDs, usernames,
+or integration tokens.
+
+Session 1 implements authentication only; every runtime feature stays false
+until Session 2 lands its real implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rex.config import MobileApiConfig
+
+MINIMUM_APP_VERSION = "0.1.0"
+
+
+def server_version() -> str:
+    """Return the installed package version, or a safe placeholder."""
+    try:
+        from importlib.metadata import version  # noqa: PLC0415
+
+        return version("askrex-assistant")
+    except Exception:  # pragma: no cover - metadata edge cases
+        return "unknown"
+
+
+def resolve_features() -> dict[str, bool]:
+    """Return the truthful feature map for the current build.
+
+    Session 1: authentication is implemented and tested; chat, streaming,
+    WebSocket, voice, TTS, live voice, notifications, approvals, and Home
+    Assistant are explicit 501 scaffolds and therefore false.
+    """
+    return {
+        "authentication": True,
+        "chat": False,
+        "chat_streaming": False,
+        "websocket_chat": False,
+        "voice_upload": False,
+        "tts": False,
+        "live_voice": False,
+        "notifications": False,
+        "approvals": False,
+        "home_assistant": False,
+    }
+
+
+def capabilities_payload(config: MobileApiConfig) -> dict[str, Any]:
+    """Build the ``GET /mobile/capabilities`` response body."""
+    return {
+        "api_version": config.api_version,
+        "minimum_app_version": MINIMUM_APP_VERSION,
+        "server_version": server_version(),
+        "features": resolve_features(),
+    }
+
+
+__all__ = [
+    "MINIMUM_APP_VERSION",
+    "capabilities_payload",
+    "resolve_features",
+    "server_version",
+]

--- a/rex/mobile_api/db.py
+++ b/rex/mobile_api/db.py
@@ -1,0 +1,136 @@
+"""Canonical users database access and idempotent mobile schema migrations.
+
+The mobile gateway reuses ``data/users.db`` (the database owned by
+``rex.auth`` / ``rex.permissions``).  It never creates a second users
+database.  This module adds, through idempotent migrations:
+
+- ``users.disabled_at`` — explicit user-active state (existing rows stay
+  active because the new column defaults to NULL);
+- ``mobile_sessions`` — per-device mobile sessions;
+- ``mobile_refresh_tokens`` — hashed, rotating refresh-token families.
+
+Raw refresh tokens are never stored; only SHA-256 hashes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_BUSY_TIMEOUT_MS = 5000
+
+
+def default_users_db_path() -> Path:
+    """Return the canonical users database path (honours ``REX_DATA_DIR``)."""
+    return Path(os.getenv("REX_DATA_DIR", "data")) / "users.db"
+
+
+def connect(db_path: Path | str) -> sqlite3.Connection:
+    """Open a connection to the users database with safe defaults.
+
+    ``isolation_level=None`` puts sqlite3 in autocommit mode so transaction
+    boundaries are explicit (``BEGIN IMMEDIATE`` / ``COMMIT``), which the
+    refresh-rotation race guarantees depend on.
+    """
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+    return conn
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def migrate_users_db(db_path: Path | str) -> None:
+    """Apply all mobile gateway migrations to the users database.
+
+    Safe to run repeatedly and safe on fresh, legacy, and already-migrated
+    databases.  Existing users, password hashes, and permissions are
+    preserved; existing users remain active (``disabled_at`` defaults NULL).
+    """
+    conn = connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        # Canonical tables (identical shape to rex.auth / rex.permissions) so
+        # a fresh database is usable without importing those modules first.
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id       TEXT PRIMARY KEY,
+                username TEXT UNIQUE NOT NULL,
+                password TEXT NOT NULL,
+                created  TEXT NOT NULL
+            )
+            """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS user_permissions (
+                user_id    TEXT NOT NULL,
+                permission TEXT NOT NULL,
+                PRIMARY KEY (user_id, permission)
+            )
+            """)
+        if "disabled_at" not in _table_columns(conn, "users"):
+            conn.execute("ALTER TABLE users ADD COLUMN disabled_at TEXT NULL")
+            logger.info("users.db migration: added users.disabled_at column")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS mobile_sessions (
+                session_id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                device_id TEXT NOT NULL,
+                device_name TEXT NOT NULL DEFAULT '',
+                platform TEXT NOT NULL DEFAULT '',
+                app_version TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                revoked_at TEXT NULL,
+                revoke_reason TEXT NULL,
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            )
+            """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_mobile_sessions_user
+            ON mobile_sessions(user_id, revoked_at)
+            """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS mobile_refresh_tokens (
+                token_hash TEXT PRIMARY KEY,
+                family_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                consumed_at TEXT NULL,
+                revoked_at TEXT NULL,
+                replacement_hash TEXT NULL,
+                FOREIGN KEY (session_id) REFERENCES mobile_sessions(session_id),
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            )
+            """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_mobile_refresh_family
+            ON mobile_refresh_tokens(family_id)
+            """)
+        conn.execute("COMMIT")
+    except BaseException:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
+        raise
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "connect",
+    "default_users_db_path",
+    "migrate_users_db",
+]

--- a/rex/mobile_api/errors.py
+++ b/rex/mobile_api/errors.py
@@ -1,0 +1,164 @@
+"""Structured mobile API errors (issue #323).
+
+Every mobile error uses the repository's nested error envelope extended with
+``retryable`` and ``request_id``::
+
+    {
+      "error": {
+        "code": "AUTH_INVALID_CREDENTIALS",
+        "message": "Invalid username or password.",
+        "retryable": false,
+        "request_id": "<request-id>"
+      }
+    }
+
+Error text must never reveal whether an arbitrary username, session ID, or
+private resource exists, and must never contain tokens, passwords, hashes, or
+request bodies.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Stable mobile error codes (master spec §5.2).
+BAD_REQUEST = "BAD_REQUEST"
+AUTH_INVALID_CREDENTIALS = "AUTH_INVALID_CREDENTIALS"
+AUTH_TOKEN_EXPIRED = "AUTH_TOKEN_EXPIRED"
+AUTH_TOKEN_INVALID = "AUTH_TOKEN_INVALID"
+AUTH_TOKEN_REVOKED = "AUTH_TOKEN_REVOKED"
+AUTH_SESSION_REVOKED = "AUTH_SESSION_REVOKED"
+AUTH_REFRESH_REUSED = "AUTH_REFRESH_REUSED"
+FORBIDDEN = "FORBIDDEN"
+PERMISSION_DENIED = "PERMISSION_DENIED"
+APPROVAL_REQUIRED = "APPROVAL_REQUIRED"
+NOT_FOUND = "NOT_FOUND"
+NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
+UNSUPPORTED_API_VERSION = "UNSUPPORTED_API_VERSION"
+INVALID_MEDIA = "INVALID_MEDIA"
+PAYLOAD_TOO_LARGE = "PAYLOAD_TOO_LARGE"
+RATE_LIMITED = "RATE_LIMITED"
+BACKEND_UNAVAILABLE = "BACKEND_UNAVAILABLE"
+INTERNAL_ERROR = "INTERNAL_ERROR"
+
+# HTTP status → mobile error code for uncaught werkzeug HTTPExceptions.
+_HTTP_STATUS_TO_CODE: dict[int, str] = {
+    400: BAD_REQUEST,
+    401: AUTH_TOKEN_INVALID,
+    403: FORBIDDEN,
+    404: NOT_FOUND,
+    405: BAD_REQUEST,
+    409: BAD_REQUEST,
+    413: PAYLOAD_TOO_LARGE,
+    415: INVALID_MEDIA,
+    426: UNSUPPORTED_API_VERSION,
+    429: RATE_LIMITED,
+    500: INTERNAL_ERROR,
+    501: NOT_IMPLEMENTED,
+    503: BACKEND_UNAVAILABLE,
+}
+
+_RETRYABLE_STATUSES = {429, 503}
+
+_INSTALLED_KEY = "rex_mobile_error_handlers_installed"
+
+
+class MobileApiError(Exception):
+    """Expected mobile API error translated to the nested envelope."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        http_status: int,
+        *,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.http_status = http_status
+        self.retryable = retryable
+
+
+def _current_request_id() -> str | None:
+    from flask import g  # noqa: PLC0415
+
+    return getattr(g, "request_id", None)
+
+
+def mobile_error_response(
+    code: str,
+    message: str,
+    http_status: int,
+    *,
+    retryable: bool = False,
+) -> tuple[Any, int]:
+    """Return a Flask ``(response, status)`` tuple with the mobile envelope."""
+    from flask import jsonify  # noqa: PLC0415
+
+    body: dict[str, Any] = {
+        "error": {
+            "code": code,
+            "message": message,
+            "retryable": retryable,
+            "request_id": _current_request_id(),
+        }
+    }
+    return jsonify(body), http_status
+
+
+def install_mobile_error_handlers(app: Any) -> None:
+    """Install the mobile error envelope handlers on *app* (idempotent)."""
+    if app.extensions.get(_INSTALLED_KEY):
+        return
+    app.extensions[_INSTALLED_KEY] = True
+
+    from werkzeug.exceptions import HTTPException  # noqa: PLC0415
+
+    @app.errorhandler(MobileApiError)
+    def _handle_mobile_error(exc: MobileApiError) -> tuple[Any, int]:
+        return mobile_error_response(
+            exc.code, exc.message, exc.http_status, retryable=exc.retryable
+        )
+
+    @app.errorhandler(HTTPException)
+    def _handle_http_exception(exc: HTTPException) -> tuple[Any, int]:
+        status = exc.code or 500
+        code = _HTTP_STATUS_TO_CODE.get(status, INTERNAL_ERROR if status >= 500 else BAD_REQUEST)
+        message = exc.description or exc.name or "An error occurred."
+        return mobile_error_response(code, message, status, retryable=status in _RETRYABLE_STATUSES)
+
+    @app.errorhandler(Exception)
+    def _handle_unexpected_exception(exc: Exception) -> tuple[Any, int]:
+        # Log only the exception and request ID — never request bodies.
+        logger.exception("Unhandled mobile API exception (request_id=%s)", _current_request_id())
+        return mobile_error_response(INTERNAL_ERROR, "An unexpected error occurred.", 500)
+
+
+__all__ = [
+    "APPROVAL_REQUIRED",
+    "AUTH_INVALID_CREDENTIALS",
+    "AUTH_REFRESH_REUSED",
+    "AUTH_SESSION_REVOKED",
+    "AUTH_TOKEN_EXPIRED",
+    "AUTH_TOKEN_INVALID",
+    "AUTH_TOKEN_REVOKED",
+    "BACKEND_UNAVAILABLE",
+    "BAD_REQUEST",
+    "FORBIDDEN",
+    "INTERNAL_ERROR",
+    "INVALID_MEDIA",
+    "MobileApiError",
+    "NOT_FOUND",
+    "NOT_IMPLEMENTED",
+    "PAYLOAD_TOO_LARGE",
+    "PERMISSION_DENIED",
+    "RATE_LIMITED",
+    "UNSUPPORTED_API_VERSION",
+    "install_mobile_error_handlers",
+    "mobile_error_response",
+]

--- a/rex/mobile_api/routes/__init__.py
+++ b/rex/mobile_api/routes/__init__.py
@@ -1,0 +1,15 @@
+"""Mobile API route blueprints.
+
+Each module exposes a ``build_*_blueprint`` factory so every app instance
+gets independent, injectable views (no module-global request state).
+"""
+
+from rex.mobile_api.routes.auth import build_auth_blueprint
+from rex.mobile_api.routes.scaffolds import build_scaffolds_blueprint
+from rex.mobile_api.routes.status import build_status_blueprint
+
+__all__ = [
+    "build_auth_blueprint",
+    "build_scaffolds_blueprint",
+    "build_status_blueprint",
+]

--- a/rex/mobile_api/routes/auth.py
+++ b/rex/mobile_api/routes/auth.py
@@ -1,0 +1,187 @@
+"""Mobile authentication routes (issue #323, Session 1).
+
+Implements exactly:
+
+- ``POST /mobile/auth/login``
+- ``POST /mobile/auth/refresh``
+- ``POST /mobile/auth/logout``
+- ``POST /mobile/auth/logout-all``
+- ``GET  /mobile/auth/session``
+
+Errors never reveal whether a username, session, or account exists, and raw
+credentials/tokens are never logged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from flask import Blueprint, g, jsonify
+
+from rex.identity import validate_user_id
+from rex.mobile_api import errors as merr
+from rex.mobile_api import sessions as msessions
+from rex.mobile_api import users as musers
+from rex.mobile_api.auth import issue_access_token, require_mobile_auth
+from rex.mobile_api.db import connect
+from rex.mobile_api.errors import MobileApiError
+from rex.mobile_api.services import MobileApiServices
+from rex.mobile_api.validation import (
+    parse_device_info,
+    parse_json_body,
+    parse_refresh_token_field,
+    require_string_field,
+)
+
+_LOGIN_FAILED = "Invalid username or password."
+
+
+def _login_rate_key() -> str:
+    """Rate-limit key for login: anonymized remote address + username hash.
+
+    Combining both reduces per-account brute force without revealing account
+    existence; the raw username never appears in limiter storage.
+    """
+    from flask import request  # noqa: PLC0415
+    from flask_limiter.util import get_remote_address  # noqa: PLC0415
+
+    username = ""
+    payload = request.get_json(silent=True)
+    if isinstance(payload, dict):
+        raw = payload.get("username")
+        if isinstance(raw, str):
+            username = raw.strip().lower()
+    digest = hashlib.sha256(username.encode("utf-8")).hexdigest()[:16]
+    return f"{get_remote_address()}|{digest}"
+
+
+def build_auth_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint:
+    """Build the ``/mobile/auth`` blueprint with route-specific rate limits."""
+    bp = Blueprint("mobile_auth", __name__, url_prefix="/mobile/auth")
+    cfg = services.config
+
+    def _token_pair_response(
+        session_id: str,
+        user_id: str,
+        username: str,
+        refresh_token: str,
+        refresh_expires_at: Any,
+    ) -> Any:
+        now = services.clock()
+        access_token = issue_access_token(
+            secret=services.jwt_secret,
+            user_id=user_id,
+            session_id=session_id,
+            ttl_seconds=cfg.access_token_ttl_seconds,
+            now=now,
+            token_id=services.id_generator(),
+        )
+        refresh_expires_in = max(0, int((refresh_expires_at - now).total_seconds()))
+        return jsonify(
+            {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "token_type": "Bearer",
+                "expires_in": cfg.access_token_ttl_seconds,
+                "refresh_expires_in": refresh_expires_in,
+                "session_id": session_id,
+                "user": musers.build_user_projection(services.db_path, user_id, username),
+            }
+        )
+
+    @bp.post("/login")
+    @limiter.limit(cfg.rate_limit_login, key_func=_login_rate_key)
+    def login() -> Any:
+        payload = parse_json_body()
+        username = require_string_field(payload, "username")
+        password = require_string_field(payload, "password")
+        device = parse_device_info(payload)
+
+        user = musers.verify_user_credentials(services.db_path, username, password)
+        if user is None:
+            raise MobileApiError(merr.AUTH_INVALID_CREDENTIALS, _LOGIN_FAILED, 401)
+
+        created = services.session_store.create_session(user["id"], device)
+        return _token_pair_response(
+            created.session_id,
+            created.user_id,
+            str(user["username"]),
+            created.refresh_token,
+            created.refresh_expires_at,
+        )
+
+    @bp.post("/refresh")
+    @limiter.limit(cfg.rate_limit_refresh)
+    def refresh() -> Any:
+        payload = parse_json_body()
+        raw_token = parse_refresh_token_field(payload)
+
+        result = services.session_store.rotate_refresh_token(raw_token)
+        if result.status == msessions.REUSED:
+            raise MobileApiError(
+                merr.AUTH_REFRESH_REUSED,
+                "Refresh token reuse detected; session revoked.",
+                401,
+            )
+        if result.status == msessions.EXPIRED:
+            raise MobileApiError(merr.AUTH_TOKEN_EXPIRED, "Refresh token expired.", 401)
+        if result.status in (msessions.SESSION_REVOKED, msessions.USER_INACTIVE):
+            raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session is no longer valid.", 401)
+        if result.status != msessions.ROTATED:
+            raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid refresh token.", 401)
+
+        assert result.user_id is not None  # narrowed by ROTATED status
+        assert result.session_id is not None
+        assert result.refresh_token is not None
+        try:
+            user_id = validate_user_id(result.user_id)
+        except ValueError as exc:
+            raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid refresh token.", 401) from exc
+        conn = connect(services.db_path)
+        try:
+            user = musers.get_user(conn, user_id)
+        finally:
+            conn.close()
+        if not musers.is_user_active(user):
+            raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session is no longer valid.", 401)
+        assert user is not None  # narrowed by is_user_active
+        return _token_pair_response(
+            result.session_id,
+            user_id,
+            str(user["username"]),
+            result.refresh_token,
+            result.refresh_expires_at,
+        )
+
+    @bp.post("/logout")
+    @require_mobile_auth
+    def logout() -> Any:
+        principal = g.mobile_principal
+        services.session_store.revoke_session(principal.session_id, "logout")
+        return jsonify({"ok": True})
+
+    @bp.post("/logout-all")
+    @require_mobile_auth
+    def logout_all() -> Any:
+        principal = g.mobile_principal
+        count = services.session_store.revoke_all_sessions_for_user(principal.user_id, "logout_all")
+        return jsonify({"ok": True, "revoked_sessions": count})
+
+    @bp.get("/session")
+    @require_mobile_auth
+    def current_session() -> Any:
+        principal = g.mobile_principal
+        return jsonify(
+            {
+                "session_id": principal.session_id,
+                "user": musers.build_user_projection(
+                    services.db_path, principal.user_id, principal.username
+                ),
+            }
+        )
+
+    return bp
+
+
+__all__ = ["build_auth_blueprint"]

--- a/rex/mobile_api/routes/auth.py
+++ b/rex/mobile_api/routes/auth.py
@@ -38,10 +38,11 @@ _LOGIN_FAILED = "Invalid username or password."
 
 
 def _login_rate_key() -> str:
-    """Rate-limit key for login: anonymized remote address + username hash.
+    """Rate-limit key for login: hashed remote address + hashed username.
 
     Combining both reduces per-account brute force without revealing account
-    existence; the raw username never appears in limiter storage.
+    existence. Neither the raw IP address nor the raw username ever appears
+    in limiter storage or logs — both components are one-way hash digests.
     """
     from flask import request  # noqa: PLC0415
     from flask_limiter.util import get_remote_address  # noqa: PLC0415
@@ -52,8 +53,10 @@ def _login_rate_key() -> str:
         raw = payload.get("username")
         if isinstance(raw, str):
             username = raw.strip().lower()
-    digest = hashlib.sha256(username.encode("utf-8")).hexdigest()[:16]
-    return f"{get_remote_address()}|{digest}"
+    username_digest = hashlib.sha256(username.encode("utf-8")).hexdigest()[:16]
+    address = get_remote_address() or "unknown"
+    address_digest = hashlib.sha256(address.encode("utf-8")).hexdigest()[:16]
+    return f"{address_digest}|{username_digest}"
 
 
 def build_auth_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint:
@@ -155,8 +158,10 @@ def build_auth_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint
         )
 
     @bp.post("/logout")
-    @require_mobile_auth
+    @require_mobile_auth(allow_revoked_session=True)
     def logout() -> Any:
+        # Idempotent: a repeated logout with the same (fully validated) token
+        # finds the session already revoked and returns the same success.
         principal = g.mobile_principal
         services.session_store.revoke_session(principal.session_id, "logout")
         return jsonify({"ok": True})

--- a/rex/mobile_api/routes/scaffolds.py
+++ b/rex/mobile_api/routes/scaffolds.py
@@ -1,0 +1,64 @@
+"""Explicit authenticated 501 scaffolds for not-yet-implemented surfaces.
+
+Until their real ownership, permission, and persistence contracts are
+implemented (Session 2 and later), these routes return HTTP 501 with
+``NOT_IMPLEMENTED`` and their capability remains false.  A scaffold never
+returns fake data or fake success.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NoReturn
+
+from flask import Blueprint
+
+from rex.mobile_api import errors as merr
+from rex.mobile_api.auth import require_mobile_auth
+from rex.mobile_api.errors import MobileApiError
+from rex.mobile_api.services import MobileApiServices
+
+# (rule name, methods, path) — paths from the master spec §6.3–§6.5.
+_SCAFFOLD_ROUTES: tuple[tuple[str, tuple[str, ...], str], ...] = (
+    ("chat", ("POST",), "/mobile/chat"),
+    ("chat_stream", ("POST",), "/mobile/chat/stream"),
+    ("voice_upload", ("POST",), "/mobile/voice/upload"),
+    ("tts_playback", ("POST",), "/mobile/tts/playback"),
+    ("home_entities", ("GET",), "/mobile/home/entities"),
+    ("home_command", ("POST",), "/mobile/home/command"),
+    ("notifications", ("GET",), "/mobile/notifications"),
+    ("approvals", ("GET",), "/mobile/approvals"),
+    ("tasks", ("GET",), "/mobile/tasks"),
+    ("workflows", ("GET",), "/mobile/workflows"),
+    ("audit_log", ("GET",), "/mobile/audit-log"),
+    ("settings", ("GET",), "/mobile/settings"),
+)
+
+
+def build_scaffolds_blueprint(services: MobileApiServices) -> Blueprint:
+    """Build the blueprint registering every explicit 501 scaffold route."""
+    bp = Blueprint("mobile_scaffolds", __name__)
+
+    def _make_view(endpoint_name: str) -> Any:
+        @require_mobile_auth
+        def scaffold_view(**_kwargs: Any) -> NoReturn:
+            raise MobileApiError(
+                merr.NOT_IMPLEMENTED,
+                "This endpoint is not implemented yet.",
+                501,
+            )
+
+        scaffold_view.__name__ = f"scaffold_{endpoint_name}"
+        return scaffold_view
+
+    for name, methods, path in _SCAFFOLD_ROUTES:
+        bp.add_url_rule(
+            path,
+            endpoint=f"scaffold_{name}",
+            view_func=_make_view(name),
+            methods=list(methods),
+        )
+
+    return bp
+
+
+__all__ = ["build_scaffolds_blueprint"]

--- a/rex/mobile_api/routes/status.py
+++ b/rex/mobile_api/routes/status.py
@@ -1,0 +1,39 @@
+"""Public status and capabilities endpoints.
+
+These may be unauthenticated but reveal only non-sensitive compatibility and
+health data — no secrets, paths, account IDs, usernames, or tokens.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Blueprint, g, jsonify
+
+from rex.mobile_api.capabilities import capabilities_payload, server_version
+from rex.mobile_api.services import MobileApiServices
+
+
+def build_status_blueprint(services: MobileApiServices) -> Blueprint:
+    """Build the ``/mobile/status`` and ``/mobile/capabilities`` blueprint."""
+    bp = Blueprint("mobile_status", __name__, url_prefix="/mobile")
+
+    @bp.get("/status")
+    def status() -> Any:
+        return jsonify(
+            {
+                "status": "ok",
+                "api_version": services.config.api_version,
+                "server_version": server_version(),
+                "request_id": getattr(g, "request_id", None),
+            }
+        )
+
+    @bp.get("/capabilities")
+    def capabilities() -> Any:
+        return jsonify(capabilities_payload(services.config))
+
+    return bp
+
+
+__all__ = ["build_status_blueprint"]

--- a/rex/mobile_api/services.py
+++ b/rex/mobile_api/services.py
@@ -49,6 +49,7 @@ class MobileApiServices:
         clock: Callable[[], datetime] | None = None,
         token_generator: Callable[[], str] | None = None,
         id_generator: Callable[[], str] | None = None,
+        audit_logger: object | None = None,
     ) -> MobileApiServices:
         """Build the default production container with optional test overrides."""
         cfg = config or MobileApiConfig()
@@ -60,6 +61,7 @@ class MobileApiServices:
             clock=clock,
             token_generator=token_generator,
             id_generator=id_generator,
+            audit_logger=audit_logger,
         )
         return cls(
             config=cfg,

--- a/rex/mobile_api/services.py
+++ b/rex/mobile_api/services.py
@@ -1,0 +1,73 @@
+"""Process-level service container for the mobile API gateway.
+
+Holds neutral, reusable dependencies only.  User-private state is never
+cached here — every private operation receives a validated user ID
+explicitly.  Clock, token, and ID generators are injectable so tests are
+deterministic.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from rex.config import MobileApiConfig
+from rex.mobile_api.auth import load_jwt_secret
+from rex.mobile_api.db import default_users_db_path
+from rex.mobile_api.sessions import MobileSessionStore
+
+
+def _default_id_generator() -> str:
+    return str(uuid.uuid4())
+
+
+@dataclass
+class MobileApiServices:
+    """Neutral dependencies shared by all mobile requests."""
+
+    config: MobileApiConfig
+    db_path: Path
+    jwt_secret: str
+    session_store: MobileSessionStore
+    id_generator: Callable[[], str] = field(default=_default_id_generator)
+
+    @property
+    def clock(self) -> Callable[[], datetime]:
+        """Return the store's injected clock (single time source)."""
+        return self.session_store.now
+
+    @classmethod
+    def build(
+        cls,
+        config: MobileApiConfig | None = None,
+        *,
+        db_path: Path | str | None = None,
+        jwt_secret: str | None = None,
+        clock: Callable[[], datetime] | None = None,
+        token_generator: Callable[[], str] | None = None,
+        id_generator: Callable[[], str] | None = None,
+    ) -> MobileApiServices:
+        """Build the default production container with optional test overrides."""
+        cfg = config or MobileApiConfig()
+        resolved_db_path = Path(db_path) if db_path is not None else default_users_db_path()
+        secret = jwt_secret if jwt_secret is not None else load_jwt_secret()
+        store = MobileSessionStore(
+            resolved_db_path,
+            refresh_ttl_seconds=cfg.refresh_token_ttl_days * 86400,
+            clock=clock,
+            token_generator=token_generator,
+            id_generator=id_generator,
+        )
+        return cls(
+            config=cfg,
+            db_path=resolved_db_path,
+            jwt_secret=secret,
+            session_store=store,
+            id_generator=id_generator or _default_id_generator,
+        )
+
+
+__all__ = ["MobileApiServices"]

--- a/rex/mobile_api/sessions.py
+++ b/rex/mobile_api/sessions.py
@@ -105,12 +105,56 @@ class MobileSessionStore:
         clock: Callable[[], datetime] | None = None,
         token_generator: Callable[[], str] | None = None,
         id_generator: Callable[[], str] | None = None,
+        audit_logger: object | None = None,
     ) -> None:
         self._db_path = Path(db_path)
         self._refresh_ttl_seconds = int(refresh_ttl_seconds)
         self._clock = clock or _default_clock
         self._token_generator = token_generator or _default_token_generator
         self._id_generator = id_generator or _default_id_generator
+        # Anything with a ``log(LogEntry)`` method; defaults to the canonical
+        # rex.audit logger, resolved lazily so importing this module stays
+        # side-effect free. Tests inject a recorder so no files are written.
+        self._audit_logger = audit_logger
+
+    def _resolve_audit_logger(self) -> object:
+        if self._audit_logger is None:
+            from rex.audit import get_audit_logger  # noqa: PLC0415
+
+            self._audit_logger = get_audit_logger()
+        return self._audit_logger
+
+    def _emit_reuse_audit_event(self, *, session_id: str, family_id: str, user_id: str) -> None:
+        """Persist a structured security-audit event for refresh-token reuse.
+
+        The event carries safe identifiers and status only — never raw
+        tokens, token hashes, access tokens, passwords, or request bodies.
+        Audit failures are logged but never break the security response
+        (the revocation has already been committed).
+        """
+        try:
+            from rex.audit import LogEntry  # noqa: PLC0415
+
+            entry = LogEntry(
+                action_id=self._id_generator(),
+                tool="mobile_auth",
+                tool_call_args={
+                    "event_type": "mobile_refresh_token_reuse",
+                    "session_id": session_id,
+                    "family_id": family_id,
+                    "user_id": user_id,
+                    "revocation_result": "family_and_session_revoked",
+                },
+                policy_decision="denied",
+                requested_by=user_id,
+                timestamp=self.now(),
+            )
+            self._resolve_audit_logger().log(entry)  # type: ignore[attr-defined]
+        except Exception:
+            logger.exception(
+                "Failed to write mobile refresh-reuse audit event: session=%s",
+                session_id,
+            )
 
     # ------------------------------------------------------------------
     # Helpers
@@ -356,6 +400,11 @@ class MobileSessionStore:
                     row["family_id"],
                     row["user_id"],
                 )
+                self._emit_reuse_audit_event(
+                    session_id=row["session_id"],
+                    family_id=row["family_id"],
+                    user_id=row["user_id"],
+                )
                 return RotationResult(
                     status=REUSED,
                     session_id=row["session_id"],
@@ -400,9 +449,14 @@ class MobileSessionStore:
                 self._revoke_family_locked(conn, row["family_id"], row["session_id"], now)
                 conn.execute("COMMIT")
                 logger.warning(
-                    "Mobile refresh concurrency loser treated as reuse: " "session=%s family=%s",
+                    "Mobile refresh concurrency loser treated as reuse: session=%s family=%s",
                     row["session_id"],
                     row["family_id"],
+                )
+                self._emit_reuse_audit_event(
+                    session_id=row["session_id"],
+                    family_id=row["family_id"],
+                    user_id=row["user_id"],
                 )
                 return RotationResult(
                     status=REUSED,

--- a/rex/mobile_api/sessions.py
+++ b/rex/mobile_api/sessions.py
@@ -1,0 +1,502 @@
+"""Mobile session and rotating refresh-token lifecycle (issue #323).
+
+Security properties enforced here:
+
+- Refresh tokens are high-entropy opaque values; only SHA-256 hashes are
+  stored, never raw values (the source tokens carry >= 256 bits of entropy,
+  so an unsalted fast hash is sufficient and allows primary-key lookup).
+- Rotation happens inside one ``BEGIN IMMEDIATE`` SQLite transaction, and the
+  consume step is an ``UPDATE ... WHERE consumed_at IS NULL`` so concurrent
+  use of one refresh token yields exactly one success.
+- Reuse of a consumed token revokes the whole token family and its session,
+  and records an audit log event containing safe IDs only.
+- Sessions are per-device; logout revokes one session, logout-all revokes
+  every session belonging to one user and no one else's.
+
+Clock, token, and ID generators are injectable for deterministic tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+import sqlite3
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from rex.identity import validate_user_id
+from rex.mobile_api.db import connect
+
+logger = logging.getLogger(__name__)
+
+# Rotation outcome statuses.
+ROTATED = "rotated"
+INVALID = "invalid"
+EXPIRED = "expired"
+REUSED = "reused"
+SESSION_REVOKED = "session_revoked"
+USER_INACTIVE = "user_inactive"
+
+_MAX_DEVICE_FIELD_LENGTH = 128
+
+
+def hash_refresh_token(raw_token: str) -> str:
+    """Return the hex SHA-256 hash under which a refresh token is stored."""
+    return hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+
+
+def _default_clock() -> datetime:
+    return datetime.now(UTC)
+
+
+def _default_token_generator() -> str:
+    # 48 bytes -> 384 bits of entropy, URL-safe base64 encoded.
+    return secrets.token_urlsafe(48)
+
+
+def _default_id_generator() -> str:
+    return str(uuid.uuid4())
+
+
+@dataclass(frozen=True)
+class DeviceInfo:
+    """Validated, presentation-only device metadata attached to a session."""
+
+    device_id: str
+    name: str = ""
+    platform: str = ""
+    app_version: str = ""
+
+
+@dataclass(frozen=True)
+class CreatedSession:
+    """Result of creating a session: the raw refresh token appears only here."""
+
+    session_id: str
+    user_id: str
+    refresh_token: str
+    refresh_expires_at: datetime
+    family_id: str
+
+
+@dataclass(frozen=True)
+class RotationResult:
+    """Outcome of a refresh-token rotation attempt."""
+
+    status: str
+    session_id: str | None = None
+    user_id: str | None = None
+    refresh_token: str | None = None
+    refresh_expires_at: datetime | None = None
+
+
+class MobileSessionStore:
+    """SQLite-backed store for mobile sessions and refresh-token families."""
+
+    def __init__(
+        self,
+        db_path: Path | str,
+        *,
+        refresh_ttl_seconds: int,
+        clock: Callable[[], datetime] | None = None,
+        token_generator: Callable[[], str] | None = None,
+        id_generator: Callable[[], str] | None = None,
+    ) -> None:
+        self._db_path = Path(db_path)
+        self._refresh_ttl_seconds = int(refresh_ttl_seconds)
+        self._clock = clock or _default_clock
+        self._token_generator = token_generator or _default_token_generator
+        self._id_generator = id_generator or _default_id_generator
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def now(self) -> datetime:
+        """Return the injected current UTC time."""
+        return self._clock()
+
+    def _connect(self) -> sqlite3.Connection:
+        return connect(self._db_path)
+
+    @staticmethod
+    def _parse_ts(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed
+
+    def session_is_active(self, row: sqlite3.Row | None, now: datetime) -> bool:
+        """Return True when a session row exists, is unrevoked, and unexpired."""
+        if row is None:
+            return False
+        if row["revoked_at"] is not None:
+            return False
+        expires_at = self._parse_ts(row["expires_at"])
+        return expires_at is not None and now < expires_at
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def create_session(self, user_id: str, device: DeviceInfo) -> CreatedSession:
+        """Create a per-device session and its first refresh token."""
+        user_id = validate_user_id(user_id)
+        now = self.now()
+        expires_at = now + timedelta(seconds=self._refresh_ttl_seconds)
+        session_id = self._id_generator()
+        family_id = self._id_generator()
+        raw_token = self._token_generator()
+
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO mobile_sessions (
+                    session_id, user_id, device_id, device_name, platform,
+                    app_version, created_at, last_seen_at, expires_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    user_id,
+                    device.device_id[:_MAX_DEVICE_FIELD_LENGTH],
+                    device.name[:_MAX_DEVICE_FIELD_LENGTH],
+                    device.platform[:_MAX_DEVICE_FIELD_LENGTH],
+                    device.app_version[:_MAX_DEVICE_FIELD_LENGTH],
+                    now.isoformat(),
+                    now.isoformat(),
+                    expires_at.isoformat(),
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO mobile_refresh_tokens (
+                    token_hash, family_id, session_id, user_id,
+                    created_at, expires_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    hash_refresh_token(raw_token),
+                    family_id,
+                    session_id,
+                    user_id,
+                    now.isoformat(),
+                    expires_at.isoformat(),
+                ),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+        finally:
+            conn.close()
+
+        logger.info("Mobile session created: session=%s user=%s", session_id, user_id)
+        return CreatedSession(
+            session_id=session_id,
+            user_id=user_id,
+            refresh_token=raw_token,
+            refresh_expires_at=expires_at,
+            family_id=family_id,
+        )
+
+    def get_session(self, session_id: str) -> sqlite3.Row | None:
+        """Return the session row for *session_id*, or None."""
+        conn = self._connect()
+        try:
+            row: sqlite3.Row | None = conn.execute(
+                "SELECT * FROM mobile_sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            return row
+        finally:
+            conn.close()
+
+    def touch_session(self, session_id: str) -> None:
+        """Update the session's last-seen timestamp."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE mobile_sessions SET last_seen_at = ? WHERE session_id = ?",
+                (self.now().isoformat(), session_id),
+            )
+        finally:
+            conn.close()
+
+    def revoke_session(self, session_id: str, reason: str) -> bool:
+        """Revoke one session and all of its refresh tokens (idempotent)."""
+        now_iso = self.now().isoformat()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            cursor = conn.execute(
+                """
+                UPDATE mobile_sessions
+                SET revoked_at = ?, revoke_reason = ?
+                WHERE session_id = ? AND revoked_at IS NULL
+                """,
+                (now_iso, reason, session_id),
+            )
+            conn.execute(
+                """
+                UPDATE mobile_refresh_tokens
+                SET revoked_at = ?
+                WHERE session_id = ? AND revoked_at IS NULL
+                """,
+                (now_iso, session_id),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+        finally:
+            conn.close()
+        revoked = cursor.rowcount > 0
+        if revoked:
+            logger.info("Mobile session revoked: session=%s reason=%s", session_id, reason)
+        return revoked
+
+    def revoke_all_sessions_for_user(self, user_id: str, reason: str) -> int:
+        """Revoke every active session for one validated user only."""
+        user_id = validate_user_id(user_id)
+        now_iso = self.now().isoformat()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            cursor = conn.execute(
+                """
+                UPDATE mobile_sessions
+                SET revoked_at = ?, revoke_reason = ?
+                WHERE user_id = ? AND revoked_at IS NULL
+                """,
+                (now_iso, reason, user_id),
+            )
+            conn.execute(
+                """
+                UPDATE mobile_refresh_tokens
+                SET revoked_at = ?
+                WHERE user_id = ? AND revoked_at IS NULL
+                """,
+                (now_iso, user_id),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+        finally:
+            conn.close()
+        count = cursor.rowcount
+        logger.info(
+            "Mobile logout-all: user=%s revoked_sessions=%d reason=%s",
+            user_id,
+            count,
+            reason,
+        )
+        return count
+
+    # ------------------------------------------------------------------
+    # Refresh rotation
+    # ------------------------------------------------------------------
+
+    def rotate_refresh_token(self, raw_token: str) -> RotationResult:
+        """Atomically rotate a refresh token.
+
+        Exactly one concurrent caller can succeed for a given token: the
+        consume step updates ``consumed_at`` only where it is still NULL.
+        Reuse of a consumed token revokes the family and session.
+        """
+        if not raw_token or not isinstance(raw_token, str):
+            return RotationResult(status=INVALID)
+        token_hash = hash_refresh_token(raw_token)
+
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT * FROM mobile_refresh_tokens WHERE token_hash = ?",
+                (token_hash,),
+            ).fetchone()
+            if row is None:
+                conn.execute("COMMIT")
+                return RotationResult(status=INVALID)
+
+            now = self.now()
+
+            if row["revoked_at"] is not None:
+                conn.execute("COMMIT")
+                return RotationResult(status=INVALID)
+
+            if row["consumed_at"] is not None:
+                self._revoke_family_locked(conn, row["family_id"], row["session_id"], now)
+                conn.execute("COMMIT")
+                logger.warning(
+                    "Mobile refresh token reuse detected: session=%s family=%s "
+                    "user=%s — family and session revoked",
+                    row["session_id"],
+                    row["family_id"],
+                    row["user_id"],
+                )
+                return RotationResult(
+                    status=REUSED,
+                    session_id=row["session_id"],
+                    user_id=row["user_id"],
+                )
+
+            token_expires = self._parse_ts(row["expires_at"])
+            if token_expires is None or now >= token_expires:
+                conn.execute("COMMIT")
+                return RotationResult(status=EXPIRED)
+
+            session = conn.execute(
+                "SELECT * FROM mobile_sessions WHERE session_id = ?",
+                (row["session_id"],),
+            ).fetchone()
+            if not self.session_is_active(session, now):
+                conn.execute("COMMIT")
+                return RotationResult(status=SESSION_REVOKED)
+
+            user = conn.execute("SELECT * FROM users WHERE id = ?", (row["user_id"],)).fetchone()
+            user_disabled = user is None or user["disabled_at"] is not None
+            if user_disabled:
+                self._revoke_family_locked(conn, row["family_id"], row["session_id"], now)
+                conn.execute("COMMIT")
+                logger.info(
+                    "Mobile refresh rejected for inactive user: session=%s",
+                    row["session_id"],
+                )
+                return RotationResult(status=USER_INACTIVE)
+
+            # Consume — this is the concurrency arbitration point.
+            consumed = conn.execute(
+                """
+                UPDATE mobile_refresh_tokens
+                SET consumed_at = ?
+                WHERE token_hash = ? AND consumed_at IS NULL
+                """,
+                (now.isoformat(), token_hash),
+            )
+            if consumed.rowcount != 1:
+                # A concurrent rotation won the race: treat as reuse.
+                self._revoke_family_locked(conn, row["family_id"], row["session_id"], now)
+                conn.execute("COMMIT")
+                logger.warning(
+                    "Mobile refresh concurrency loser treated as reuse: " "session=%s family=%s",
+                    row["session_id"],
+                    row["family_id"],
+                )
+                return RotationResult(
+                    status=REUSED,
+                    session_id=row["session_id"],
+                    user_id=row["user_id"],
+                )
+
+            new_raw = self._token_generator()
+            new_hash = hash_refresh_token(new_raw)
+            new_expires = now + timedelta(seconds=self._refresh_ttl_seconds)
+            conn.execute(
+                """
+                INSERT INTO mobile_refresh_tokens (
+                    token_hash, family_id, session_id, user_id,
+                    created_at, expires_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    new_hash,
+                    row["family_id"],
+                    row["session_id"],
+                    row["user_id"],
+                    now.isoformat(),
+                    new_expires.isoformat(),
+                ),
+            )
+            conn.execute(
+                """
+                UPDATE mobile_refresh_tokens
+                SET replacement_hash = ?
+                WHERE token_hash = ?
+                """,
+                (new_hash, token_hash),
+            )
+            conn.execute(
+                """
+                UPDATE mobile_sessions
+                SET last_seen_at = ?, expires_at = ?
+                WHERE session_id = ?
+                """,
+                (now.isoformat(), new_expires.isoformat(), row["session_id"]),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+        finally:
+            conn.close()
+
+        return RotationResult(
+            status=ROTATED,
+            session_id=row["session_id"],
+            user_id=row["user_id"],
+            refresh_token=new_raw,
+            refresh_expires_at=new_expires,
+        )
+
+    @staticmethod
+    def _revoke_family_locked(
+        conn: sqlite3.Connection, family_id: str, session_id: str, now: datetime
+    ) -> None:
+        """Revoke a token family and its session inside the caller's transaction."""
+        now_iso = now.isoformat()
+        conn.execute(
+            """
+            UPDATE mobile_refresh_tokens
+            SET revoked_at = ?
+            WHERE family_id = ? AND revoked_at IS NULL
+            """,
+            (now_iso, family_id),
+        )
+        conn.execute(
+            """
+            UPDATE mobile_sessions
+            SET revoked_at = ?, revoke_reason = ?
+            WHERE session_id = ? AND revoked_at IS NULL
+            """,
+            (now_iso, "refresh_token_reuse", session_id),
+        )
+
+
+__all__ = [
+    "EXPIRED",
+    "INVALID",
+    "REUSED",
+    "ROTATED",
+    "SESSION_REVOKED",
+    "USER_INACTIVE",
+    "CreatedSession",
+    "DeviceInfo",
+    "MobileSessionStore",
+    "RotationResult",
+    "hash_refresh_token",
+]

--- a/rex/mobile_api/users.py
+++ b/rex/mobile_api/users.py
@@ -1,0 +1,147 @@
+"""Mobile user lookup, credential verification, and display projection.
+
+All reads go against the canonical ``data/users.db`` tables (``users``,
+``user_permissions``).  User IDs are authorization keys: every path validates
+them with :func:`rex.identity.validate_user_id` before any private access.
+
+Passwords, hashes, and tokens are never logged from this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Any
+
+import bcrypt
+
+from rex.identity import get_user_profile, validate_user_id
+from rex.mobile_api.db import connect
+
+logger = logging.getLogger(__name__)
+
+# Presentation-only defaults.  `role` and `color` are display projections;
+# authorization always uses the live permission set.
+DEFAULT_USER_COLOR = "#2D7FF9"
+
+# A real bcrypt hash of an unguessable throwaway value, used to equalise
+# timing between "unknown username" and "wrong password" login failures.
+_DUMMY_BCRYPT_HASH = bcrypt.hashpw(b"askrex-dummy-timing-equalizer", bcrypt.gensalt())
+
+
+def find_user_by_username(conn: sqlite3.Connection, username: str) -> sqlite3.Row | None:
+    """Return the user row for *username*, or None."""
+    row: sqlite3.Row | None = conn.execute(
+        "SELECT * FROM users WHERE username = ?", (username,)
+    ).fetchone()
+    return row
+
+
+def get_user(conn: sqlite3.Connection, user_id: str) -> sqlite3.Row | None:
+    """Return the user row for a validated *user_id*, or None.
+
+    Raises:
+        ValueError: If *user_id* fails canonical validation (fails closed
+            before any database read).
+    """
+    user_id = validate_user_id(user_id)
+    row: sqlite3.Row | None = conn.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    ).fetchone()
+    return row
+
+
+def is_user_active(row: sqlite3.Row | None) -> bool:
+    """Return True when the user row exists and is not disabled."""
+    if row is None:
+        return False
+    try:
+        disabled_at = row["disabled_at"]
+    except (IndexError, KeyError):
+        # Pre-migration row shape: no disabled_at column means active.
+        disabled_at = None
+    return disabled_at is None
+
+
+def verify_user_credentials(db_path: Any, username: str, password: str) -> sqlite3.Row | None:
+    """Verify username/password against the canonical users table.
+
+    Returns the user row only when the password matches AND the user is
+    active AND the stored user ID is canonically valid.  Every failure mode
+    returns None so callers produce one non-enumerating error.
+    """
+    username = (username or "").strip()
+    if not username or not password:
+        return None
+    conn = connect(db_path)
+    try:
+        row = find_user_by_username(conn, username)
+        if row is None:
+            # Equalise timing with the real-password path.
+            bcrypt.checkpw(password.encode(), _DUMMY_BCRYPT_HASH)
+            return None
+        if not bcrypt.checkpw(password.encode(), row["password"].encode()):
+            return None
+        if not is_user_active(row):
+            logger.info("Mobile login rejected for disabled user account")
+            return None
+        try:
+            validate_user_id(row["id"])
+        except ValueError:
+            logger.warning("Mobile login rejected: stored user ID failed validation")
+            return None
+        return row
+    finally:
+        conn.close()
+
+
+def get_user_permissions(db_path: Any, user_id: str) -> list[str]:
+    """Return the live permission names for a validated *user_id*."""
+    user_id = validate_user_id(user_id)
+    conn = connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT permission FROM user_permissions WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return sorted(row["permission"] for row in rows)
+
+
+def role_projection(permissions: list[str] | frozenset[str]) -> str:
+    """Map the live permission set to the presentation-only role string."""
+    return "owner" if "admin" in permissions else "member"
+
+
+def build_user_projection(db_path: Any, user_id: str, username: str) -> dict[str, Any]:
+    """Return the live user display projection for API responses.
+
+    ``role`` and ``color`` are presentation data only; the server never
+    authorizes from them.
+    """
+    user_id = validate_user_id(user_id)
+    permissions = get_user_permissions(db_path, user_id)
+    display_name = username
+    profile = get_user_profile(user_id)
+    if profile and isinstance(profile.get("name"), str) and profile["name"].strip():
+        display_name = profile["name"].strip()
+    return {
+        "id": user_id,
+        "name": display_name,
+        "role": role_projection(permissions),
+        "permissions": permissions,
+        "color": DEFAULT_USER_COLOR,
+    }
+
+
+__all__ = [
+    "DEFAULT_USER_COLOR",
+    "build_user_projection",
+    "find_user_by_username",
+    "get_user",
+    "get_user_permissions",
+    "is_user_active",
+    "role_projection",
+    "verify_user_credentials",
+]

--- a/rex/mobile_api/validation.py
+++ b/rex/mobile_api/validation.py
@@ -1,0 +1,115 @@
+"""Strict request payload validation helpers for mobile routes.
+
+All external payloads are untrusted.  JSON is parsed strictly enough to
+distinguish malformed JSON (400) from a wrong content type (415) and from an
+empty object.  Client-supplied identity/authorization fields are never
+accepted anywhere.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+
+from rex.mobile_api import errors as merr
+from rex.mobile_api.errors import MobileApiError
+from rex.mobile_api.sessions import DeviceInfo
+
+_DEVICE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_MAX_DEVICE_TEXT_LENGTH = 128
+_MAX_TOKEN_LENGTH = 512
+_MAX_CREDENTIAL_LENGTH = 512
+
+
+def parse_json_body() -> dict[str, Any]:
+    """Return the request's JSON object, failing closed on bad input.
+
+    Raises:
+        MobileApiError: 415 ``INVALID_MEDIA`` for a non-JSON content type,
+            400 ``BAD_REQUEST`` for malformed JSON or a non-object payload.
+    """
+    from flask import request  # noqa: PLC0415
+
+    if request.mimetype != "application/json":
+        raise MobileApiError(
+            merr.INVALID_MEDIA,
+            "Content-Type must be application/json.",
+            415,
+        )
+    try:
+        payload = request.get_json(force=False, silent=False)
+    except Exception as exc:
+        raise MobileApiError(merr.BAD_REQUEST, "Request body is not valid JSON.", 400) from exc
+    if not isinstance(payload, dict):
+        raise MobileApiError(merr.BAD_REQUEST, "Request body must be a JSON object.", 400)
+    return payload
+
+
+def require_string_field(
+    payload: dict[str, Any],
+    name: str,
+    *,
+    max_length: int = _MAX_CREDENTIAL_LENGTH,
+) -> str:
+    """Return a required non-empty string field, or raise 400."""
+    value = payload.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise MobileApiError(merr.BAD_REQUEST, f"Field '{name}' is required.", 400)
+    if len(value) > max_length:
+        raise MobileApiError(merr.BAD_REQUEST, f"Field '{name}' is too long.", 400)
+    return value
+
+
+def parse_refresh_token_field(payload: dict[str, Any]) -> str:
+    """Return the ``refresh_token`` field without echoing its value anywhere."""
+    value = payload.get("refresh_token")
+    if not isinstance(value, str) or not value.strip() or len(value) > _MAX_TOKEN_LENGTH:
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'refresh_token' is required.", 400)
+    return value.strip()
+
+
+def parse_device_info(payload: dict[str, Any]) -> DeviceInfo:
+    """Validate optional login device metadata.
+
+    ``device_id`` is an app-generated stable random identifier — validated
+    for length/format but never trusted as identity.  A missing device object
+    gets a server-generated random device ID.
+
+    Raises:
+        MobileApiError: 400 when the device object or device_id is invalid.
+    """
+    device = payload.get("device")
+    if device is None:
+        return DeviceInfo(device_id=str(uuid.uuid4()))
+    if not isinstance(device, dict):
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'device' must be an object.", 400)
+
+    device_id = device.get("device_id")
+    if device_id is None:
+        device_id = str(uuid.uuid4())
+    elif not isinstance(device_id, str) or not _DEVICE_ID_PATTERN.fullmatch(device_id):
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'device.device_id' is invalid.", 400)
+
+    def _text(name: str) -> str:
+        value = device.get(name, "")
+        if value is None:
+            return ""
+        if not isinstance(value, str):
+            raise MobileApiError(merr.BAD_REQUEST, f"Field 'device.{name}' must be a string.", 400)
+        return value.strip()[:_MAX_DEVICE_TEXT_LENGTH]
+
+    return DeviceInfo(
+        device_id=device_id,
+        name=_text("name"),
+        platform=_text("platform"),
+        app_version=_text("app_version"),
+    )
+
+
+__all__ = [
+    "parse_device_info",
+    "parse_json_body",
+    "parse_refresh_token_field",
+    "require_string_field",
+]

--- a/tests/mobile_api/__init__.py
+++ b/tests/mobile_api/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the mobile API gateway (issue #323)."""

--- a/tests/mobile_api/conftest.py
+++ b/tests/mobile_api/conftest.py
@@ -68,14 +68,36 @@ def mobile_config():
     return MobileApiConfig()
 
 
+class RecordingAuditLogger:
+    """In-memory stand-in for rex.audit.AuditLogger — writes no files."""
+
+    def __init__(self) -> None:
+        self.entries: list = []
+
+    def log(self, entry) -> None:
+        self.entries.append(entry)
+
+
 @pytest.fixture()
-def services(mobile_env: Path, clock: FakeClock, mobile_config):
+def audit_recorder() -> RecordingAuditLogger:
+    return RecordingAuditLogger()
+
+
+@pytest.fixture()
+def services(
+    mobile_env: Path,
+    clock: FakeClock,
+    mobile_config,
+    audit_recorder: RecordingAuditLogger,
+):
     from rex.mobile_api.db import migrate_users_db
     from rex.mobile_api.services import MobileApiServices
 
     db_path = mobile_env / "users.db"
     migrate_users_db(db_path)
-    return MobileApiServices.build(mobile_config, db_path=db_path, clock=clock)
+    return MobileApiServices.build(
+        mobile_config, db_path=db_path, clock=clock, audit_logger=audit_recorder
+    )
 
 
 @pytest.fixture()

--- a/tests/mobile_api/conftest.py
+++ b/tests/mobile_api/conftest.py
@@ -1,0 +1,137 @@
+"""Shared fixtures for mobile API gateway tests.
+
+All tests use temporary data directories, an injected controllable clock,
+and deterministic ID generation.  No test touches the real ``data/`` or
+``Memory/`` directories or leaves repository changes behind.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+TEST_JWT_SECRET = "unit-test-jwt-secret-0123456789abcdef0123456789abcdef"
+
+
+class FakeClock:
+    """Controllable UTC clock.
+
+    Starts at the real current time so PyJWT's real-time ``exp``/``nbf``
+    validation agrees with tokens issued through the injected clock, then
+    advances only when a test says so.
+    """
+
+    def __init__(self, start: datetime | None = None) -> None:
+        self.current = start or datetime.now(UTC)
+
+    def __call__(self) -> datetime:
+        return self.current
+
+    def advance(self, seconds: float = 0, days: float = 0) -> None:
+        self.current += timedelta(seconds=seconds, days=days)
+
+
+def sequential_token_generator(prefix: str = "refresh") -> Callable[[], str]:
+    """Deterministic high-length token generator for storage tests."""
+    counter = itertools.count(1)
+
+    def _generate() -> str:
+        return f"{prefix}-token-{next(counter):04d}-" + "x" * 43
+
+    return _generate
+
+
+@pytest.fixture()
+def mobile_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the canonical stores at a temp dir and set a strong JWT secret."""
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("REX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("REX_JWT_SECRET", TEST_JWT_SECRET)
+    return data_dir
+
+
+@pytest.fixture()
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture()
+def mobile_config():
+    from rex.config import MobileApiConfig
+
+    return MobileApiConfig()
+
+
+@pytest.fixture()
+def services(mobile_env: Path, clock: FakeClock, mobile_config):
+    from rex.mobile_api.db import migrate_users_db
+    from rex.mobile_api.services import MobileApiServices
+
+    db_path = mobile_env / "users.db"
+    migrate_users_db(db_path)
+    return MobileApiServices.build(mobile_config, db_path=db_path, clock=clock)
+
+
+@pytest.fixture()
+def app(services):
+    from rex.mobile_api.app import create_mobile_app
+
+    application = create_mobile_app(services=services)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app):
+    with app.test_client() as test_client:
+        yield test_client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def create_user(username: str, password: str, *, admin: bool = False) -> str:
+    """Create a canonical user (env-scoped tmp db) and return its ID."""
+    from rex.auth import create_user as _create
+    from rex.permissions import grant_permission
+
+    user = _create(username, password)
+    if admin:
+        grant_permission(user["id"], "admin")
+    return str(user["id"])
+
+
+def disable_user(db_path: Path, user_id: str) -> None:
+    from rex.mobile_api.db import connect
+
+    conn = connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE users SET disabled_at = ? WHERE id = ?",
+            (datetime.now(UTC).isoformat(), user_id),
+        )
+    finally:
+        conn.close()
+
+
+def login(client, username: str, password: str, device: dict | None = None):
+    payload: dict = {"username": username, "password": password}
+    if device is not None:
+        payload["device"] = device
+    return client.post("/mobile/auth/login", json=payload)
+
+
+def auth_header(access_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def login_tokens(client, username: str, password: str) -> dict:
+    response = login(client, username, password)
+    assert response.status_code == 200, response.get_json()
+    return response.get_json()

--- a/tests/mobile_api/conftest.py
+++ b/tests/mobile_api/conftest.py
@@ -14,7 +14,9 @@ from pathlib import Path
 
 import pytest
 
-TEST_JWT_SECRET = "unit-test-jwt-secret-0123456789abcdef0123456789abcdef"
+TEST_JWT_SECRET = (
+    "unit-test-jwt-secret-0123456789abcdef0123456789abcdef"  # pragma: allowlist secret
+)
 
 
 class FakeClock:

--- a/tests/mobile_api/test_app.py
+++ b/tests/mobile_api/test_app.py
@@ -1,0 +1,180 @@
+"""Application factory and middleware foundation tests.
+
+Matrix rows: FND-001, FND-002, FND-009..FND-015, plus default rate limiting.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.mobile_api.conftest import create_user
+
+
+class TestImportSideEffects:
+    def test_import_does_not_touch_database(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FND-001: importing the package must not create or mutate the DB."""
+        import importlib
+
+        data_dir = tmp_path / "data"
+        monkeypatch.setenv("REX_DATA_DIR", str(data_dir))
+
+        import rex.mobile_api
+        import rex.mobile_api.app
+
+        importlib.reload(rex.mobile_api)
+        assert not data_dir.exists()
+
+
+class TestAppFactory:
+    def test_two_apps_are_independent(self, services) -> None:
+        """FND-002: the factory returns independent app instances."""
+        from rex.mobile_api.app import create_mobile_app
+
+        app_one = create_mobile_app(services=services)
+        app_two = create_mobile_app(services=services)
+        assert app_one is not app_two
+        assert (
+            app_one.extensions["mobile_api_limiter"] is not app_two.extensions["mobile_api_limiter"]
+        )
+
+    def test_unknown_route_returns_nested_404(self, client) -> None:
+        """FND-009: unknown routes use the canonical envelope with request ID."""
+        response = client.get("/mobile/does-not-exist")
+        assert response.status_code == 404
+        body = response.get_json()
+        assert body["error"]["code"] == "NOT_FOUND"
+        assert body["error"]["retryable"] is False
+        assert body["error"]["request_id"]
+
+    def test_unexpected_exception_returns_generic_500(self, app) -> None:
+        """FND-010: unexpected exceptions leak no stack, path, or secret."""
+        state = {"secret_path": "C:/very/secret/model/path"}
+
+        @app.route("/mobile/_boom")
+        def _boom():  # pragma: no cover - exercised via test client
+            raise RuntimeError(f"exploded near {state['secret_path']}")
+
+        app.config["TESTING"] = False
+        app.config["PROPAGATE_EXCEPTIONS"] = False
+        with app.test_client() as client:
+            response = client.get("/mobile/_boom")
+        assert response.status_code == 500
+        body = response.get_json()
+        assert body["error"]["code"] == "INTERNAL_ERROR"
+        assert "secret" not in body["error"]["message"]
+        assert state["secret_path"] not in response.get_data(as_text=True)
+
+    def test_request_id_header_matches_error_field(self, client) -> None:
+        """FND-011: the header and error field carry the same request ID."""
+        response = client.get("/mobile/does-not-exist")
+        assert response.headers["X-Request-ID"] == response.get_json()["error"]["request_id"]
+
+    def test_api_version_header_on_every_response(self, client) -> None:
+        """FND-012: X-AskRex-API-Version is present on success and error."""
+        ok = client.get("/mobile/status")
+        missing = client.get("/mobile/does-not-exist")
+        assert ok.headers["X-AskRex-API-Version"] == "1.0"
+        assert missing.headers["X-AskRex-API-Version"] == "1.0"
+
+    def test_unsupported_content_type_rejected(self, client) -> None:
+        """FND-013: non-JSON content type is rejected before business logic."""
+        response = client.post(
+            "/mobile/auth/login",
+            data="username=james&password=x",
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert response.status_code == 415
+        assert response.get_json()["error"]["code"] == "INVALID_MEDIA"
+
+    def test_oversized_json_body_rejected(self, mobile_env: Path, clock) -> None:
+        """FND-014: bodies over max_json_bytes get 413 before processing."""
+        from rex.config import MobileApiConfig
+        from rex.mobile_api.app import create_mobile_app
+        from rex.mobile_api.db import migrate_users_db
+        from rex.mobile_api.services import MobileApiServices
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+        config = MobileApiConfig(max_json_bytes=256)
+        services = MobileApiServices.build(config, db_path=db_path, clock=clock)
+        app = create_mobile_app(services=services)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            response = client.post(
+                "/mobile/auth/login",
+                json={"username": "a", "password": "b" * 1024},
+            )
+        assert response.status_code == 413
+        assert response.get_json()["error"]["code"] == "PAYLOAD_TOO_LARGE"
+
+    def test_cors_denied_by_default(self, client) -> None:
+        """FND-015: no Access-Control-Allow-Origin unless explicitly configured."""
+        response = client.get("/mobile/status", headers={"Origin": "https://evil.example"})
+        assert "Access-Control-Allow-Origin" not in response.headers
+
+    def test_cors_allows_only_configured_origin(self, mobile_env: Path, clock) -> None:
+        from rex.config import MobileApiConfig
+        from rex.mobile_api.app import create_mobile_app
+        from rex.mobile_api.db import migrate_users_db
+        from rex.mobile_api.services import MobileApiServices
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+        config = MobileApiConfig(allowed_origins=["https://app.askrex.local"])
+        services = MobileApiServices.build(config, db_path=db_path, clock=clock)
+        app = create_mobile_app(services=services)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            allowed = client.get("/mobile/status", headers={"Origin": "https://app.askrex.local"})
+            denied = client.get("/mobile/status", headers={"Origin": "https://evil.example"})
+        assert allowed.headers.get("Access-Control-Allow-Origin") == "https://app.askrex.local"
+        assert "Access-Control-Allow-Origin" not in denied.headers
+
+
+class TestDefaultRateLimit:
+    def test_default_limit_returns_canonical_429(self, mobile_env: Path, clock) -> None:
+        from rex.config import MobileApiConfig
+        from rex.mobile_api.app import create_mobile_app
+        from rex.mobile_api.db import migrate_users_db
+        from rex.mobile_api.services import MobileApiServices
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+        config = MobileApiConfig(rate_limit_default="2 per minute")
+        services = MobileApiServices.build(config, db_path=db_path, clock=clock)
+        app = create_mobile_app(services=services)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            assert client.get("/mobile/status").status_code == 200
+            assert client.get("/mobile/status").status_code == 200
+            limited = client.get("/mobile/status")
+        assert limited.status_code == 429
+        body = limited.get_json()
+        assert body["error"]["code"] == "RATE_LIMITED"
+        assert body["error"]["retryable"] is True
+        assert int(limited.headers["Retry-After"]) >= 1
+
+
+class TestClientIdentityFieldsIgnored:
+    def test_login_ignores_client_role_and_permissions(self, client) -> None:
+        """AUTH-021: client-supplied role/permissions never become authority."""
+        create_user("james", "pw-123456", admin=False)
+        response = client.post(
+            "/mobile/auth/login",
+            json={
+                "username": "james",
+                "password": "pw-123456",
+                "role": "owner",
+                "permissions": ["admin"],
+                "risk_level": "none",
+                "approved": True,
+            },
+        )
+        assert response.status_code == 200
+        user = response.get_json()["user"]
+        assert user["role"] == "member"
+        assert user["permissions"] == []

--- a/tests/mobile_api/test_app.py
+++ b/tests/mobile_api/test_app.py
@@ -52,7 +52,7 @@ class TestAppFactory:
 
     def test_unexpected_exception_returns_generic_500(self, app) -> None:
         """FND-010: unexpected exceptions leak no stack, path, or secret."""
-        state = {"secret_path": "C:/very/secret/model/path"}
+        state = {"secret_path": "C:/very/secret/model/path"}  # pragma: allowlist secret
 
         @app.route("/mobile/_boom")
         def _boom():  # pragma: no cover - exercised via test client
@@ -167,7 +167,7 @@ class TestClientIdentityFieldsIgnored:
             "/mobile/auth/login",
             json={
                 "username": "james",
-                "password": "pw-123456",
+                "password": "pw-123456",  # pragma: allowlist secret
                 "role": "owner",
                 "permissions": ["admin"],
                 "risk_level": "none",

--- a/tests/mobile_api/test_cli.py
+++ b/tests/mobile_api/test_cli.py
@@ -88,14 +88,16 @@ class TestMobileApiCommand:
         return captured
 
     def test_flags_override_config(self, monkeypatch, capsys) -> None:
+        # "0.0.0.0" here only exercises CLI flag precedence against a fake
+        # app object — nothing binds a socket in this test.
         captured = self._run(
             monkeypatch,
-            cli_host="0.0.0.0",
+            cli_host="0.0.0.0",  # nosec B104
             cli_port=9000,
             config_host="127.0.0.1",
             config_port=8765,
         )
-        assert captured["host"] == "0.0.0.0"
+        assert captured["host"] == "0.0.0.0"  # nosec B104
         assert captured["port"] == 9000
         output = capsys.readouterr().out
         assert "WARNING" in output  # LAN bind without TLS warns

--- a/tests/mobile_api/test_cli.py
+++ b/tests/mobile_api/test_cli.py
@@ -1,0 +1,213 @@
+"""CLI tests for ``rex mobile-api`` and ``rex mobile-user create``.
+
+Matrix rows: FND-008, USR-007..USR-010.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.mobile_api.conftest import TEST_JWT_SECRET
+
+
+@pytest.fixture()
+def cli_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("REX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("REX_JWT_SECRET", TEST_JWT_SECRET)
+    return data_dir
+
+
+@pytest.fixture()
+def profile_sandbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list:
+    """Redirect profile creation into a temp dir; record calls."""
+    import rex.identity as rex_identity
+
+    calls: list = []
+    original = rex_identity.create_user_profile
+
+    def _sandboxed(user_id: str, name: str, **kwargs):
+        calls.append({"user_id": user_id, "name": name})
+        return original(user_id, name, memory_dir=tmp_path / "Memory", **kwargs)
+
+    monkeypatch.setattr(rex_identity, "create_user_profile", _sandboxed)
+    return calls
+
+
+def _user_rows(data_dir: Path) -> list:
+    db = data_dir / "users.db"
+    if not db.exists():
+        return []
+    conn = sqlite3.connect(str(db))
+    try:
+        return conn.execute("SELECT username FROM users").fetchall()
+    finally:
+        conn.close()
+
+
+class TestMobileApiCommand:
+    def _run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        cli_host: str | None,
+        cli_port: int | None,
+        config_host: str = "127.0.0.1",
+        config_port: int = 8765,
+    ) -> dict:
+        """Run cmd_mobile_api with fakes; return the captured bind info."""
+        import rex.config as rex_config
+        import rex.mobile_api.app as mobile_app
+        from rex.commands.mobile import cmd_mobile_api
+        from rex.config import MobileApiConfig
+
+        captured: dict = {}
+
+        class _FakeApp:
+            def run(self, host: str, port: int) -> None:
+                captured["host"] = host
+                captured["port"] = port
+
+        def _fake_create(config=None, services=None):
+            captured["config"] = config
+            return _FakeApp()
+
+        fake_settings = SimpleNamespace(
+            mobile_api=MobileApiConfig(host=config_host, port=config_port)
+        )
+        monkeypatch.setattr(rex_config, "load_config", lambda: fake_settings)
+        monkeypatch.setattr(mobile_app, "create_mobile_app", _fake_create)
+
+        args = argparse.Namespace(host=cli_host, port=cli_port)
+        assert cmd_mobile_api(args) == 0
+        return captured
+
+    def test_flags_override_config(self, monkeypatch, capsys) -> None:
+        captured = self._run(
+            monkeypatch,
+            cli_host="0.0.0.0",
+            cli_port=9000,
+            config_host="127.0.0.1",
+            config_port=8765,
+        )
+        assert captured["host"] == "0.0.0.0"
+        assert captured["port"] == 9000
+        output = capsys.readouterr().out
+        assert "WARNING" in output  # LAN bind without TLS warns
+        assert "0.0.0.0:9000" in output
+
+    def test_config_used_when_no_flags(self, monkeypatch, capsys) -> None:
+        captured = self._run(
+            monkeypatch,
+            cli_host=None,
+            cli_port=None,
+            config_host="127.0.0.1",
+            config_port=9100,
+        )
+        assert captured["host"] == "127.0.0.1"
+        assert captured["port"] == 9100
+        output = capsys.readouterr().out
+        assert "WARNING" not in output  # loopback bind does not warn
+        assert "/mobile/status" in output
+
+    def test_invalid_port_fails_before_serving(self, monkeypatch, capsys) -> None:
+        import rex.config as rex_config
+        from rex.commands.mobile import cmd_mobile_api
+        from rex.config import MobileApiConfig
+
+        fake_settings = SimpleNamespace(mobile_api=MobileApiConfig())
+        monkeypatch.setattr(rex_config, "load_config", lambda: fake_settings)
+        args = argparse.Namespace(host=None, port=99999)
+        assert cmd_mobile_api(args) == 1
+
+    def test_banner_never_prints_secret(self, monkeypatch, capsys) -> None:
+        self._run(monkeypatch, cli_host=None, cli_port=None)
+        assert TEST_JWT_SECRET not in capsys.readouterr().out
+
+
+class TestMobileUserCreate:
+    def _run_create(self, monkeypatch: pytest.MonkeyPatch, username: str, prompts: list) -> int:
+        import getpass
+
+        from rex.commands.mobile import cmd_mobile_user
+
+        prompt_iter = iter(prompts)
+
+        def _fake_getpass(prompt: str = "") -> str:
+            value = next(prompt_iter)
+            if isinstance(value, BaseException):
+                raise value
+            return value
+
+        monkeypatch.setattr(getpass, "getpass", _fake_getpass)
+        args = argparse.Namespace(mobile_user_command="create", username=username)
+        return cmd_mobile_user(args)
+
+    def test_creates_user_profile_and_first_admin(
+        self, cli_env: Path, profile_sandbox: list, monkeypatch, capsys
+    ) -> None:
+        """USR-007: user, profile, and first-user admin created canonically."""
+        from rex.permissions import get_permissions
+
+        result = self._run_create(monkeypatch, "james", ["pw-123456", "pw-123456"])
+        assert result == 0
+        rows = _user_rows(cli_env)
+        assert [row[0] for row in rows] == ["james"]
+        assert len(profile_sandbox) == 1
+        user_id = profile_sandbox[0]["user_id"]
+        assert "admin" in get_permissions(user_id)
+        output = capsys.readouterr().out
+        assert "pw-123456" not in output  # USR-009: never echoed
+
+    def test_second_user_is_not_admin(
+        self, cli_env: Path, profile_sandbox: list, monkeypatch
+    ) -> None:
+        from rex.permissions import get_permissions
+
+        assert self._run_create(monkeypatch, "james", ["pw-1", "pw-1"]) == 0
+        assert self._run_create(monkeypatch, "sarah", ["pw-2", "pw-2"]) == 0
+        assert "admin" not in get_permissions(profile_sandbox[1]["user_id"])
+
+    def test_duplicate_username_fails_without_partial_state(
+        self, cli_env: Path, profile_sandbox: list, monkeypatch
+    ) -> None:
+        """USR-008: safe nonzero failure; no extra profile or permissions."""
+        assert self._run_create(monkeypatch, "james", ["pw-1", "pw-1"]) == 0
+        assert self._run_create(monkeypatch, "james", ["pw-2", "pw-2"]) == 1
+        assert len(_user_rows(cli_env)) == 1
+        assert len(profile_sandbox) == 1
+
+    def test_password_mismatch_creates_nothing(
+        self, cli_env: Path, profile_sandbox: list, monkeypatch
+    ) -> None:
+        assert self._run_create(monkeypatch, "james", ["pw-1", "different"]) == 1
+        assert _user_rows(cli_env) == []
+        assert profile_sandbox == []
+
+    def test_interrupted_prompt_creates_nothing(
+        self, cli_env: Path, profile_sandbox: list, monkeypatch
+    ) -> None:
+        """USR-010: an interrupted prompt leaves no partial user record."""
+        result = self._run_create(monkeypatch, "james", [KeyboardInterrupt()])
+        assert result == 1
+        assert _user_rows(cli_env) == []
+        assert profile_sandbox == []
+
+    def test_empty_password_rejected(
+        self, cli_env: Path, profile_sandbox: list, monkeypatch
+    ) -> None:
+        assert self._run_create(monkeypatch, "james", ["", ""]) == 1
+        assert _user_rows(cli_env) == []
+
+    def test_cli_has_no_password_argument(self) -> None:
+        """USR-009: the parser never accepts a password through argv."""
+        from rex.cli import create_parser
+
+        parser = create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["mobile-user", "create", "--username", "a", "--password", "b"])

--- a/tests/mobile_api/test_config.py
+++ b/tests/mobile_api/test_config.py
@@ -1,0 +1,133 @@
+"""Configuration and secret validation tests.
+
+Matrix rows: FND-003, FND-005, FND-006, FND-007.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestMobileApiConfigDefaults:
+    def test_safe_defaults(self) -> None:
+        from rex.config import MobileApiConfig
+
+        config = MobileApiConfig()
+        assert config.enabled is False
+        assert config.host == "127.0.0.1"
+        assert config.port == 8765
+        assert config.allowed_origins == []
+        assert config.require_tls is False
+        assert config.api_version == "1.0"
+        assert config.access_token_ttl_seconds == 900
+        assert config.refresh_token_ttl_days == 30
+        assert config.max_json_bytes == 1_048_576
+
+    def test_parsed_from_json_group(self) -> None:
+        from rex.config import _parse_mobile_api_config
+
+        config = _parse_mobile_api_config(
+            {"port": 9000, "access_token_ttl_seconds": 300, "unknown_key": 1}
+        )
+        assert config.port == 9000
+        assert config.access_token_ttl_seconds == 300
+
+    def test_none_group_yields_defaults(self) -> None:
+        from rex.config import _parse_mobile_api_config
+
+        assert _parse_mobile_api_config(None).port == 8765
+
+
+class TestMobileApiConfigValidation:
+    @pytest.mark.parametrize("port", [0, -1, 65536])
+    def test_invalid_port_rejected(self, port: int) -> None:
+        from rex.config import MobileApiConfig
+
+        with pytest.raises(ValueError):
+            MobileApiConfig(port=port)
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "access_token_ttl_seconds",
+            "refresh_token_ttl_days",
+            "max_json_bytes",
+            "max_audio_bytes",
+            "max_audio_seconds",
+        ],
+    )
+    def test_non_positive_limits_rejected(self, field: str) -> None:
+        from rex.config import MobileApiConfig
+
+        with pytest.raises(ValueError):
+            MobileApiConfig(**{field: 0})
+
+    @pytest.mark.parametrize("value", ["", "lots", "per minute", "10 per parsec"])
+    def test_invalid_rate_limit_rejected(self, value: str) -> None:
+        from rex.config import MobileApiConfig
+
+        with pytest.raises(ValueError):
+            MobileApiConfig(rate_limit_default=value)
+
+    def test_valid_rate_limits_accepted(self) -> None:
+        from rex.config import MobileApiConfig
+
+        config = MobileApiConfig(rate_limit_default="120 per hour", rate_limit_login="5/minute")
+        assert config.rate_limit_default == "120 per hour"
+
+    def test_wildcard_origin_rejected(self) -> None:
+        from rex.config import MobileApiConfig
+
+        with pytest.raises(ValueError, match="deny-by-default"):
+            MobileApiConfig(allowed_origins=["*"])
+
+    def test_empty_host_rejected(self) -> None:
+        from rex.config import MobileApiConfig
+
+        with pytest.raises(ValueError):
+            MobileApiConfig(host="  ")
+
+    def test_invalid_group_raises_configuration_error(self) -> None:
+        from rex.assistant_errors import ConfigurationError
+        from rex.config import _parse_mobile_api_config
+
+        with pytest.raises(ConfigurationError):
+            _parse_mobile_api_config({"port": 999999})
+        with pytest.raises(ConfigurationError):
+            _parse_mobile_api_config("not-a-dict")
+
+
+class TestJwtSecret:
+    def test_missing_secret_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rex.mobile_api.auth import MobileAuthConfigurationError, load_jwt_secret
+
+        monkeypatch.delenv("REX_JWT_SECRET", raising=False)
+        with pytest.raises(MobileAuthConfigurationError, match="REX_JWT_SECRET"):
+            load_jwt_secret()
+
+    def test_weak_secret_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rex.mobile_api.auth import MobileAuthConfigurationError, load_jwt_secret
+
+        monkeypatch.setenv("REX_JWT_SECRET", "short-secret")
+        with pytest.raises(MobileAuthConfigurationError) as excinfo:
+            load_jwt_secret()
+        # The error must not echo the configured secret value.
+        assert "short-secret" not in str(excinfo.value)
+
+    def test_strong_secret_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rex.mobile_api.auth import load_jwt_secret
+
+        secret = "a" * 64
+        monkeypatch.setenv("REX_JWT_SECRET", secret)
+        assert load_jwt_secret() == secret
+
+    def test_app_factory_fails_closed_without_secret(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from rex.mobile_api.app import create_mobile_app
+        from rex.mobile_api.auth import MobileAuthConfigurationError
+
+        monkeypatch.setenv("REX_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.delenv("REX_JWT_SECRET", raising=False)
+        with pytest.raises(MobileAuthConfigurationError):
+            create_mobile_app()

--- a/tests/mobile_api/test_config.py
+++ b/tests/mobile_api/test_config.py
@@ -97,6 +97,78 @@ class TestMobileApiConfigValidation:
             _parse_mobile_api_config("not-a-dict")
 
 
+class TestMobileApiConfigSerialization:
+    """mobile_api is canonical nested config and must survive serialization."""
+
+    def _build_config(self):
+        from rex.config import build_app_config
+
+        return build_app_config(
+            {
+                "mobile_api": {
+                    "host": "192.168.1.50",
+                    "port": 9001,
+                    "access_token_ttl_seconds": 600,
+                    "allowed_origins": ["https://app.askrex.local"],
+                }
+            }
+        )
+
+    def test_to_dict_includes_mobile_api(self) -> None:
+        from rex.config import AppConfig
+
+        raw = AppConfig().to_dict()
+        assert "mobile_api" in raw
+        assert raw["mobile_api"]["host"] == "127.0.0.1"
+        assert raw["mobile_api"]["port"] == 8765
+
+    def test_loaded_values_survive_serialization(self) -> None:
+        raw = self._build_config().to_dict()
+        group = raw["mobile_api"]
+        assert group["host"] == "192.168.1.50"
+        assert group["port"] == 9001
+        assert group["access_token_ttl_seconds"] == 600
+        assert group["allowed_origins"] == ["https://app.askrex.local"]
+
+    def test_serialized_group_is_json_safe_and_secret_free(self) -> None:
+        import json
+
+        raw = self._build_config().to_dict()
+        text = json.dumps(raw["mobile_api"])
+        # The JWT secret lives in .env only and has no config field at all.
+        assert "secret" not in text.lower()
+        assert "REX_JWT" not in text
+        assert set(raw["mobile_api"].keys()) == {
+            "enabled",
+            "host",
+            "port",
+            "allowed_origins",
+            "require_tls",
+            "api_version",
+            "access_token_ttl_seconds",
+            "refresh_token_ttl_days",
+            "max_json_bytes",
+            "max_audio_bytes",
+            "max_audio_seconds",
+            "rate_limit_default",
+            "rate_limit_login",
+            "rate_limit_refresh",
+            "rate_limit_chat",
+            "rate_limit_voice",
+        }
+
+    def test_show_config_output_includes_mobile_api(self, capsys) -> None:
+        """`rex-config show` prints the mobile_api group."""
+        import json
+
+        from rex.config import show_config
+
+        show_config(self._build_config())
+        printed = json.loads(capsys.readouterr().out)
+        assert printed["mobile_api"]["port"] == 9001
+        assert printed["mobile_api"]["host"] == "192.168.1.50"
+
+
 class TestJwtSecret:
     def test_missing_secret_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from rex.mobile_api.auth import MobileAuthConfigurationError, load_jwt_secret

--- a/tests/mobile_api/test_jwt.py
+++ b/tests/mobile_api/test_jwt.py
@@ -1,0 +1,195 @@
+"""Access JWT validation tests using crafted tokens.
+
+Matrix rows: AUTH-008..AUTH-020, SES-002..SES-004, USR-006, USR-012.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt as pyjwt
+
+from tests.mobile_api.conftest import (
+    TEST_JWT_SECRET,
+    auth_header,
+    create_user,
+    disable_user,
+    login_tokens,
+)
+
+_SESSION_URL = "/mobile/auth/session"
+
+
+def _claims(
+    *,
+    sub: str,
+    sid: str,
+    iss: str = "askrex-assistant",
+    aud: str = "askrex-mobile",
+    ttl_seconds: int = 900,
+    nbf_offset: int = 0,
+) -> dict:
+    now = datetime.now(UTC)
+    return {
+        "iss": iss,
+        "aud": aud,
+        "sub": sub,
+        "sid": sid,
+        "jti": "crafted-token-id",
+        "iat": now,
+        "nbf": now + timedelta(seconds=nbf_offset),
+        "exp": now + timedelta(seconds=ttl_seconds),
+    }
+
+
+def _encode(claims: dict, secret: str = TEST_JWT_SECRET, algorithm: str = "HS256") -> str:
+    return pyjwt.encode(claims, secret, algorithm=algorithm)
+
+
+class TestAccessTokenClaims:
+    def test_login_token_contains_required_claims(self, client) -> None:
+        """AUTH-008: iss/aud/sub/sid/jti/iat/nbf/exp are all present."""
+        user_id = create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        claims = pyjwt.decode(
+            tokens["access_token"],
+            TEST_JWT_SECRET,
+            algorithms=["HS256"],
+            audience="askrex-mobile",
+            issuer="askrex-assistant",
+        )
+        for name in ("iss", "aud", "sub", "sid", "jti", "iat", "nbf", "exp"):
+            assert name in claims
+        assert claims["sub"] == user_id
+        assert claims["sid"] == tokens["session_id"]
+        assert claims["exp"] - claims["iat"] == 900
+
+
+class TestTokenRejection:
+    def _login(self, client) -> tuple[str, str]:
+        user_id = create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        return user_id, tokens["session_id"]
+
+    def _assert_401(self, client, token: str, code: str) -> None:
+        response = client.get(_SESSION_URL, headers=auth_header(token))
+        assert response.status_code == 401
+        assert response.get_json()["error"]["code"] == code
+
+    def test_wrong_signature_rejected(self, client) -> None:
+        user_id, sid = self._login(client)
+        token = _encode(_claims(sub=user_id, sid=sid), secret="w" * 64)
+        self._assert_401(client, token, "AUTH_TOKEN_INVALID")
+
+    def test_wrong_algorithm_rejected(self, client) -> None:
+        user_id, sid = self._login(client)
+        token = _encode(_claims(sub=user_id, sid=sid), algorithm="HS512")
+        self._assert_401(client, token, "AUTH_TOKEN_INVALID")
+
+    def test_wrong_issuer_rejected(self, client) -> None:
+        user_id, sid = self._login(client)
+        token = _encode(_claims(sub=user_id, sid=sid, iss="evil-issuer"))
+        self._assert_401(client, token, "AUTH_TOKEN_INVALID")
+
+    def test_wrong_audience_rejected(self, client) -> None:
+        user_id, sid = self._login(client)
+        token = _encode(_claims(sub=user_id, sid=sid, aud="askrex-desktop"))
+        self._assert_401(client, token, "AUTH_TOKEN_INVALID")
+
+    def test_expired_token_rejected(self, client) -> None:
+        user_id, sid = self._login(client)
+        token = _encode(_claims(sub=user_id, sid=sid, ttl_seconds=-120))
+        self._assert_401(client, token, "AUTH_TOKEN_EXPIRED")
+
+    def test_future_nbf_rejected(self, client) -> None:
+        user_id, sid = self._login(client)
+        token = _encode(_claims(sub=user_id, sid=sid, nbf_offset=600))
+        self._assert_401(client, token, "AUTH_TOKEN_INVALID")
+
+    def test_missing_required_claim_rejected(self, client) -> None:
+        user_id, sid = self._login(client)
+        claims = _claims(sub=user_id, sid=sid)
+        del claims["sid"]
+        self._assert_401(client, _encode(claims), "AUTH_TOKEN_INVALID")
+
+    def test_invalid_sub_fails_before_private_access(self, client, monkeypatch) -> None:
+        """AUTH-016 / USR-012: a non-canonical sub never reaches user lookup."""
+        _, sid = self._login(client)
+
+        reached = {"user_lookup": False}
+        from rex.mobile_api import users as musers
+
+        original = musers.get_user
+
+        def _tracking_get_user(conn, user_id):
+            reached["user_lookup"] = True
+            return original(conn, user_id)
+
+        monkeypatch.setattr(musers, "get_user", _tracking_get_user)
+        for bad_sub in ("..", "../../etc", "con", "a/b"):
+            token = _encode(_claims(sub=bad_sub, sid=sid))
+            self._assert_401(client, token, "AUTH_TOKEN_INVALID")
+        assert reached["user_lookup"] is False
+
+    def test_unknown_session_rejected(self, client) -> None:
+        user_id, _ = self._login(client)
+        token = _encode(_claims(sub=user_id, sid="00000000-0000-0000-0000-000000000000"))
+        self._assert_401(client, token, "AUTH_TOKEN_INVALID")
+
+    def test_session_owned_by_other_user_rejected(self, client) -> None:
+        """AUTH-018 / SES-008: cross-user session use is indistinguishable."""
+        create_user("james", "pw-123456")
+        tokens_a = login_tokens(client, "james", "pw-123456")
+        other_id = create_user("mallory", "pw-abcdef")
+        token = _encode(_claims(sub=other_id, sid=tokens_a["session_id"]))
+        # Same code/message as an unknown session: no session enumeration.
+        self._assert_401(client, token, "AUTH_TOKEN_INVALID")
+
+    def test_revoked_session_with_unexpired_jwt_rejected(self, client) -> None:
+        """AUTH-019: logout invalidates otherwise-unexpired access tokens."""
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        access = tokens["access_token"]
+        assert client.post("/mobile/auth/logout", headers=auth_header(access)).status_code == 200
+        self._assert_401(client, access, "AUTH_SESSION_REVOKED")
+
+    def test_expired_session_with_unexpired_jwt_rejected(self, client, clock) -> None:
+        """AUTH-020: session expiry wins even while the JWT is still valid."""
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        clock.advance(days=31)
+        self._assert_401(client, tokens["access_token"], "AUTH_SESSION_REVOKED")
+
+    def test_deleted_user_with_live_session_rejected(self, client, services) -> None:
+        """USR-006: access fails closed when the user vanishes."""
+        from rex.mobile_api.db import connect
+
+        user_id = create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        conn = connect(services.db_path)
+        try:
+            conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        finally:
+            conn.close()
+        self._assert_401(client, tokens["access_token"], "AUTH_SESSION_REVOKED")
+
+    def test_disabled_user_with_live_session_rejected(self, client, services) -> None:
+        user_id = create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        disable_user(services.db_path, user_id)
+        self._assert_401(client, tokens["access_token"], "AUTH_SESSION_REVOKED")
+
+
+class TestAuthorizationHeaderSyntax:
+    def test_missing_header_rejected(self, client) -> None:
+        response = client.get(_SESSION_URL)
+        assert response.status_code == 401
+
+    def test_wrong_scheme_rejected(self, client) -> None:
+        create_user("james", "pw-123456")
+        response = client.get(_SESSION_URL, headers={"Authorization": "Basic amFtZXM6cHc="})
+        assert response.status_code == 401
+
+    def test_empty_bearer_rejected(self, client) -> None:
+        response = client.get(_SESSION_URL, headers={"Authorization": "Bearer "})
+        assert response.status_code == 401

--- a/tests/mobile_api/test_login.py
+++ b/tests/mobile_api/test_login.py
@@ -1,0 +1,168 @@
+"""Login endpoint tests.
+
+Matrix rows: AUTH-001..AUTH-007, AUTH-024, USR-005, USR-011.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tests.mobile_api.conftest import (
+    TEST_JWT_SECRET,
+    create_user,
+    disable_user,
+    login,
+)
+
+
+def _sessions(db_path: Path) -> list[sqlite3.Row]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute("SELECT * FROM mobile_sessions").fetchall()
+    finally:
+        conn.close()
+
+
+class TestLoginSuccess:
+    def test_valid_login_returns_token_pair_and_projection(self, client, services) -> None:
+        user_id = create_user("james", "pw-123456", admin=True)
+        response = login(client, "james", "pw-123456")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["token_type"] == "Bearer"
+        assert body["expires_in"] == 900
+        assert body["refresh_expires_in"] == 30 * 86400
+        assert body["access_token"]
+        assert body["refresh_token"]
+        assert body["session_id"]
+        assert body["user"]["id"] == user_id
+        assert body["user"]["role"] == "owner"
+        assert body["user"]["permissions"] == ["admin"]
+        assert body["user"]["name"] == "james"
+
+    def test_device_metadata_stored_with_session(self, client, services) -> None:
+        create_user("james", "pw-123456")
+        response = login(
+            client,
+            "james",
+            "pw-123456",
+            device={
+                "device_id": "stable-random-device-01",
+                "name": "James's iPhone",
+                "platform": "ios",
+                "app_version": "0.1.0",
+            },
+        )
+        assert response.status_code == 200
+        rows = _sessions(services.db_path)
+        assert len(rows) == 1
+        assert rows[0]["device_id"] == "stable-random-device-01"
+        assert rows[0]["platform"] == "ios"
+
+    def test_missing_device_gets_generated_id(self, client, services) -> None:
+        create_user("james", "pw-123456")
+        assert login(client, "james", "pw-123456").status_code == 200
+        rows = _sessions(services.db_path)
+        assert len(rows) == 1
+        assert rows[0]["device_id"]
+
+
+class TestLoginFailure:
+    def test_invalid_password_is_401_without_enumeration(self, client) -> None:
+        create_user("james", "pw-123456")
+        wrong_password = login(client, "james", "wrong-password")
+        unknown_user = login(client, "no-such-user", "wrong-password")
+        assert wrong_password.status_code == 401
+        assert unknown_user.status_code == 401
+        # USR-011: externally indistinguishable errors.
+        assert wrong_password.get_json()["error"]["code"] == "AUTH_INVALID_CREDENTIALS"
+        assert (
+            wrong_password.get_json()["error"]["message"]
+            == unknown_user.get_json()["error"]["message"]
+        )
+
+    def test_disabled_user_cannot_login(self, client, services) -> None:
+        user_id = create_user("james", "pw-123456")
+        disable_user(services.db_path, user_id)
+        response = login(client, "james", "pw-123456")
+        assert response.status_code == 401
+        assert response.get_json()["error"]["code"] == "AUTH_INVALID_CREDENTIALS"
+
+    def test_missing_fields_return_400(self, client) -> None:
+        assert client.post("/mobile/auth/login", json={}).status_code == 400
+        assert client.post("/mobile/auth/login", json={"username": "james"}).status_code == 400
+        assert client.post("/mobile/auth/login", json={"password": "x"}).status_code == 400
+
+    def test_malformed_json_returns_400(self, client) -> None:
+        response = client.post(
+            "/mobile/auth/login",
+            data="{not-json",
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert response.get_json()["error"]["code"] == "BAD_REQUEST"
+
+    def test_non_object_json_returns_400(self, client) -> None:
+        response = client.post(
+            "/mobile/auth/login", data='"a string"', content_type="application/json"
+        )
+        assert response.status_code == 400
+
+    def test_invalid_device_id_rejected(self, client) -> None:
+        create_user("james", "pw-123456")
+        response = login(
+            client,
+            "james",
+            "pw-123456",
+            device={"device_id": "../../etc/passwd"},
+        )
+        assert response.status_code == 400
+
+    def test_overlong_device_id_rejected(self, client) -> None:
+        create_user("james", "pw-123456")
+        response = login(client, "james", "pw-123456", device={"device_id": "a" * 200})
+        assert response.status_code == 400
+
+
+class TestLoginRateLimit:
+    def test_login_rate_limit_applies(self, mobile_env: Path, clock) -> None:
+        """AUTH-024: repeated logins hit the login-specific limit with 429."""
+        from rex.config import MobileApiConfig
+        from rex.mobile_api.app import create_mobile_app
+        from rex.mobile_api.db import migrate_users_db
+        from rex.mobile_api.services import MobileApiServices
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+        config = MobileApiConfig(
+            rate_limit_login="2 per minute", rate_limit_default="100 per minute"
+        )
+        services = MobileApiServices.build(config, db_path=db_path, clock=clock)
+        app = create_mobile_app(services=services)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            for _ in range(2):
+                login(client, "james", "bad-password")
+            limited = login(client, "james", "bad-password")
+        assert limited.status_code == 429
+        assert limited.get_json()["error"]["code"] == "RATE_LIMITED"
+        assert "Retry-After" in limited.headers
+
+
+class TestLoginSecrecy:
+    def test_password_and_tokens_never_logged(self, client, caplog) -> None:
+        """AUTH-007: raw credentials and tokens are absent from captured logs."""
+        import logging
+
+        create_user("james", "super-secret-pw")
+        with caplog.at_level(logging.DEBUG):
+            response = login(client, "james", "super-secret-pw")
+        assert response.status_code == 200
+        body = response.get_json()
+        log_text = " ".join(record.getMessage() for record in caplog.records)
+        assert "super-secret-pw" not in log_text
+        assert body["access_token"] not in log_text
+        assert body["refresh_token"] not in log_text
+        assert TEST_JWT_SECRET not in log_text

--- a/tests/mobile_api/test_login.py
+++ b/tests/mobile_api/test_login.py
@@ -151,6 +151,35 @@ class TestLoginRateLimit:
         assert "Retry-After" in limited.headers
 
 
+class TestLoginRateKey:
+    """The login limiter key must never contain raw IPs or usernames."""
+
+    def _key(self, app, username, address: str = "203.0.113.7") -> str:
+        from rex.mobile_api.routes.auth import _login_rate_key
+
+        with app.test_request_context(
+            "/mobile/auth/login",
+            method="POST",
+            json={"username": username, "password": "x"},
+            environ_base={"REMOTE_ADDR": address},
+        ):
+            return _login_rate_key()
+
+    def test_raw_ip_and_username_absent_from_key(self, app) -> None:
+        key = self._key(app, "james", address="203.0.113.7")
+        assert "203.0.113.7" not in key
+        assert "james" not in key
+
+    def test_username_normalization_is_consistent(self, app) -> None:
+        assert self._key(app, "James ") == self._key(app, "james")
+        assert self._key(app, "  JAMES") == self._key(app, "james")
+
+    def test_distinct_usernames_and_addresses_produce_distinct_keys(self, app) -> None:
+        base = self._key(app, "james", address="203.0.113.7")
+        assert self._key(app, "sarah", address="203.0.113.7") != base
+        assert self._key(app, "james", address="203.0.113.99") != base
+
+
 class TestLoginSecrecy:
     def test_password_and_tokens_never_logged(self, client, caplog) -> None:
         """AUTH-007: raw credentials and tokens are absent from captured logs."""

--- a/tests/mobile_api/test_logout.py
+++ b/tests/mobile_api/test_logout.py
@@ -23,15 +23,76 @@ class TestLogout:
         )
         assert refresh.status_code == 401
 
-    def test_repeated_logout_is_harmless(self, client) -> None:
-        """REF-012: a second logout fails closed with a documented 401."""
+    def test_repeated_logout_is_idempotent(self, client) -> None:
+        """REF-012: repeated logout returns the same harmless success."""
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        access = tokens["access_token"]
+        first = client.post("/mobile/auth/logout", headers=auth_header(access))
+        second = client.post("/mobile/auth/logout", headers=auth_header(access))
+        third = client.post("/mobile/auth/logout", headers=auth_header(access))
+        for response in (first, second, third):
+            assert response.status_code == 200
+            assert response.get_json() == {"ok": True}
+
+    def test_repeated_logout_does_not_modify_the_session(self, client, services) -> None:
+        """The logout-only path never reactivates or mutates the session."""
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        access = tokens["access_token"]
+        client.post("/mobile/auth/logout", headers=auth_header(access))
+        before = dict(services.session_store.get_session(tokens["session_id"]))
+        client.post("/mobile/auth/logout", headers=auth_header(access))
+        after = dict(services.session_store.get_session(tokens["session_id"]))
+        assert after == before
+        assert after["revoked_at"] is not None
+        assert after["revoke_reason"] == "logout"
+
+    def test_logout_still_requires_full_token_validation(self, client) -> None:
+        """The idempotent path never weakens JWT validation."""
+        import jwt as pyjwt
+
+        from tests.mobile_api.conftest import TEST_JWT_SECRET
+
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        claims = pyjwt.decode(
+            tokens["access_token"],
+            TEST_JWT_SECRET,
+            algorithms=["HS256"],
+            audience="askrex-mobile",
+            issuer="askrex-assistant",
+        )
+        # Wrong signature is still rejected on logout.
+        forged = pyjwt.encode(claims, "w" * 64, algorithm="HS256")
+        assert client.post("/mobile/auth/logout", headers=auth_header(forged)).status_code == 401
+        # A session owned by someone else is still rejected on logout.
+        other_id = create_user("sarah", "pw-abcdef")
+        claims["sub"] = other_id
+        crossed = pyjwt.encode(claims, TEST_JWT_SECRET, algorithm="HS256")
+        assert client.post("/mobile/auth/logout", headers=auth_header(crossed)).status_code == 401
+        # Missing auth is still rejected.
+        assert client.post("/mobile/auth/logout").status_code == 401
+
+    def test_revoked_token_fails_on_every_other_protected_endpoint(self, client) -> None:
+        """Revoked sessions are permitted on /logout only — nowhere else."""
         create_user("james", "pw-123456")
         tokens = login_tokens(client, "james", "pw-123456")
         access = tokens["access_token"]
         assert client.post("/mobile/auth/logout", headers=auth_header(access)).status_code == 200
-        second = client.post("/mobile/auth/logout", headers=auth_header(access))
-        assert second.status_code == 401
-        assert second.get_json()["error"]["code"] == "AUTH_SESSION_REVOKED"
+
+        protected = [
+            ("get", "/mobile/auth/session"),
+            ("post", "/mobile/auth/logout-all"),
+            ("post", "/mobile/chat"),
+            ("post", "/mobile/voice/upload"),
+            ("get", "/mobile/notifications"),
+            ("get", "/mobile/settings"),
+        ]
+        for method, path in protected:
+            response = getattr(client, method)(path, headers=auth_header(access))
+            assert response.status_code == 401, path
+            assert response.get_json()["error"]["code"] == "AUTH_SESSION_REVOKED", path
 
 
 class TestLogoutAll:

--- a/tests/mobile_api/test_logout.py
+++ b/tests/mobile_api/test_logout.py
@@ -1,0 +1,101 @@
+"""Logout, logout-all, and two-user isolation tests.
+
+Matrix rows: REF-011..REF-015.
+"""
+
+from __future__ import annotations
+
+from tests.mobile_api.conftest import auth_header, create_user, login_tokens
+
+
+class TestLogout:
+    def test_logout_revokes_access_and_refresh(self, client) -> None:
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        access = tokens["access_token"]
+
+        assert client.post("/mobile/auth/logout", headers=auth_header(access)).status_code == 200
+        # The otherwise-unexpired access token is invalidated by session state.
+        assert client.get("/mobile/auth/session", headers=auth_header(access)).status_code == 401
+        # And the refresh token is dead too.
+        refresh = client.post(
+            "/mobile/auth/refresh", json={"refresh_token": tokens["refresh_token"]}
+        )
+        assert refresh.status_code == 401
+
+    def test_repeated_logout_is_harmless(self, client) -> None:
+        """REF-012: a second logout fails closed with a documented 401."""
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        access = tokens["access_token"]
+        assert client.post("/mobile/auth/logout", headers=auth_header(access)).status_code == 200
+        second = client.post("/mobile/auth/logout", headers=auth_header(access))
+        assert second.status_code == 401
+        assert second.get_json()["error"]["code"] == "AUTH_SESSION_REVOKED"
+
+
+class TestLogoutAll:
+    def test_logout_all_revokes_every_own_session(self, client) -> None:
+        create_user("james", "pw-123456")
+        first = login_tokens(client, "james", "pw-123456")
+        second = login_tokens(client, "james", "pw-123456")
+
+        response = client.post(
+            "/mobile/auth/logout-all", headers=auth_header(second["access_token"])
+        )
+        assert response.status_code == 200
+        assert response.get_json()["revoked_sessions"] == 2
+
+        for tokens in (first, second):
+            assert (
+                client.get(
+                    "/mobile/auth/session",
+                    headers=auth_header(tokens["access_token"]),
+                ).status_code
+                == 401
+            )
+
+    def test_logout_all_does_not_touch_other_users(self, client) -> None:
+        """REF-014: logout-all is scoped to the authenticated user only."""
+        create_user("james", "pw-123456")
+        create_user("sarah", "pw-abcdef")
+        james = login_tokens(client, "james", "pw-123456")
+        sarah = login_tokens(client, "sarah", "pw-abcdef")
+
+        client.post("/mobile/auth/logout-all", headers=auth_header(james["access_token"]))
+
+        assert (
+            client.get(
+                "/mobile/auth/session", headers=auth_header(james["access_token"])
+            ).status_code
+            == 401
+        )
+        # Sarah's session is untouched.
+        still_active = client.get(
+            "/mobile/auth/session", headers=auth_header(sarah["access_token"])
+        )
+        assert still_active.status_code == 200
+
+    def test_users_refresh_tokens_stay_isolated(self, client) -> None:
+        """REF-015: one user's refresh token cannot act on another's session."""
+        create_user("james", "pw-123456")
+        create_user("sarah", "pw-abcdef")
+        james = login_tokens(client, "james", "pw-123456")
+        sarah = login_tokens(client, "sarah", "pw-abcdef")
+
+        client.post("/mobile/auth/logout-all", headers=auth_header(james["access_token"]))
+        # James's refresh is revoked; Sarah's still rotates.
+        assert (
+            client.post(
+                "/mobile/auth/refresh",
+                json={"refresh_token": james["refresh_token"]},
+            ).status_code
+            == 401
+        )
+        assert (
+            client.post(
+                "/mobile/auth/refresh",
+                json={"refresh_token": sarah["refresh_token"]},
+            ).status_code
+            == 200
+        )

--- a/tests/mobile_api/test_migrations.py
+++ b/tests/mobile_api/test_migrations.py
@@ -1,0 +1,136 @@
+"""Migration tests: fresh, legacy, and repeated runs against users.db.
+
+Matrix rows: USR-001, USR-002, USR-003, USR-004.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import bcrypt
+import pytest
+
+from tests.mobile_api.conftest import login
+
+pytestmark = pytest.mark.usefixtures("mobile_env")
+
+
+def _table_names(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    finally:
+        conn.close()
+    return {row[0] for row in rows}
+
+
+def _user_columns(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("PRAGMA table_info(users)").fetchall()
+    finally:
+        conn.close()
+    return {row[1] for row in rows}
+
+
+def _make_legacy_db(db_path: Path, username: str, password: str) -> str:
+    """Create a pre-mobile users.db (no disabled_at, no mobile tables)."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("""
+            CREATE TABLE users (
+                id       TEXT PRIMARY KEY,
+                username TEXT UNIQUE NOT NULL,
+                password TEXT NOT NULL,
+                created  TEXT NOT NULL
+            )
+            """)
+        password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+        user_id = "11111111-2222-3333-4444-555555555555"
+        conn.execute(
+            "INSERT INTO users (id, username, password, created) VALUES (?, ?, ?, ?)",
+            (user_id, username, password_hash, datetime.now(UTC).isoformat()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return user_id
+
+
+class TestFreshMigration:
+    def test_creates_all_tables_and_columns(self, mobile_env: Path) -> None:
+        from rex.mobile_api.db import migrate_users_db
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+
+        tables = _table_names(db_path)
+        assert {
+            "users",
+            "user_permissions",
+            "mobile_sessions",
+            "mobile_refresh_tokens",
+        } <= tables
+        assert "disabled_at" in _user_columns(db_path)
+
+
+class TestLegacyMigration:
+    def test_preserves_existing_users_and_hashes(self, mobile_env: Path) -> None:
+        from rex.mobile_api.db import migrate_users_db
+
+        db_path = mobile_env / "users.db"
+        user_id = _make_legacy_db(db_path, "james", "legacy-pass")
+
+        before = sqlite3.connect(str(db_path))
+        original_hash = before.execute(
+            "SELECT password FROM users WHERE id = ?", (user_id,)
+        ).fetchone()[0]
+        before.close()
+
+        migrate_users_db(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT username, password, disabled_at FROM users WHERE id = ?",
+                (user_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == "james"
+        assert row[1] == original_hash
+        assert row[2] is None  # existing users remain active
+
+    def test_existing_user_logs_in_after_migration(
+        self, mobile_env: Path, clock, mobile_config
+    ) -> None:
+        from rex.mobile_api.app import create_mobile_app
+        from rex.mobile_api.services import MobileApiServices
+
+        db_path = mobile_env / "users.db"
+        _make_legacy_db(db_path, "james", "legacy-pass")
+
+        services = MobileApiServices.build(mobile_config, db_path=db_path, clock=clock)
+        app = create_mobile_app(services=services)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            response = login(client, "james", "legacy-pass")
+        assert response.status_code == 200
+        assert "access_token" in response.get_json()
+
+
+class TestRepeatedMigration:
+    def test_migration_is_idempotent(self, mobile_env: Path) -> None:
+        from rex.mobile_api.db import migrate_users_db
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+        first = _table_names(db_path)
+        migrate_users_db(db_path)
+        migrate_users_db(db_path)
+        assert _table_names(db_path) == first
+        assert "disabled_at" in _user_columns(db_path)

--- a/tests/mobile_api/test_refresh.py
+++ b/tests/mobile_api/test_refresh.py
@@ -1,0 +1,195 @@
+"""Refresh rotation, reuse detection, concurrency, and revocation tests.
+
+Matrix rows: REF-001..REF-010, REF-016, REF-018.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+from tests.mobile_api.conftest import (
+    create_user,
+    disable_user,
+    login_tokens,
+    sequential_token_generator,
+)
+
+_REFRESH_URL = "/mobile/auth/refresh"
+
+
+def _refresh(client, token):
+    return client.post(_REFRESH_URL, json={"refresh_token": token})
+
+
+def _db_dump(db_path: Path) -> str:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return "\n".join(conn.iterdump())
+    finally:
+        conn.close()
+
+
+class TestRefreshRotation:
+    def test_valid_refresh_returns_new_pair_same_session(self, client) -> None:
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        response = _refresh(client, tokens["refresh_token"])
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["session_id"] == tokens["session_id"]
+        assert body["refresh_token"] != tokens["refresh_token"]
+        assert body["access_token"]
+        assert body["user"]["id"]
+
+    def test_raw_refresh_tokens_never_stored(self, client, services) -> None:
+        """REF-002: only hashes are stored; raw values are absent from the DB."""
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        rotated = _refresh(client, tokens["refresh_token"]).get_json()
+        dump = _db_dump(services.db_path)
+        assert tokens["refresh_token"] not in dump
+        assert rotated["refresh_token"] not in dump
+
+    def test_reuse_of_consumed_token_revokes_family_and_session(self, client) -> None:
+        """REF-003: replaying a rotated token kills the whole family."""
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        rotated = _refresh(client, tokens["refresh_token"]).get_json()
+
+        reuse = _refresh(client, tokens["refresh_token"])
+        assert reuse.status_code == 401
+        assert reuse.get_json()["error"]["code"] == "AUTH_REFRESH_REUSED"
+
+        # The still-fresh replacement token is now revoked too.
+        follow_up = _refresh(client, rotated["refresh_token"])
+        assert follow_up.status_code == 401
+
+        # And the session no longer authenticates the rotated access token.
+        session = client.get(
+            "/mobile/auth/session",
+            headers={"Authorization": f"Bearer {rotated['access_token']}"},
+        )
+        assert session.status_code == 401
+
+    def test_concurrent_refresh_yields_exactly_one_success(self, mobile_env: Path, clock) -> None:
+        """REF-004: two concurrent rotations of one token → one winner."""
+        from rex.mobile_api.db import migrate_users_db
+        from rex.mobile_api.sessions import (
+            ROTATED,
+            DeviceInfo,
+            MobileSessionStore,
+        )
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+        user_id = create_user("james", "pw-123456")
+        store = MobileSessionStore(
+            db_path,
+            refresh_ttl_seconds=30 * 86400,
+            clock=clock,
+            token_generator=sequential_token_generator(),
+        )
+        created = store.create_session(user_id, DeviceInfo(device_id="device-1"))
+
+        barrier = threading.Barrier(2)
+        results: list = [None, None]
+
+        def _rotate(slot: int) -> None:
+            barrier.wait()
+            results[slot] = store.rotate_refresh_token(created.refresh_token)
+
+        threads = [threading.Thread(target=_rotate, args=(slot,)) for slot in (0, 1)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        statuses = sorted(result.status for result in results)
+        assert statuses.count(ROTATED) == 1
+        issued = [r.refresh_token for r in results if r.refresh_token]
+        assert len(issued) == 1
+
+
+class TestRefreshRejection:
+    def test_expired_refresh_token_rejected(self, client, clock) -> None:
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        clock.advance(days=31)
+        response = _refresh(client, tokens["refresh_token"])
+        assert response.status_code == 401
+        assert response.get_json()["error"]["code"] == "AUTH_TOKEN_EXPIRED"
+
+    def test_revoked_refresh_token_rejected(self, client) -> None:
+        """REF-006: logout revokes the refresh token."""
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        client.post(
+            "/mobile/auth/logout",
+            headers={"Authorization": f"Bearer {tokens['access_token']}"},
+        )
+        response = _refresh(client, tokens["refresh_token"])
+        assert response.status_code == 401
+
+    def test_disabled_user_refresh_rejected_and_session_revoked(self, client, services) -> None:
+        """REF-008 / USR-005: a disabled user cannot refresh."""
+        user_id = create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        disable_user(services.db_path, user_id)
+        response = _refresh(client, tokens["refresh_token"])
+        assert response.status_code == 401
+        session = services.session_store.get_session(tokens["session_id"])
+        assert session["revoked_at"] is not None
+
+    def test_random_token_rejected_without_enumeration(self, client) -> None:
+        response = _refresh(client, "r" * 64)
+        assert response.status_code == 401
+        assert response.get_json()["error"]["code"] == "AUTH_TOKEN_INVALID"
+
+    def test_malformed_refresh_payloads_rejected(self, client) -> None:
+        assert client.post(_REFRESH_URL, json={}).status_code == 400
+        assert client.post(_REFRESH_URL, json={"refresh_token": 12345}).status_code == 400
+        assert client.post(_REFRESH_URL, json={"refresh_token": ""}).status_code == 400
+        assert client.post(_REFRESH_URL, json={"refresh_token": "x" * 4096}).status_code == 400
+
+    def test_refresh_rate_limit(self, mobile_env: Path, clock) -> None:
+        """REF-016: the refresh route has its own limit and leaks no tokens."""
+        from rex.config import MobileApiConfig
+        from rex.mobile_api.app import create_mobile_app
+        from rex.mobile_api.db import migrate_users_db
+        from rex.mobile_api.services import MobileApiServices
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+        config = MobileApiConfig(
+            rate_limit_refresh="2 per minute", rate_limit_default="100 per minute"
+        )
+        services = MobileApiServices.build(config, db_path=db_path, clock=clock)
+        app = create_mobile_app(services=services)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            for _ in range(2):
+                _refresh(client, "does-not-matter")
+            limited = _refresh(client, "does-not-matter")
+        assert limited.status_code == 429
+        assert "does-not-matter" not in limited.get_data(as_text=True)
+
+
+class TestReuseAudit:
+    def test_reuse_event_logged_with_safe_ids_only(self, client, caplog) -> None:
+        """REF-018: the audit event has session/family IDs but no raw token."""
+        import logging
+
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        _refresh(client, tokens["refresh_token"])
+        with caplog.at_level(logging.WARNING):
+            _refresh(client, tokens["refresh_token"])
+        reuse_records = [
+            record for record in caplog.records if "reuse" in record.getMessage().lower()
+        ]
+        assert reuse_records
+        log_text = " ".join(record.getMessage() for record in reuse_records)
+        assert tokens["session_id"] in log_text
+        assert tokens["refresh_token"] not in log_text

--- a/tests/mobile_api/test_refresh.py
+++ b/tests/mobile_api/test_refresh.py
@@ -81,6 +81,7 @@ class TestRefreshRotation:
             DeviceInfo,
             MobileSessionStore,
         )
+        from tests.mobile_api.conftest import RecordingAuditLogger
 
         db_path = mobile_env / "users.db"
         migrate_users_db(db_path)
@@ -90,6 +91,7 @@ class TestRefreshRotation:
             refresh_ttl_seconds=30 * 86400,
             clock=clock,
             token_generator=sequential_token_generator(),
+            audit_logger=RecordingAuditLogger(),
         )
         created = store.create_session(user_id, DeviceInfo(device_id="device-1"))
 
@@ -193,3 +195,100 @@ class TestReuseAudit:
         log_text = " ".join(record.getMessage() for record in reuse_records)
         assert tokens["session_id"] in log_text
         assert tokens["refresh_token"] not in log_text
+
+    def test_reuse_creates_exactly_one_persistent_audit_event(
+        self, client, services, audit_recorder
+    ) -> None:
+        """A structured security-audit event is persisted on reuse."""
+        user_id = create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+
+        _refresh(client, tokens["refresh_token"])  # normal rotation
+        assert audit_recorder.entries == []  # no reuse event on rotation
+
+        reuse = _refresh(client, tokens["refresh_token"])
+        assert reuse.status_code == 401
+        assert len(audit_recorder.entries) == 1
+
+        entry = audit_recorder.entries[0]
+        args = entry.tool_call_args
+        assert args["event_type"] == "mobile_refresh_token_reuse"
+        assert args["session_id"] == tokens["session_id"]
+        assert args["family_id"]
+        assert args["user_id"] == user_id
+        assert args["revocation_result"] == "family_and_session_revoked"
+        assert entry.action_id
+        assert entry.timestamp is not None
+
+        # The revocation actually happened.
+        session = services.session_store.get_session(tokens["session_id"])
+        assert session["revoked_at"] is not None
+
+    def test_audit_event_contains_no_token_material(self, client, audit_recorder) -> None:
+        from rex.mobile_api.sessions import hash_refresh_token
+
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        rotated = _refresh(client, tokens["refresh_token"]).get_json()
+        _refresh(client, tokens["refresh_token"])  # reuse
+
+        assert len(audit_recorder.entries) == 1
+        serialized = audit_recorder.entries[0].model_dump_json()
+        for forbidden in (
+            tokens["refresh_token"],
+            rotated["refresh_token"],
+            hash_refresh_token(tokens["refresh_token"]),
+            hash_refresh_token(rotated["refresh_token"]),
+            tokens["access_token"],
+            rotated["access_token"],
+            "pw-123456",
+        ):
+            assert forbidden not in serialized
+
+    def test_two_users_reuse_events_stay_separate(self, client, audit_recorder) -> None:
+        james_id = create_user("james", "pw-123456")
+        sarah_id = create_user("sarah", "pw-abcdef")
+        james = login_tokens(client, "james", "pw-123456")
+        sarah = login_tokens(client, "sarah", "pw-abcdef")
+
+        _refresh(client, james["refresh_token"])
+        _refresh(client, james["refresh_token"])  # james reuse
+        _refresh(client, sarah["refresh_token"])
+        _refresh(client, sarah["refresh_token"])  # sarah reuse
+
+        assert len(audit_recorder.entries) == 2
+        by_user = {e.tool_call_args["user_id"]: e.tool_call_args for e in audit_recorder.entries}
+        assert by_user[james_id]["session_id"] == james["session_id"]
+        assert by_user[sarah_id]["session_id"] == sarah["session_id"]
+
+    def test_default_audit_logger_writes_persistent_event(
+        self, mobile_env, clock, tmp_path
+    ) -> None:
+        """Without injection, the canonical rex.audit logger persists the event."""
+        from rex.audit import AuditLogger
+        from rex.mobile_api.db import migrate_users_db
+        from rex.mobile_api.sessions import DeviceInfo, MobileSessionStore
+
+        db_path = mobile_env / "users.db"
+        migrate_users_db(db_path)
+        user_id = create_user("james", "pw-123456")
+        audit = AuditLogger(log_path=tmp_path / "logs" / "audit.log")
+        store = MobileSessionStore(
+            db_path,
+            refresh_ttl_seconds=30 * 86400,
+            clock=clock,
+            audit_logger=audit,
+        )
+        created = store.create_session(user_id, DeviceInfo(device_id="dev-1"))
+        store.rotate_refresh_token(created.refresh_token)
+        store.rotate_refresh_token(created.refresh_token)  # reuse
+
+        entries = audit.read()
+        reuse_entries = [
+            e for e in entries if e.tool_call_args.get("event_type") == "mobile_refresh_token_reuse"
+        ]
+        assert len(reuse_entries) == 1
+        assert reuse_entries[0].tool_call_args["user_id"] == user_id
+        assert created.refresh_token not in (tmp_path / "logs" / "audit.log").read_text(
+            encoding="utf-8"
+        )

--- a/tests/mobile_api/test_scaffolds.py
+++ b/tests/mobile_api/test_scaffolds.py
@@ -1,0 +1,45 @@
+"""Explicit 501 scaffold tests: authenticated, truthful, never fake success.
+
+Matrix rows: FND-018, CAP-008.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.mobile_api.conftest import auth_header, create_user, login_tokens
+
+_SCAFFOLDS = [
+    ("post", "/mobile/chat"),
+    ("post", "/mobile/chat/stream"),
+    ("post", "/mobile/voice/upload"),
+    ("post", "/mobile/tts/playback"),
+    ("get", "/mobile/home/entities"),
+    ("post", "/mobile/home/command"),
+    ("get", "/mobile/notifications"),
+    ("get", "/mobile/approvals"),
+    ("get", "/mobile/tasks"),
+    ("get", "/mobile/workflows"),
+    ("get", "/mobile/audit-log"),
+    ("get", "/mobile/settings"),
+]
+
+
+class TestScaffolds:
+    @pytest.mark.parametrize(("method", "path"), _SCAFFOLDS)
+    def test_unauthenticated_scaffold_requires_auth(self, client, method: str, path: str) -> None:
+        response = getattr(client, method)(path)
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize(("method", "path"), _SCAFFOLDS)
+    def test_authenticated_scaffold_returns_explicit_501(
+        self, client, method: str, path: str
+    ) -> None:
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        response = getattr(client, method)(path, headers=auth_header(tokens["access_token"]))
+        assert response.status_code == 501
+        body = response.get_json()
+        assert body["error"]["code"] == "NOT_IMPLEMENTED"
+        assert body["error"]["retryable"] is False
+        assert body["error"]["request_id"]

--- a/tests/mobile_api/test_session_endpoint.py
+++ b/tests/mobile_api/test_session_endpoint.py
@@ -1,0 +1,89 @@
+"""Current-session endpoint and live authorization projection tests.
+
+Matrix rows: SES-001, SES-005..SES-007, AUTH-021..AUTH-023.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.mobile_api.conftest import auth_header, create_user, login_tokens
+
+_SESSION_URL = "/mobile/auth/session"
+
+
+class TestCurrentSession:
+    def test_returns_live_projection(self, client) -> None:
+        user_id = create_user("james", "pw-123456", admin=True)
+        tokens = login_tokens(client, "james", "pw-123456")
+        response = client.get(_SESSION_URL, headers=auth_header(tokens["access_token"]))
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["session_id"] == tokens["session_id"]
+        assert body["user"]["id"] == user_id
+        assert body["user"]["role"] == "owner"
+        assert body["user"]["permissions"] == ["admin"]
+
+    def test_client_user_id_is_ignored(self, client) -> None:
+        """SES-005: a user_id query parameter never changes the principal."""
+        user_id = create_user("james", "pw-123456")
+        other_id = create_user("sarah", "pw-abcdef")
+        tokens = login_tokens(client, "james", "pw-123456")
+        response = client.get(
+            f"{_SESSION_URL}?user_id={other_id}",
+            headers=auth_header(tokens["access_token"]),
+        )
+        assert response.status_code == 200
+        assert response.get_json()["user"]["id"] == user_id
+
+    def test_non_admin_maps_to_member(self, client) -> None:
+        """SES-006: role is a presentation projection of live permissions."""
+        create_user("james", "pw-123456", admin=False)
+        tokens = login_tokens(client, "james", "pw-123456")
+        response = client.get(_SESSION_URL, headers=auth_header(tokens["access_token"]))
+        assert response.get_json()["user"]["role"] == "member"
+
+    def test_permission_change_reflected_live(self, client) -> None:
+        """SES-007 / AUTH-022: current DB permissions, not token-time claims."""
+        from rex.permissions import grant_permission, revoke_permission
+
+        user_id = create_user("james", "pw-123456", admin=True)
+        tokens = login_tokens(client, "james", "pw-123456")
+        access = tokens["access_token"]
+
+        grant_permission(user_id, "ha_control")
+        first = client.get(_SESSION_URL, headers=auth_header(access)).get_json()
+        assert "ha_control" in first["user"]["permissions"]
+
+        revoke_permission(user_id, "admin")
+        second = client.get(_SESSION_URL, headers=auth_header(access)).get_json()
+        assert second["user"]["role"] == "member"
+        assert "admin" not in second["user"]["permissions"]
+
+    def test_profile_change_reflected_live(self, client, monkeypatch, tmp_path: Path) -> None:
+        """AUTH-023: /session reflects the current display profile."""
+        from rex import identity as rex_identity
+        from rex.mobile_api import auth as mauth
+        from rex.mobile_api import users as musers
+
+        user_id = create_user("james", "pw-123456")
+        profile_dir = tmp_path / "Memory" / user_id
+        profile_dir.mkdir(parents=True)
+
+        def _fake_profile(requested_id: str, *, memory_dir=None):
+            rex_identity.validate_user_id(requested_id)
+            core = tmp_path / "Memory" / requested_id / "core.json"
+            if core.exists():
+                return json.loads(core.read_text(encoding="utf-8"))
+            return None
+
+        monkeypatch.setattr(musers, "get_user_profile", _fake_profile)
+        monkeypatch.setattr(mauth, "get_user_profile", _fake_profile)
+
+        tokens = login_tokens(client, "james", "pw-123456")
+        access = tokens["access_token"]
+
+        (profile_dir / "core.json").write_text(json.dumps({"name": "James R."}), encoding="utf-8")
+        response = client.get(_SESSION_URL, headers=auth_header(access))
+        assert response.get_json()["user"]["name"] == "James R."

--- a/tests/mobile_api/test_status_capabilities.py
+++ b/tests/mobile_api/test_status_capabilities.py
@@ -1,0 +1,65 @@
+"""Status, capabilities, and capability-privacy tests.
+
+Matrix rows: FND-016, FND-017, CAP-001, CAP-009, CAP-010.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+class TestStatus:
+    def test_status_is_minimal_and_public(self, client) -> None:
+        response = client.get("/mobile/status")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["status"] == "ok"
+        assert body["api_version"] == "1.0"
+        assert body["server_version"]
+        assert body["request_id"]
+        assert set(body.keys()) == {
+            "status",
+            "api_version",
+            "server_version",
+            "request_id",
+        }
+
+
+class TestCapabilities:
+    def test_session_one_capabilities_are_truthful(self, client) -> None:
+        """CAP-001: authentication true; every runtime feature false."""
+        response = client.get("/mobile/capabilities")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["api_version"] == "1.0"
+        assert body["minimum_app_version"] == "0.1.0"
+        features = body["features"]
+        assert features["authentication"] is True
+        for name in (
+            "chat",
+            "chat_streaming",
+            "websocket_chat",
+            "voice_upload",
+            "tts",
+            "live_voice",
+            "notifications",
+            "approvals",
+            "home_assistant",
+        ):
+            assert features[name] is False, name
+
+    def test_capabilities_expose_no_sensitive_data(self, client) -> None:
+        """CAP-009: no paths, tokens, account IDs, usernames, or model paths."""
+        response = client.get("/mobile/capabilities")
+        body = response.get_json()
+        assert set(body.keys()) == {
+            "api_version",
+            "minimum_app_version",
+            "server_version",
+            "features",
+        }
+        text = json.dumps(body)
+        assert "\\\\" not in text  # no Windows paths
+        assert "C:/" not in text and "C:\\" not in text
+        assert "users.db" not in text
+        assert "secret" not in text.lower()


### PR DESCRIPTION
## Summary

Session 1 of the mobile API gateway (#323): foundation and authentication. Adds `rex/mobile_api/` — an injectable Flask application factory serving only `/mobile/*` — plus typed configuration, canonical `users.db` migrations, per-device sessions with rotating hashed refresh tokens, short-lived access JWTs, CLI commands, explicit 501 scaffolds, and a 128-test suite.

Refs #323 (do not close; Session 2 — chat/WebSocket/voice/TTS — remains).

## Implemented routes

| Route | Behavior |
|---|---|
| `POST /mobile/auth/login` | Credential login against canonical `users.db` (bcrypt), per-device session, token pair, live user projection |
| `POST /mobile/auth/refresh` | Atomic refresh rotation; reuse of a consumed token revokes the family/session (`AUTH_REFRESH_REUSED`) |
| `POST /mobile/auth/logout` | Revokes the current session; invalidates otherwise-unexpired access tokens via session checks |
| `POST /mobile/auth/logout-all` | Revokes every session of the authenticated user only |
| `GET /mobile/auth/session` | Live user/session projection (authoritative display state) |
| `GET /mobile/status`, `GET /mobile/capabilities` | Public, non-sensitive; capabilities are truthful (auth `true`, all runtime features `false`) |
| chat / chat-stream / voice / TTS / home / notifications / approvals / tasks / workflows / audit-log / settings | Explicit authenticated **501 `NOT_IMPLEMENTED`** scaffolds — never fake data or success |

## Security model

- Access JWTs (15 min) carry `iss`/`aud`/`sub`/`sid`/`jti`/`iat`/`nbf`/`exp`; validation checks algorithm, signature, issuer, audience, time claims, required claims, canonical `sub` (via `rex.identity.validate_user_id` **before** any private lookup), session existence/ownership/status, and user active state — then resolves permissions live server-side into an immutable request principal.
- Refresh tokens: 384-bit opaque values, SHA-256 hashes only in storage, one `BEGIN IMMEDIATE` transaction per rotation; concurrent use of one token yields exactly one success; reuse revokes the token family + session with an audited (token-free) event.
- Client-supplied `user_id`/role/permissions/risk/approval fields are never trusted; login/username errors are non-enumerating with bcrypt timing equalization.
- Deny-by-default CORS (`*` rejected at config validation), 1 MiB JSON body limit, route-specific rate limits (login 10/min keyed by anonymized IP + username hash, refresh 30/min), `X-Request-ID` + `X-AskRex-API-Version` on every response, nested error envelope with `retryable` and `request_id`.
- Passwords, tokens, hashes, and request bodies never appear in logs (asserted by tests).
- Default bind `127.0.0.1:8765`; explicit `0.0.0.0` prints a development-only no-TLS warning and stays authenticated + rate limited.

## Schema changes (idempotent migrations on data/users.db)

- `users.disabled_at TEXT NULL` (added only when absent; existing users stay active)
- `mobile_sessions` (per-device sessions with revocation state) + user index
- `mobile_refresh_tokens` (hashed token families with consumed/revoked/replacement tracking) + family index

Existing users, bcrypt hashes, and permissions are preserved; fresh, legacy, and repeated migrations are tested.

## CLI

- `python -m rex mobile-api [--host HOST] [--port PORT]` — flags > `mobile_api` config > safe defaults; banner prints bind/status URL/TLS expectation, never secrets.
- `python -m rex mobile-user create --username NAME` — double `getpass` prompt (no argv password), reuses `rex.auth.create_user`, creates the matching profile, bootstraps first-user admin; interrupted prompts create nothing.

## Configuration

- New typed `MobileApiConfig` under `config.mobile_api` (JSON group `mobile_api`), validated at load (port/TTLs/limits/rate-limit grammar/origins).
- `REX_JWT_SECRET` (already in `.env.example`) now also signs mobile access tokens and must be ≥ 32 chars for the mobile gateway; missing/weak secrets fail closed before serving.

## Tests and validation

- `pytest -q tests/mobile_api` — **128 passed** (migrations, login, JWT claim/signature/issuer/audience/nbf/expiry, invalid/reserved `sub` before private access, session/user status, rotation + threaded concurrency race, reuse-family revocation, logout/logout-all + two-user isolation, live permission/profile changes, request IDs, nested errors, rate limits, log redaction, status/capabilities/scaffolds, CLI precedence + safe user creation, config validation).
- `pytest -q tests/test_us047_user_auth.py tests/test_us048_data_isolation.py tests/test_us052_permissions.py` — 58 passed.
- `ruff check .`, `black --check`, `python -m compileall -q rex scripts`, `mypy rex --ignore-missing-imports`, `detect-secrets scan --baseline .secrets.baseline` — all clean.
- `python -m rex doctor` — "Rex is ready to use."
- Full suite: see PR checks.
- Live local smoke (Windows 11, loopback): status → capabilities → login → invalid login → session → refresh → refresh-reuse (family revoked) → scaffold 501 → logout → revoked session; server log verified free of credentials/tokens.

## Docs

- `docs/mobile/MOBILE_API_SETUP_WINDOWS.md` — secret generation, user creation, localhost/LAN startup, PowerShell verification, Windows Firewall (private profile) setup, troubleshooting.
- Root `CLAUDE.md`, `.env.example`, `config/rex_config.example.json` updated.

## Known limitations / remaining Session 2 work

- No real chat/SSE/WebSocket/voice/TTS — all are truthful 501 scaffolds with `false` capabilities.
- No `mobile_message_requests` idempotency store yet (Session 2, with chat).
- Rate limiting uses in-memory storage — single-process development only.
- LAN use is plain-HTTP development-only; public deployment is separately gated on TLS/reverse-proxy work.
- Physical-iPhone and LAN smoke tests have not been performed.
