### PR TITLE
feat(mobile): add secure chat voice and TTS runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Mobile API gateway (issue #323) runs via the CLI, not a console script:
 
 ### Core components
 
-API: Flask (Flask-CORS, Flask-Limiter)
+API: Flask (Flask-CORS, Flask-Limiter, Flask-Sock for the mobile WebSocket)
 
 GUI: Web dashboard via `rex.gui_app` (React + Flask). `gui.py` is deprecated.
 
@@ -197,7 +197,7 @@ Bridge compatibility wrappers (17) — exec canonical `bridge/<name>.py` in thei
 - rex/identity.py
 - rex/voice_identity/
 - rex/computers/
-- rex/mobile_api/ — authenticated mobile API gateway (issue #323): injectable Flask app factory (`app.py`), typed config helpers, idempotent `users.db` migrations (`db.py`), per-device sessions + rotating hashed refresh tokens (`sessions.py`), short-lived access JWTs + request principal (`auth.py`), structured mobile errors (`errors.py`), truthful capabilities (`capabilities.py`), routes under `rex/mobile_api/routes/`. Session 1 implements auth only; chat/voice/TTS/HA routes are explicit 501 scaffolds.
+- rex/mobile_api/ — authenticated mobile API gateway (issue #323): injectable Flask app factory (`app.py`), typed config helpers, idempotent `users.db` migrations (`db.py`), per-device sessions + rotating hashed refresh tokens (`sessions.py`), short-lived access JWTs + request principal (`auth.py`), structured mobile errors (`errors.py`), truthful runtime-aware capabilities (`capabilities.py`), cross-transport `(user_id, message_id)` chat idempotency (`idempotency.py`, `mobile_message_requests` table), canonical Assistant adapter (`chat.py` — explicit `active_user_id`, never direct `LanguageModel` calls), canonical snake_case streaming events (`events.py`), first-frame-auth WebSocket protocol via Flask-Sock (`websocket.py`, close codes 4401/4403/4408/4429), STT/TTS adapters reusing the existing Whisper and XTTS/edge-tts/pyttsx3 stacks (`voice.py`), routes under `rex/mobile_api/routes/` (`chat.py`: POST /mobile/chat + SSE /mobile/chat/stream; `voice.py`: /mobile/voice/upload + /mobile/tts/playback). Home Assistant/notifications/approvals/tasks/workflows/audit/settings remain explicit 501 scaffolds with false capabilities; `live_voice` stays false. Cross-repo wire contract fixtures live in `tests/mobile_api/contract_vectors.json` (identical copy in the AskRex mobile repo).
 
 ### Assistant architecture
 
@@ -339,9 +339,10 @@ Runtime configuration → config/rex_config.json
 
 The mobile gateway adds an eighth typed group, `config.mobile_api`
 (`MobileApiConfig`, JSON group `mobile_api` in `config/rex_config.json`):
-host/port, token TTLs, body limits, deny-by-default CORS origins, and
-route-specific rate-limit strings. It is canonical nested config with no flat
-equivalents. The mobile JWT signing secret is `REX_JWT_SECRET` in `.env`
+host/port, token TTLs, body limits, deny-by-default CORS origins,
+route-specific rate-limit strings, and `idempotency_retention_hours` (the
+retention window for cross-transport chat idempotency records, default 48).
+It is canonical nested config with no flat equivalents. The mobile JWT signing secret is `REX_JWT_SECRET` in `.env`
 (minimum 32 characters; the gateway fails closed without it). See
 `docs/mobile/MOBILE_API_SETUP_WINDOWS.md` for setup.
 

--- a/docs/mobile/MOBILE_API_SETUP_WINDOWS.md
+++ b/docs/mobile/MOBILE_API_SETUP_WINDOWS.md
@@ -278,6 +278,12 @@ timeout close `4408`, logout revocation close `4401`, no URL token, and
 same-message HTTP replay with one Assistant execution. The automated test is
 `tests/mobile_api/test_chat_websocket_live.py`.
 
+Close code `4403` (authenticated but forbidden) is **reserved** and has never
+been exercised: the canonical permission model gates tools at dispatch time,
+not chat access, so Session 2 has no real authenticated-but-forbidden
+condition and no server code path emits 4403. Clients still handle it
+defensively (no automatic reconnect).
+
 `python -m pytest -q tests/mobile_api` passed 252 tests. The complete repository
 suite still has unrelated failures reproduced on `master` in time/weather,
 workflow, and the generated coverage-report meta test. Physical-iPhone and LAN

--- a/docs/mobile/MOBILE_API_SETUP_WINDOWS.md
+++ b/docs/mobile/MOBILE_API_SETUP_WINDOWS.md
@@ -1,13 +1,25 @@
 # Mobile API Gateway — Windows Setup and Troubleshooting
 
-This guide covers running the AskRex mobile API gateway (Session 1: foundation
-and authentication) on Windows 10/11 with PowerShell.
+This guide covers running the AskRex mobile API gateway on Windows 10/11 with
+PowerShell.
 
-The gateway serves `/mobile/*` only. Chat, streaming, WebSocket, voice, TTS,
+The gateway serves `/mobile/*` only. Session 1 delivered authentication
+(login, rotating refresh sessions, logout, session restore). Session 2 adds
+authenticated chat (`POST /mobile/chat`), SSE streaming
+(`POST /mobile/chat/stream`), WebSocket chat
+(`WebSocket /mobile/chat/stream`, first-frame `auth`), voice upload
+(`POST /mobile/voice/upload`), and protected TTS
+(`POST /mobile/tts/playback`), all sharing one server-side
+`(user_id, message_id)` idempotency store so a retried or replayed message
+never executes twice.
+
 Home Assistant, notifications, approvals, tasks, workflows, audit-log, and
-settings routes exist as explicit HTTP 501 `NOT_IMPLEMENTED` scaffolds and are
+settings routes remain explicit HTTP 501 `NOT_IMPLEMENTED` scaffolds and are
 reported as `false` in `/mobile/capabilities` until they are really
-implemented.
+implemented. `live_voice` (real-time duplex audio) is not implemented and
+stays `false`. Voice and TTS capabilities are runtime-aware: they report
+`true` only when their dependencies (Whisper + ffmpeg + a downloaded model;
+the configured TTS engine) are actually available.
 
 ## 1. Prerequisites
 
@@ -67,7 +79,8 @@ group. All values below are the defaults; add only what you need to change:
     "rate_limit_login": "10 per minute",
     "rate_limit_refresh": "30 per minute",
     "rate_limit_chat": "30 per minute",
-    "rate_limit_voice": "10 per minute"
+    "rate_limit_voice": "10 per minute",
+    "idempotency_retention_hours": 48
   }
 }
 ```
@@ -169,6 +182,49 @@ Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8765/mobile/auth/logout `
   -Headers @{ Authorization = "Bearer $($refresh.access_token)" }
 ```
 
+Chat (non-streaming; `message_id`/`conversation_id` are client-generated
+UUIDs and double as the idempotency key — resending the exact same request
+replays the stored result without re-executing):
+
+```powershell
+$chat = @{
+  message_id      = [guid]::NewGuid().ToString()
+  conversation_id = [guid]::NewGuid().ToString()
+  sent_at         = (Get-Date).ToUniversalTime().ToString("o")
+  message         = "Hello Rex"
+  mode            = "mobile_text"
+} | ConvertTo-Json
+Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8765/mobile/chat `
+  -ContentType "application/json" -Body $chat `
+  -Headers @{ Authorization = "Bearer $($login.access_token)" }
+```
+
+SSE streaming uses the same body against `POST /mobile/chat/stream` and
+returns `text/event-stream` frames (`token` events, then one terminal
+`message_done` or `error`). The WebSocket endpoint is
+`ws://127.0.0.1:8765/mobile/chat/stream`; the first frame must be
+`{"type": "auth", "access_token": "<jwt>", "client": {...}}` — tokens never
+go in the URL.
+
+TTS (JSON base64 audio; text is never placed in a query string):
+
+```powershell
+$tts = Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8765/mobile/tts/playback `
+  -ContentType "application/json" -Body (@{ text = "Hello from Rex." } | ConvertTo-Json) `
+  -Headers @{ Authorization = "Bearer $($login.access_token)" }
+[IO.File]::WriteAllBytes("rex-tts-sample.wav", [Convert]::FromBase64String($tts.audio_base64))
+```
+
+Voice upload (multipart; the file's actual bytes are validated — M4A/MP4,
+AAC, MP3, or WAV — and must decode successfully; limits are 15 MiB and 60
+seconds):
+
+```powershell
+curl.exe -X POST http://127.0.0.1:8765/mobile/voice/upload `
+  -H "Authorization: Bearer $($login.access_token)" `
+  -F "audio=@recording.m4a" -F "mode=mobile_voice"
+```
+
 ## 8. Troubleshooting
 
 | Symptom | Cause / fix |
@@ -181,6 +237,11 @@ Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8765/mobile/auth/logout `
 | `401 AUTH_TOKEN_EXPIRED` | The access token passed its 15-minute lifetime — refresh, or the refresh token passed its 30-day lifetime — log in again. |
 | `429 RATE_LIMITED` | Too many requests; wait for the `Retry-After` seconds in the response. |
 | `501 NOT_IMPLEMENTED` | The route is a truthful scaffold — that feature is not built yet (see `/mobile/capabilities`). |
+| `409 IDEMPOTENCY_CONFLICT` | The same `message_id` was reused with a different message body, or the `Idempotency-Key` header does not match the JSON `message_id`. Send a new message ID. |
+| `409 REQUEST_IN_PROGRESS` | The same message is still executing (e.g. a retry raced the original delivery). Wait for the original result; it is replayed for the same ID once complete. |
+| `503 BACKEND_UNAVAILABLE` on `/mobile/voice/upload` | Whisper, ffmpeg, or the configured Whisper model is not available locally. Models are never downloaded during a request — install/download them first (`pip install -r requirements-cpu.txt`, ffmpeg on PATH, then run any local STT once to fetch the model). |
+| `503 BACKEND_UNAVAILABLE` on `/mobile/tts/playback` | The configured TTS engine (`config.voice.tts_engine`) is not installed or failed/timed out. `/mobile/capabilities` reports the current truth. |
+| `415 INVALID_MEDIA` on voice upload | The uploaded bytes are not a supported container (M4A/MP4, AAC, MP3, WAV) or could not be decoded. The filename and declared MIME type are ignored — only real content counts. |
 | Phone cannot reach the server | Confirm the server is bound to `0.0.0.0`, the firewall rule targets the Private profile and correct port, both devices share the same network, and the phone uses `http://<PC-LAN-IP>:8765`. |
 | `port ... in use` | Another process owns the port. Pick another port with `--port`. |
 

--- a/docs/mobile/MOBILE_API_SETUP_WINDOWS.md
+++ b/docs/mobile/MOBILE_API_SETUP_WINDOWS.md
@@ -215,6 +215,9 @@ $tts = Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8765/mobile/tts/play
 [IO.File]::WriteAllBytes("rex-tts-sample.wav", [Convert]::FromBase64String($tts.audio_base64))
 ```
 
+The response `voice` is the concrete provider voice that produced the audio;
+`requested_voice` preserves the caller's request (`default` when omitted).
+
 Voice upload (multipart; the file's actual bytes are validated — M4A/MP4,
 AAC, MP3, or WAV — and must decode successfully; limits are 15 MiB and 60
 seconds):
@@ -265,3 +268,17 @@ status → capabilities → login → invalid login → session → refresh →
 refresh-reuse (family revoked) → scaffold 501 → logout → revoked session.
 Physical-iPhone and LAN validation have **not** been performed in Session 1
 and remain tracked under issue #323.
+
+## Validation record (Session 2 correction pass)
+
+Windows 11 / Python 3.11 loopback validation exercised an actual
+Flask-Sock/simple-websocket upgrade and verified first-frame authentication,
+ack/token/message_done delivery, invalid-token close `4401`, observable auth
+timeout close `4408`, logout revocation close `4401`, no URL token, and
+same-message HTTP replay with one Assistant execution. The automated test is
+`tests/mobile_api/test_chat_websocket_live.py`.
+
+`python -m pytest -q tests/mobile_api` passed 252 tests. The complete repository
+suite still has unrelated failures reproduced on `master` in time/weather,
+workflow, and the generated coverage-report meta test. Physical-iPhone and LAN
+validation remain not run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "flask>=3.1.3",      # CVE-2026-27205 fixed in 3.1.3
     "flask-cors>=6.0.0", # CVE-2024-6839, CVE-2024-6844, CVE-2024-6866 fixed in 6.0.0
     "flask-limiter>=3.5.0",
+    "flask-sock>=0.7.0",  # mobile WebSocket chat (issue #323); pure-Python, validated on Windows/Py3.11
     "requests>=2.32.0",  # CVE-2024-35195 fixed in 2.32.0
 
     # Configuration & Validation
@@ -386,6 +387,7 @@ module = [
   "flask_cors",
   "flask_limiter",
   "flask_limiter.*",
+  "flask_sock",
   "playsound",
   "pytest",
   "setuptools",

--- a/rex/config.py
+++ b/rex/config.py
@@ -265,6 +265,9 @@ class MobileApiConfig(BaseModel):
     rate_limit_refresh: str = "30 per minute"
     rate_limit_chat: str = "30 per minute"
     rate_limit_voice: str = "10 per minute"
+    # Retention window for the cross-transport (user_id, message_id)
+    # idempotency records; must cover realistic reconnect/retry behaviour.
+    idempotency_retention_hours: int = 48
 
     @field_validator("host", "api_version")
     @classmethod
@@ -287,6 +290,7 @@ class MobileApiConfig(BaseModel):
         "max_json_bytes",
         "max_audio_bytes",
         "max_audio_seconds",
+        "idempotency_retention_hours",
     )
     @classmethod
     def _positive(cls, value: int) -> int:

--- a/rex/mobile_api/app.py
+++ b/rex/mobile_api/app.py
@@ -163,6 +163,7 @@ def create_mobile_app(
     # WebSocket /mobile/chat/stream — registered only when the validated
     # Flask-Sock stack is installed; the capability stays false otherwise.
     ws_registered = register_websocket(app, services)
+    services.websocket_registered = ws_registered
 
     logger.info(
         "Mobile API app created (api_version=%s, websocket=%s)",

--- a/rex/mobile_api/app.py
+++ b/rex/mobile_api/app.py
@@ -28,10 +28,13 @@ from rex.mobile_api.db import migrate_users_db
 from rex.mobile_api.errors import install_mobile_error_handlers
 from rex.mobile_api.routes import (
     build_auth_blueprint,
+    build_chat_blueprint,
     build_scaffolds_blueprint,
     build_status_blueprint,
+    build_voice_blueprint,
 )
 from rex.mobile_api.services import MobileApiServices
+from rex.mobile_api.websocket import register_websocket
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +129,10 @@ def create_mobile_app(
     migrate_users_db(services.db_path)
 
     app = Flask("rex_mobile_api")
-    app.config["MAX_CONTENT_LENGTH"] = cfg.max_json_bytes
+    # The transport-level cap must admit multipart voice uploads (15 MiB by
+    # default); JSON routes enforce the tighter ``max_json_bytes`` limit in
+    # ``parse_json_body`` before any parsing work.
+    app.config["MAX_CONTENT_LENGTH"] = max(cfg.max_json_bytes, cfg.max_audio_bytes + 128 * 1024)
     app.extensions["mobile_api_services"] = services
 
     # Reused canonical middleware: assigns g.request_id before authentication
@@ -150,9 +156,19 @@ def create_mobile_app(
 
     app.register_blueprint(build_status_blueprint(services))
     app.register_blueprint(build_auth_blueprint(services, limiter))
+    app.register_blueprint(build_chat_blueprint(services, limiter))
+    app.register_blueprint(build_voice_blueprint(services, limiter))
     app.register_blueprint(build_scaffolds_blueprint(services))
 
-    logger.info("Mobile API app created (api_version=%s)", cfg.api_version)
+    # WebSocket /mobile/chat/stream — registered only when the validated
+    # Flask-Sock stack is installed; the capability stays false otherwise.
+    ws_registered = register_websocket(app, services)
+
+    logger.info(
+        "Mobile API app created (api_version=%s, websocket=%s)",
+        cfg.api_version,
+        "on" if ws_registered else "off",
+    )
     return app
 
 

--- a/rex/mobile_api/auth.py
+++ b/rex/mobile_api/auth.py
@@ -153,6 +153,23 @@ def authenticate_request(
         MobileApiError: On any validation failure (fails closed).
     """
     token = _bearer_token_from_request()
+    return authenticate_token(services, token, allow_revoked_session=allow_revoked_session)
+
+
+def authenticate_token(
+    services: MobileApiServices, token: str, *, allow_revoked_session: bool = False
+) -> MobilePrincipal:
+    """Validate an access token and return the request principal.
+
+    Shared by the HTTP Bearer path and the WebSocket first-frame ``auth``
+    path so both transports apply identical validation: signature/algorithm,
+    issuer, audience, time claims, required claims, canonical ``sub``
+    (before any private lookup), session existence/ownership/status, and
+    user existence/active status.  Fails closed on any mismatch.
+
+    Raises:
+        MobileApiError: On any validation failure.
+    """
     claims = decode_access_token(token, services.jwt_secret)
 
     # Canonical identity validation BEFORE any private lookup.
@@ -241,6 +258,7 @@ __all__ = [
     "MobileAuthConfigurationError",
     "MobilePrincipal",
     "authenticate_request",
+    "authenticate_token",
     "decode_access_token",
     "issue_access_token",
     "load_jwt_secret",

--- a/rex/mobile_api/capabilities.py
+++ b/rex/mobile_api/capabilities.py
@@ -1,19 +1,34 @@
-"""Truthful mobile capability reporting (issue #323, Session 1).
+"""Truthful mobile capability reporting (issue #323).
 
-A feature is ``true`` only when its real backend path and automated tests
-exist.  Configuration alone never makes a capability true, and the response
-must never expose secrets, file paths, model paths, account IDs, usernames,
-or integration tokens.
+A feature is ``true`` only when its real backend path exists, its focused
+automated tests exist, and its required runtime dependencies are available
+right now.  Configuration alone never makes a capability true, and the
+response must never expose secrets, file paths, model paths, account IDs,
+usernames, or integration tokens.
 
-Session 1 implements authentication only; every runtime feature stays false
-until Session 2 lands its real implementation.
+Session 2 implements chat (HTTP), SSE streaming, WebSocket chat, voice
+upload, and TTS.  ``chat``/``chat_streaming`` are code-complete and tested;
+``websocket_chat`` additionally requires the validated Flask-Sock stack;
+``voice_upload`` requires Whisper + ffmpeg + a locally cached model;
+``tts`` requires the configured engine's dependency.
+
+``live_voice``, ``notifications``, ``approvals``, and ``home_assistant``
+remain false: their complete server-authoritative mobile paths are not
+implemented.  A configured Home Assistant integration alone does not make
+the mobile ``home_assistant`` capability true.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import TYPE_CHECKING, Any
 
 from rex.config import MobileApiConfig
+
+if TYPE_CHECKING:
+    from rex.mobile_api.services import MobileApiServices
+
+logger = logging.getLogger(__name__)
 
 MINIMUM_APP_VERSION = "0.1.0"
 
@@ -28,20 +43,46 @@ def server_version() -> str:
         return "unknown"
 
 
-def resolve_features() -> dict[str, bool]:
-    """Return the truthful feature map for the current build.
+def _chat_available() -> bool:
+    """True when the canonical Assistant code path is importable."""
+    try:
+        from importlib.util import find_spec  # noqa: PLC0415
 
-    Session 1: authentication is implemented and tested; chat, streaming,
-    WebSocket, voice, TTS, live voice, notifications, approvals, and Home
-    Assistant are explicit 501 scaffolds and therefore false.
+        return find_spec("rex.assistant") is not None
+    except Exception:  # pragma: no cover - importlib edge cases
+        return False
+
+
+def resolve_features(services: MobileApiServices | None = None) -> dict[str, bool]:
+    """Return the truthful feature map for the current build and runtime.
+
+    ``services`` provides the runtime adapters whose dependency checks make
+    voice/TTS truthful; without it (bare config contexts) those features are
+    reported false rather than guessed.
     """
+    from rex.mobile_api.websocket import websocket_dependency_available  # noqa: PLC0415
+
+    chat = _chat_available()
+    voice_upload = False
+    tts = False
+    if services is not None:
+        try:
+            voice_upload = services.stt.availability()[0]
+        except Exception:  # pragma: no cover - adapter failure means false
+            logger.warning("Voice capability check failed", exc_info=True)
+        try:
+            tts = services.tts.availability()[0]
+        except Exception:  # pragma: no cover - adapter failure means false
+            logger.warning("TTS capability check failed", exc_info=True)
+
     return {
         "authentication": True,
-        "chat": False,
-        "chat_streaming": False,
-        "websocket_chat": False,
-        "voice_upload": False,
-        "tts": False,
+        "chat": chat,
+        "chat_streaming": chat,
+        "websocket_chat": chat and websocket_dependency_available(),
+        "voice_upload": chat and voice_upload,
+        "tts": tts,
+        # Not implemented as complete server-authoritative mobile paths:
         "live_voice": False,
         "notifications": False,
         "approvals": False,
@@ -49,13 +90,15 @@ def resolve_features() -> dict[str, bool]:
     }
 
 
-def capabilities_payload(config: MobileApiConfig) -> dict[str, Any]:
+def capabilities_payload(
+    config: MobileApiConfig, services: MobileApiServices | None = None
+) -> dict[str, Any]:
     """Build the ``GET /mobile/capabilities`` response body."""
     return {
         "api_version": config.api_version,
         "minimum_app_version": MINIMUM_APP_VERSION,
         "server_version": server_version(),
-        "features": resolve_features(),
+        "features": resolve_features(services),
     }
 
 

--- a/rex/mobile_api/capabilities.py
+++ b/rex/mobile_api/capabilities.py
@@ -43,16 +43,6 @@ def server_version() -> str:
         return "unknown"
 
 
-def _chat_available() -> bool:
-    """True when the canonical Assistant code path is importable."""
-    try:
-        from importlib.util import find_spec  # noqa: PLC0415
-
-        return find_spec("rex.assistant") is not None
-    except Exception:  # pragma: no cover - importlib edge cases
-        return False
-
-
 def resolve_features(services: MobileApiServices | None = None) -> dict[str, bool]:
     """Return the truthful feature map for the current build and runtime.
 
@@ -60,12 +50,14 @@ def resolve_features(services: MobileApiServices | None = None) -> dict[str, boo
     voice/TTS truthful; without it (bare config contexts) those features are
     reported false rather than guessed.
     """
-    from rex.mobile_api.websocket import websocket_dependency_available  # noqa: PLC0415
-
-    chat = _chat_available()
+    chat = False
     voice_upload = False
     tts = False
     if services is not None:
+        try:
+            chat = services.chat_service.availability()[0]
+        except Exception:  # adapter/configuration failure means false
+            logger.warning("Chat capability check failed", exc_info=True)
         try:
             voice_upload = services.stt.availability()[0]
         except Exception:  # pragma: no cover - adapter failure means false
@@ -79,7 +71,7 @@ def resolve_features(services: MobileApiServices | None = None) -> dict[str, boo
         "authentication": True,
         "chat": chat,
         "chat_streaming": chat,
-        "websocket_chat": chat and websocket_dependency_available(),
+        "websocket_chat": chat and bool(services and services.websocket_registered),
         "voice_upload": chat and voice_upload,
         "tts": tts,
         # Not implemented as complete server-authoritative mobile paths:

--- a/rex/mobile_api/chat.py
+++ b/rex/mobile_api/chat.py
@@ -1,0 +1,124 @@
+"""Canonical Assistant adapter for the mobile gateway (issue #323, Session 2).
+
+``MobileChatService`` is the only place mobile transports touch the Rex
+runtime.  It:
+
+- lazily builds one process-level *unbound* ``Assistant`` (issue #303: no
+  implicit identity; construction performs no user-scoped reads/writes);
+- passes the validated request identity explicitly as ``active_user_id`` to
+  ``Assistant.generate_reply()`` / ``Assistant.stream_reply()`` on every
+  call — it never mutates a shared current user;
+- never calls ``LanguageModel`` directly (the GUI direct-LLM helper is an
+  explicitly documented anti-pattern for this gateway);
+- translates runtime failures into truthful structured errors
+  (``BACKEND_UNAVAILABLE``) — never a mock reply.
+
+Ordinary conversational output is ``completed``; ``verified`` is reserved
+for real completion evidence, which this adapter never fabricates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from collections.abc import Callable, Iterator
+from typing import Any
+
+from rex.mobile_api import errors as merr
+from rex.mobile_api.errors import MobileApiError
+
+logger = logging.getLogger(__name__)
+
+# Canonical completion status for a normal conversational reply.
+STATUS_COMPLETED = "completed"
+
+
+def _default_assistant_factory() -> Any:
+    """Build the canonical unbound Assistant (no implicit identity)."""
+    from rex.assistant import Assistant  # noqa: PLC0415 - heavy import on demand
+
+    return Assistant()
+
+
+def _backend_unavailable(exc: Exception) -> MobileApiError:
+    # The client receives a generic truthful failure; details go to the
+    # server log only (never a mock reply, never internal text on the wire).
+    return MobileApiError(
+        merr.BACKEND_UNAVAILABLE,
+        "Rex is temporarily unavailable.",
+        503,
+        retryable=True,
+    )
+
+
+class MobileChatService:
+    """Thread-safe adapter from mobile transports to the canonical Assistant."""
+
+    def __init__(self, assistant_factory: Callable[[], Any] | None = None) -> None:
+        self._assistant_factory = assistant_factory or _default_assistant_factory
+        self._assistant: Any = None
+        self._init_lock = threading.Lock()
+
+    def _get_assistant(self) -> Any:
+        if self._assistant is not None:
+            return self._assistant
+        with self._init_lock:
+            if self._assistant is None:
+                try:
+                    self._assistant = self._assistant_factory()
+                except Exception as exc:
+                    logger.error("Mobile chat Assistant initialization failed: %s", exc)
+                    raise _backend_unavailable(exc) from exc
+        return self._assistant
+
+    def generate(self, message: str, *, user_id: str, voice_mode: bool = False) -> str:
+        """Return one complete reply for ``user_id`` via the canonical Assistant."""
+        assistant = self._get_assistant()
+        try:
+            return str(
+                asyncio.run(
+                    assistant.generate_reply(message, voice_mode=voice_mode, active_user_id=user_id)
+                )
+            )
+        except MobileApiError:
+            raise
+        except Exception as exc:
+            logger.error("Mobile chat generate_reply failed: %s", exc)
+            raise _backend_unavailable(exc) from exc
+
+    def stream(self, message: str, *, user_id: str) -> Iterator[str]:
+        """Yield reply chunks for ``user_id`` via ``Assistant.stream_reply()``.
+
+        Bridges the async generator onto a private event loop owned by the
+        calling (request) thread.  Any runtime failure surfaces as a
+        structured ``BACKEND_UNAVAILABLE`` error for the transport to emit
+        as a terminal error event.
+        """
+        assistant = self._get_assistant()
+        loop = asyncio.new_event_loop()
+        agen = None
+        try:
+            agen = assistant.stream_reply(message, active_user_id=user_id)
+            while True:
+                try:
+                    chunk = loop.run_until_complete(agen.__anext__())
+                except StopAsyncIteration:
+                    break
+                except MobileApiError:
+                    raise
+                except Exception as exc:
+                    logger.error("Mobile chat stream_reply failed: %s", exc)
+                    raise _backend_unavailable(exc) from exc
+                if chunk:
+                    yield str(chunk)
+        finally:
+            if agen is not None:
+                try:
+                    loop.run_until_complete(agen.aclose())
+                except Exception:  # pragma: no cover - close-time cleanup
+                    logger.debug("Mobile chat stream close failed", exc_info=True)
+            loop.close()
+
+
+__all__ = ["STATUS_COMPLETED", "MobileChatService"]

--- a/rex/mobile_api/chat.py
+++ b/rex/mobile_api/chat.py
@@ -21,8 +21,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 from collections.abc import Callable, Iterator
+from importlib.util import find_spec
+from pathlib import Path
 from typing import Any
 
 from rex.mobile_api import errors as merr
@@ -59,6 +62,52 @@ class MobileChatService:
         self._assistant_factory = assistant_factory or _default_assistant_factory
         self._assistant: Any = None
         self._init_lock = threading.Lock()
+
+    def availability(self) -> tuple[bool, str]:
+        """Check configured LLM prerequisites without loading a model or making a request."""
+        try:
+            from rex.config import settings  # noqa: PLC0415
+
+            provider = str(settings.llm_provider).strip().lower()
+            model = str(settings.llm_model or "").strip()
+            if not model:
+                return False, "no LLM model configured"
+            if provider == "openai":
+                ready = (
+                    find_spec("openai") is not None
+                    and bool(settings.openai_api_key or os.getenv("OPENAI_API_KEY"))
+                    and bool(settings.openai_model)
+                )
+                return (ready, "ok" if ready else "OpenAI is not fully configured")
+            if provider == "anthropic":
+                ready = (
+                    find_spec("anthropic") is not None
+                    and bool(settings.anthropic_api_key or os.getenv("ANTHROPIC_API_KEY"))
+                    and bool(settings.anthropic_model)
+                )
+                return (ready, "ok" if ready else "Anthropic is not fully configured")
+            if provider == "ollama":
+                # A configured URL/package cannot prove that the requested local model exists.
+                return False, "Ollama model readiness is not locally proven"
+            if provider == "transformers":
+                if find_spec("torch") is None or find_spec("transformers") is None:
+                    return False, "transformers runtime is not installed"
+                path = Path(model)
+                if path.exists():
+                    return True, "ok"
+                try:
+                    from transformers.utils.hub import try_to_load_from_cache  # noqa: PLC0415
+
+                    cached = try_to_load_from_cache(model, "config.json")
+                    ready = isinstance(cached, str) and Path(cached).is_file()
+                    return (ready, "ok" if ready else "transformers model is not cached")
+                except Exception:
+                    return False, "transformers model readiness check failed"
+            if provider == "echo":
+                return True, "ok"
+            return False, f"unsupported LLM provider '{provider}'"
+        except Exception:
+            return False, "LLM configuration is unavailable"
 
     def _get_assistant(self) -> Any:
         if self._assistant is not None:

--- a/rex/mobile_api/db.py
+++ b/rex/mobile_api/db.py
@@ -118,6 +118,24 @@ def migrate_users_db(db_path: Path | str) -> None:
             CREATE INDEX IF NOT EXISTS idx_mobile_refresh_family
             ON mobile_refresh_tokens(family_id)
             """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS mobile_message_requests (
+                user_id TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                conversation_id TEXT NOT NULL,
+                request_hash TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                response_json TEXT NULL,
+                error_code TEXT NULL,
+                PRIMARY KEY (user_id, message_id)
+            )
+            """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_mobile_message_requests_created
+            ON mobile_message_requests(created_at)
+            """)
         conn.execute("COMMIT")
     except BaseException:
         try:

--- a/rex/mobile_api/errors.py
+++ b/rex/mobile_api/errors.py
@@ -37,6 +37,11 @@ PERMISSION_DENIED = "PERMISSION_DENIED"
 APPROVAL_REQUIRED = "APPROVAL_REQUIRED"
 NOT_FOUND = "NOT_FOUND"
 NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
+# Cross-transport idempotency (issue #323 Session 2): a reused message ID
+# with a different semantic payload conflicts; a duplicate of a request that
+# is still executing is reported without re-execution.
+IDEMPOTENCY_CONFLICT = "IDEMPOTENCY_CONFLICT"
+REQUEST_IN_PROGRESS = "REQUEST_IN_PROGRESS"
 UNSUPPORTED_API_VERSION = "UNSUPPORTED_API_VERSION"
 INVALID_MEDIA = "INVALID_MEDIA"
 PAYLOAD_TOO_LARGE = "PAYLOAD_TOO_LARGE"
@@ -150,6 +155,7 @@ __all__ = [
     "BACKEND_UNAVAILABLE",
     "BAD_REQUEST",
     "FORBIDDEN",
+    "IDEMPOTENCY_CONFLICT",
     "INTERNAL_ERROR",
     "INVALID_MEDIA",
     "MobileApiError",
@@ -158,6 +164,7 @@ __all__ = [
     "PAYLOAD_TOO_LARGE",
     "PERMISSION_DENIED",
     "RATE_LIMITED",
+    "REQUEST_IN_PROGRESS",
     "UNSUPPORTED_API_VERSION",
     "install_mobile_error_handlers",
     "mobile_error_response",

--- a/rex/mobile_api/events.py
+++ b/rex/mobile_api/events.py
@@ -1,0 +1,121 @@
+"""Canonical mobile streaming events (issue #323, Session 2).
+
+One builder per canonical event type, shared by the SSE and WebSocket
+transports so the wire grammar cannot drift between them.  Every wire field
+is ``snake_case`` and every payload is valid JSON — malformed internal data
+is never emitted as assistant prose.
+
+Truthfulness: events are only emitted from real runtime boundaries.  The
+current Assistant streaming surface exposes text tokens and a terminal
+completion; ``tool_call`` / ``tool_result`` / ``approval_required`` builders
+exist for the documented contract but the backend emits them only when the
+corresponding real action boundary produces them — never by parsing
+generated prose.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Canonical event type names (wire contract).
+EVENT_AUTH_OK = "auth_ok"
+EVENT_AUTH_ERROR = "auth_error"
+EVENT_ACK = "ack"
+EVENT_TOKEN = "token"
+EVENT_TOOL_CALL = "tool_call"
+EVENT_TOOL_RESULT = "tool_result"
+EVENT_APPROVAL_REQUIRED = "approval_required"
+EVENT_MESSAGE_DONE = "message_done"
+EVENT_ERROR = "error"
+EVENT_PING = "ping"
+EVENT_PONG = "pong"
+
+
+def token_event(message_id: str, content: str) -> dict[str, Any]:
+    return {"type": EVENT_TOKEN, "message_id": message_id, "content": content}
+
+
+def message_done_event(
+    message_id: str,
+    conversation_id: str,
+    full_content: str,
+    status: str = "completed",
+) -> dict[str, Any]:
+    return {
+        "type": EVENT_MESSAGE_DONE,
+        "message_id": message_id,
+        "conversation_id": conversation_id,
+        "full_content": full_content,
+        "status": status,
+    }
+
+
+def error_event(
+    code: str,
+    message: str,
+    *,
+    message_id: str | None = None,
+    retryable: bool = False,
+    request_id: str | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "type": EVENT_ERROR,
+        "code": code,
+        "message": message,
+        "retryable": retryable,
+        "request_id": request_id,
+    }
+    if message_id is not None:
+        event["message_id"] = message_id
+    return event
+
+
+def ack_event(message_id: str, accepted_at: str) -> dict[str, Any]:
+    return {"type": EVENT_ACK, "message_id": message_id, "accepted_at": accepted_at}
+
+
+def auth_ok_event(session_id: str, user: dict[str, Any]) -> dict[str, Any]:
+    return {"type": EVENT_AUTH_OK, "session_id": session_id, "user": user}
+
+
+def auth_error_event(code: str, message: str) -> dict[str, Any]:
+    return {"type": EVENT_AUTH_ERROR, "code": code, "message": message}
+
+
+def pong_event(sent_at: str) -> dict[str, Any]:
+    return {"type": EVENT_PONG, "sent_at": sent_at}
+
+
+def encode_event(event: dict[str, Any]) -> str:
+    """Serialize an event to canonical JSON (one line, no NaN)."""
+    return json.dumps(event, ensure_ascii=True, allow_nan=False, separators=(",", ":"))
+
+
+def format_sse(event: dict[str, Any]) -> str:
+    """Format an event as one Server-Sent Events ``data:`` frame."""
+    return f"data: {encode_event(event)}\n\n"
+
+
+__all__ = [
+    "EVENT_ACK",
+    "EVENT_APPROVAL_REQUIRED",
+    "EVENT_AUTH_ERROR",
+    "EVENT_AUTH_OK",
+    "EVENT_ERROR",
+    "EVENT_MESSAGE_DONE",
+    "EVENT_PING",
+    "EVENT_PONG",
+    "EVENT_TOKEN",
+    "EVENT_TOOL_CALL",
+    "EVENT_TOOL_RESULT",
+    "ack_event",
+    "auth_error_event",
+    "auth_ok_event",
+    "encode_event",
+    "error_event",
+    "format_sse",
+    "message_done_event",
+    "pong_event",
+    "token_event",
+]

--- a/rex/mobile_api/idempotency.py
+++ b/rex/mobile_api/idempotency.py
@@ -1,0 +1,298 @@
+"""Cross-transport chat idempotency (issue #323, Session 2).
+
+HTTP, SSE, and WebSocket chat share one durable reservation store keyed by
+``(user_id, message_id)`` in the canonical users database
+(``mobile_message_requests``).  The reservation is inserted *before* any
+acknowledgement or Assistant/tool execution, so a retried or replayed
+message ID can never execute twice — regardless of which transport carried
+the retry.
+
+Semantics:
+
+- A new ``(user_id, message_id)`` is reserved atomically (``BEGIN
+  IMMEDIATE`` + ``INSERT``); exactly one concurrent caller wins.
+- An exact duplicate (same deterministic request hash) of a *completed*
+  request replays the stored terminal result without executing anything.
+- An exact duplicate of a *failed* request replays the stored error code —
+  clients retry a genuinely new attempt with a new message ID.
+- An exact duplicate of a request that is *still processing* is reported as
+  in progress and never starts a second execution.
+- The same message ID with a *different* request hash is a conflict and
+  never executes.
+- The same message ID from a different user is an independent request.
+
+The request hash covers only semantic execution fields (message text, IDs,
+mode, timestamp, client context) — never transport artifacts, tokens, or
+headers.  Stored rows contain the terminal response body (which the client
+already received) and never tokens, passwords, or credentials.
+
+Retention: rows older than ``mobile_api.idempotency_retention_hours``
+(default 48h) are pruned opportunistically on reservation; the window is
+deliberately longer than any realistic reconnect/retry cycle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from rex.identity import validate_user_id
+from rex.mobile_api.db import connect
+
+logger = logging.getLogger(__name__)
+
+# Reservation outcomes.
+RESERVED = "reserved"
+DUPLICATE_PROCESSING = "duplicate_processing"
+DUPLICATE_COMPLETED = "duplicate_completed"
+DUPLICATE_FAILED = "duplicate_failed"
+CONFLICT = "conflict"
+
+# Row statuses.
+STATUS_PROCESSING = "processing"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+
+# Error code recorded when a streaming client disconnected before the
+# terminal event.  Stored (not a wire code) so a replay of the same message
+# ID reports the terminal failure instead of executing tools twice.
+CLIENT_DISCONNECTED = "CLIENT_DISCONNECTED"
+
+# Semantic execution fields included in the deterministic request hash.
+_HASH_FIELDS = (
+    "message_id",
+    "conversation_id",
+    "sent_at",
+    "message",
+    "mode",
+    "client_context",
+)
+
+
+def compute_request_hash(payload: Mapping[str, Any]) -> str:
+    """Return the deterministic hash of a chat request's semantic fields.
+
+    Only fields that influence execution are included; transport-only
+    artifacts (headers, frame types, tokens) never are.  A replayed message
+    must carry the exact original semantic payload to be treated as the
+    same request.
+    """
+    canonical = {name: payload.get(name) for name in _HASH_FIELDS}
+    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class Reservation:
+    """Outcome of a reservation attempt for ``(user_id, message_id)``."""
+
+    outcome: str
+    status: str | None = None
+    response_json: str | None = None
+    error_code: str | None = None
+
+    @property
+    def is_new(self) -> bool:
+        return self.outcome == RESERVED
+
+
+def _default_clock() -> datetime:
+    return datetime.now(UTC)
+
+
+class MobileMessageStore:
+    """SQLite-backed shared idempotency store for mobile chat requests."""
+
+    def __init__(
+        self,
+        db_path: Path | str,
+        *,
+        retention_hours: int = 48,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._db_path = Path(db_path)
+        self._retention = timedelta(hours=retention_hours)
+        self._clock = clock or _default_clock
+
+    def now(self) -> datetime:
+        return self._clock()
+
+    def _connect(self) -> sqlite3.Connection:
+        return connect(self._db_path)
+
+    # ── Reservation ────────────────────────────────────────────────────
+
+    def reserve(
+        self,
+        user_id: str,
+        message_id: str,
+        conversation_id: str,
+        request_hash: str,
+    ) -> Reservation:
+        """Durably reserve ``(user_id, message_id)`` before any execution.
+
+        Exactly one concurrent caller receives ``RESERVED``; every other
+        caller observes the existing row's state without executing.
+        """
+        user_id = validate_user_id(user_id)
+        now = self.now().isoformat()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT request_hash, status, response_json, error_code "
+                "FROM mobile_message_requests WHERE user_id = ? AND message_id = ?",
+                (user_id, message_id),
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    "INSERT INTO mobile_message_requests "
+                    "(user_id, message_id, conversation_id, request_hash, status, "
+                    " created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        user_id,
+                        message_id,
+                        conversation_id,
+                        request_hash,
+                        STATUS_PROCESSING,
+                        now,
+                        now,
+                    ),
+                )
+                conn.execute("COMMIT")
+                self._prune_expired_safely()
+                return Reservation(outcome=RESERVED, status=STATUS_PROCESSING)
+            conn.execute("COMMIT")
+        except BaseException:
+            self._rollback(conn)
+            raise
+        finally:
+            conn.close()
+
+        if row["request_hash"] != request_hash:
+            return Reservation(outcome=CONFLICT, status=str(row["status"]))
+        status = str(row["status"])
+        if status == STATUS_COMPLETED:
+            return Reservation(
+                outcome=DUPLICATE_COMPLETED,
+                status=status,
+                response_json=row["response_json"],
+            )
+        if status == STATUS_FAILED:
+            return Reservation(
+                outcome=DUPLICATE_FAILED,
+                status=status,
+                error_code=row["error_code"],
+            )
+        return Reservation(outcome=DUPLICATE_PROCESSING, status=status)
+
+    # ── Terminal state ─────────────────────────────────────────────────
+
+    def complete(self, user_id: str, message_id: str, response_json: str) -> None:
+        """Store the terminal successful result for a reserved request."""
+        self._finish(user_id, message_id, STATUS_COMPLETED, response_json, None)
+
+    def fail(self, user_id: str, message_id: str, error_code: str) -> None:
+        """Store the terminal failure code for a reserved request."""
+        self._finish(user_id, message_id, STATUS_FAILED, None, error_code)
+
+    def _finish(
+        self,
+        user_id: str,
+        message_id: str,
+        status: str,
+        response_json: str | None,
+        error_code: str | None,
+    ) -> None:
+        user_id = validate_user_id(user_id)
+        now = self.now().isoformat()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "UPDATE mobile_message_requests "
+                "SET status = ?, response_json = ?, error_code = ?, updated_at = ? "
+                "WHERE user_id = ? AND message_id = ? AND status = ?",
+                (status, response_json, error_code, now, user_id, message_id, STATUS_PROCESSING),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            self._rollback(conn)
+            raise
+        finally:
+            conn.close()
+
+    def get(self, user_id: str, message_id: str) -> sqlite3.Row | None:
+        """Return the stored request row (or None)."""
+        user_id = validate_user_id(user_id)
+        conn = self._connect()
+        try:
+            row: sqlite3.Row | None = conn.execute(
+                "SELECT * FROM mobile_message_requests WHERE user_id = ? AND message_id = ?",
+                (user_id, message_id),
+            ).fetchone()
+            return row
+        finally:
+            conn.close()
+
+    # ── Retention ──────────────────────────────────────────────────────
+
+    def prune_expired(self) -> int:
+        """Delete rows older than the retention window; return count removed.
+
+        Terminal and stale ``processing`` rows (e.g. after a crash) are both
+        removed once older than retention.  Active rows are never touched.
+        """
+        cutoff = (self.now() - self._retention).isoformat()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            cursor = conn.execute(
+                "DELETE FROM mobile_message_requests WHERE created_at < ?",
+                (cutoff,),
+            )
+            conn.execute("COMMIT")
+            return cursor.rowcount
+        except BaseException:
+            self._rollback(conn)
+            raise
+        finally:
+            conn.close()
+
+    def _prune_expired_safely(self) -> None:
+        try:
+            removed = self.prune_expired()
+            if removed:
+                logger.info("Pruned %d expired mobile message request(s)", removed)
+        except sqlite3.Error:  # pragma: no cover - opportunistic housekeeping
+            logger.warning("Mobile idempotency pruning failed", exc_info=True)
+
+    @staticmethod
+    def _rollback(conn: sqlite3.Connection) -> None:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:  # pragma: no cover - already rolled back
+            pass
+
+
+__all__ = [
+    "CLIENT_DISCONNECTED",
+    "CONFLICT",
+    "DUPLICATE_COMPLETED",
+    "DUPLICATE_FAILED",
+    "DUPLICATE_PROCESSING",
+    "RESERVED",
+    "STATUS_COMPLETED",
+    "STATUS_FAILED",
+    "STATUS_PROCESSING",
+    "MobileMessageStore",
+    "Reservation",
+    "compute_request_hash",
+]

--- a/rex/mobile_api/routes/__init__.py
+++ b/rex/mobile_api/routes/__init__.py
@@ -5,11 +5,15 @@ gets independent, injectable views (no module-global request state).
 """
 
 from rex.mobile_api.routes.auth import build_auth_blueprint
+from rex.mobile_api.routes.chat import build_chat_blueprint
 from rex.mobile_api.routes.scaffolds import build_scaffolds_blueprint
 from rex.mobile_api.routes.status import build_status_blueprint
+from rex.mobile_api.routes.voice import build_voice_blueprint
 
 __all__ = [
     "build_auth_blueprint",
+    "build_chat_blueprint",
     "build_scaffolds_blueprint",
     "build_status_blueprint",
+    "build_voice_blueprint",
 ]

--- a/rex/mobile_api/routes/chat.py
+++ b/rex/mobile_api/routes/chat.py
@@ -1,0 +1,265 @@
+"""Authenticated mobile chat routes (issue #323, Session 2).
+
+``POST /mobile/chat``          — non-streaming chat.
+``POST /mobile/chat/stream``   — SSE streaming chat.
+
+Both routes:
+
+- require the Session 1 mobile principal (Bearer access token);
+- reject any client-supplied identity/authorization field;
+- validate ``message_id``/``conversation_id``/``sent_at``/size/mode/context;
+- require a matching ``Idempotency-Key`` header when present;
+- durably reserve ``(user_id, message_id)`` *before* any acknowledgement or
+  Assistant/tool execution (shared with the WebSocket transport);
+- call the canonical ``Assistant`` with an explicit ``active_user_id``;
+- report normal conversational completion as ``completed`` (never
+  ``verified``) and translate backend failure into structured errors.
+
+Duplicate handling (see :mod:`rex.mobile_api.idempotency`): an exact
+completed duplicate replays the stored terminal result; an exact duplicate
+still in progress reports ``REQUEST_IN_PROGRESS`` without re-executing; a
+reused message ID with different semantics returns ``IDEMPOTENCY_CONFLICT``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from flask import Blueprint, Response, g, jsonify, request
+
+from rex.mobile_api import errors as merr
+from rex.mobile_api import events as mev
+from rex.mobile_api import idempotency as idem
+from rex.mobile_api.auth import require_mobile_auth
+from rex.mobile_api.chat import STATUS_COMPLETED
+from rex.mobile_api.errors import MobileApiError
+from rex.mobile_api.services import MobileApiServices
+from rex.mobile_api.validation import ChatRequest, parse_chat_payload, parse_json_body
+
+logger = logging.getLogger(__name__)
+
+CLIENT_DISCONNECTED = idem.CLIENT_DISCONNECTED
+
+_FAILED_REPLAY_STATUS: dict[str, int] = {
+    merr.BACKEND_UNAVAILABLE: 503,
+    merr.BAD_REQUEST: 400,
+    merr.PAYLOAD_TOO_LARGE: 413,
+    merr.INVALID_MEDIA: 415,
+}
+
+
+def _validated_chat_request() -> ChatRequest:
+    payload = parse_json_body()
+    chat_request = parse_chat_payload(payload)
+    header_key = request.headers.get("Idempotency-Key")
+    if header_key is not None and header_key.strip() != chat_request.message_id:
+        raise MobileApiError(
+            merr.IDEMPOTENCY_CONFLICT,
+            "Idempotency-Key header does not match message_id.",
+            409,
+        )
+    return chat_request
+
+
+def _reserve(services: MobileApiServices, user_id: str, req: ChatRequest) -> idem.Reservation:
+    request_hash = idem.compute_request_hash(req.semantic_fields())
+    return services.message_store.reserve(
+        user_id, req.message_id, req.conversation_id, request_hash
+    )
+
+
+def _conflict_error() -> MobileApiError:
+    return MobileApiError(
+        merr.IDEMPOTENCY_CONFLICT,
+        "This message ID was already used with a different request.",
+        409,
+    )
+
+
+def _in_progress_error() -> MobileApiError:
+    return MobileApiError(
+        merr.REQUEST_IN_PROGRESS,
+        "This message is already being processed.",
+        409,
+        retryable=True,
+    )
+
+
+def _failed_replay_error(error_code: str | None) -> MobileApiError:
+    code = error_code or merr.INTERNAL_ERROR
+    status = _FAILED_REPLAY_STATUS.get(code, 500)
+    if code == CLIENT_DISCONNECTED:
+        code, status = merr.INTERNAL_ERROR, 500
+    return MobileApiError(
+        code,
+        "A previous attempt of this message failed. Send a new message ID to retry.",
+        status,
+    )
+
+
+def build_chat_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint:
+    bp = Blueprint("mobile_chat", __name__, url_prefix="/mobile")
+    cfg = services.config
+
+    @bp.post("/chat")
+    @limiter.limit(cfg.rate_limit_chat)
+    @require_mobile_auth
+    def chat() -> Any:
+        principal = g.mobile_principal
+        chat_request = _validated_chat_request()
+        reservation = _reserve(services, principal.user_id, chat_request)
+
+        if reservation.outcome == idem.CONFLICT:
+            raise _conflict_error()
+        if reservation.outcome == idem.DUPLICATE_PROCESSING:
+            raise _in_progress_error()
+        if reservation.outcome == idem.DUPLICATE_FAILED:
+            raise _failed_replay_error(reservation.error_code)
+        if reservation.outcome == idem.DUPLICATE_COMPLETED:
+            # Exact duplicate: replay the stored terminal result, no execution.
+            stored = json.loads(reservation.response_json or "{}")
+            return jsonify(stored), 200
+
+        try:
+            completion = services.chat_service.generate(
+                chat_request.message, user_id=principal.user_id
+            )
+        except MobileApiError as exc:
+            services.message_store.fail(principal.user_id, chat_request.message_id, exc.code)
+            raise
+        except Exception:
+            services.message_store.fail(
+                principal.user_id, chat_request.message_id, merr.INTERNAL_ERROR
+            )
+            raise
+
+        body: dict[str, object] = {
+            "request_id": getattr(g, "request_id", None),
+            "message_id": chat_request.message_id,
+            "conversation_id": chat_request.conversation_id,
+            "response": completion,
+            "status": STATUS_COMPLETED,
+            "events": [],
+        }
+        # Persist the terminal result before responding so a retry replays
+        # exactly what this client received.
+        services.message_store.complete(
+            principal.user_id,
+            chat_request.message_id,
+            json.dumps(body, ensure_ascii=True),
+        )
+        return jsonify(body), 200
+
+    @bp.post("/chat/stream")
+    @limiter.limit(cfg.rate_limit_chat)
+    @require_mobile_auth
+    def chat_stream() -> Any:
+        principal = g.mobile_principal
+        chat_request = _validated_chat_request()
+        request_id = getattr(g, "request_id", None)
+        reservation = _reserve(services, principal.user_id, chat_request)
+
+        if reservation.outcome == idem.CONFLICT:
+            raise _conflict_error()
+        if reservation.outcome == idem.DUPLICATE_PROCESSING:
+            raise _in_progress_error()
+        if reservation.outcome == idem.DUPLICATE_FAILED:
+            raise _failed_replay_error(reservation.error_code)
+        if reservation.outcome == idem.DUPLICATE_COMPLETED:
+            stored = json.loads(reservation.response_json or "{}")
+            replay = mev.message_done_event(
+                chat_request.message_id,
+                chat_request.conversation_id,
+                str(stored.get("response", "")),
+                status=str(stored.get("status", STATUS_COMPLETED)),
+            )
+            return _sse_response(iter([mev.format_sse(replay)]))
+
+        user_id = principal.user_id
+        message_id = chat_request.message_id
+        conversation_id = chat_request.conversation_id
+        message = chat_request.message
+        store = services.message_store
+        chat_service = services.chat_service
+
+        def generate():
+            # No Flask request-context access inside the generator: every
+            # needed value was captured above.
+            collected: list[str] = []
+            finished = False
+            try:
+                try:
+                    for chunk in chat_service.stream(message, user_id=user_id):
+                        collected.append(chunk)
+                        yield mev.format_sse(mev.token_event(message_id, chunk))
+                except MobileApiError as exc:
+                    store.fail(user_id, message_id, exc.code)
+                    finished = True
+                    yield mev.format_sse(
+                        mev.error_event(
+                            exc.code,
+                            exc.message,
+                            message_id=message_id,
+                            retryable=exc.retryable,
+                            request_id=request_id,
+                        )
+                    )
+                    return
+                except Exception:
+                    logger.exception("Mobile SSE stream failed (request_id=%s)", request_id)
+                    store.fail(user_id, message_id, merr.INTERNAL_ERROR)
+                    finished = True
+                    yield mev.format_sse(
+                        mev.error_event(
+                            merr.INTERNAL_ERROR,
+                            "An unexpected error occurred.",
+                            message_id=message_id,
+                            request_id=request_id,
+                        )
+                    )
+                    return
+
+                full_content = "".join(collected)
+                body: dict[str, object] = {
+                    "request_id": request_id,
+                    "message_id": message_id,
+                    "conversation_id": conversation_id,
+                    "response": full_content,
+                    "status": STATUS_COMPLETED,
+                    "events": [],
+                }
+                # Terminal result is stored before message_done is emitted.
+                store.complete(user_id, message_id, json.dumps(body, ensure_ascii=True))
+                finished = True
+                yield mev.format_sse(
+                    mev.message_done_event(
+                        message_id, conversation_id, full_content, status=STATUS_COMPLETED
+                    )
+                )
+            finally:
+                if not finished:
+                    # Client disconnected mid-stream: leave a coherent
+                    # terminal state so a replayed ID never re-executes.
+                    try:
+                        store.fail(user_id, message_id, CLIENT_DISCONNECTED)
+                    except Exception:  # pragma: no cover - cleanup path
+                        logger.warning(
+                            "Failed to record disconnected stream (request_id=%s)",
+                            request_id,
+                        )
+
+        return _sse_response(generate())
+
+    return bp
+
+
+def _sse_response(iterator) -> Response:
+    response = Response(iterator, mimetype="text/event-stream")
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+    return response
+
+
+__all__ = ["CLIENT_DISCONNECTED", "build_chat_blueprint"]

--- a/rex/mobile_api/routes/scaffolds.py
+++ b/rex/mobile_api/routes/scaffolds.py
@@ -17,12 +17,10 @@ from rex.mobile_api.auth import require_mobile_auth
 from rex.mobile_api.errors import MobileApiError
 from rex.mobile_api.services import MobileApiServices
 
-# (rule name, methods, path) — paths from the master spec §6.3–§6.5.
+# (rule name, methods, path) — paths from the master spec §6.5.  Chat,
+# streaming, voice, and TTS graduated to real routes in Session 2 and are
+# registered by their own blueprints.
 _SCAFFOLD_ROUTES: tuple[tuple[str, tuple[str, ...], str], ...] = (
-    ("chat", ("POST",), "/mobile/chat"),
-    ("chat_stream", ("POST",), "/mobile/chat/stream"),
-    ("voice_upload", ("POST",), "/mobile/voice/upload"),
-    ("tts_playback", ("POST",), "/mobile/tts/playback"),
     ("home_entities", ("GET",), "/mobile/home/entities"),
     ("home_command", ("POST",), "/mobile/home/command"),
     ("notifications", ("GET",), "/mobile/notifications"),

--- a/rex/mobile_api/routes/status.py
+++ b/rex/mobile_api/routes/status.py
@@ -31,7 +31,7 @@ def build_status_blueprint(services: MobileApiServices) -> Blueprint:
 
     @bp.get("/capabilities")
     def capabilities() -> Any:
-        return jsonify(capabilities_payload(services.config))
+        return jsonify(capabilities_payload(services.config, services))
 
     return bp
 

--- a/rex/mobile_api/routes/voice.py
+++ b/rex/mobile_api/routes/voice.py
@@ -90,127 +90,118 @@ def _validate_upload_form() -> bytes:
     return bytes(audio_parts[0].read())
 
 
+def _decode_upload(services: MobileApiServices, data: bytes) -> str:
+    cfg = services.config
+    container = sniff_audio_container(data)
+    if container is None:
+        raise MobileApiError(
+            merr.INVALID_MEDIA, "Unsupported audio format. Use M4A/MP4, AAC, MP3, or WAV.", 415
+        )
+    with tempfile.TemporaryDirectory(prefix="rex-mobile-voice-") as tmp_dir:
+        tmp_path = Path(tmp_dir) / f"upload.{container}"
+        tmp_path.write_bytes(data)
+        audio = services.stt.decode(str(tmp_path))
+        duration_seconds = float(len(audio)) / WHISPER_SAMPLE_RATE
+        if duration_seconds > cfg.max_audio_seconds:
+            raise MobileApiError(
+                merr.PAYLOAD_TOO_LARGE,
+                f"Audio is longer than {cfg.max_audio_seconds} seconds.",
+                413,
+            )
+        return services.stt.transcribe(audio)
+
+
+def _add_optional_tts(services: MobileApiServices, body: dict[str, Any]) -> None:
+    response_text = str(body["response"])
+    tts_available, _ = services.tts.availability()
+    if not tts_available or not response_text:
+        return
+    try:
+        voice_id = services.tts.resolve_voice(None)
+        audio_bytes = services.tts.synthesize(response_text, voice_id)
+        body["tts_base64"] = base64.b64encode(audio_bytes).decode("ascii")
+        body["tts_mime_type"] = services.tts.mime_type()
+    except MobileApiError:
+        logger.info("Voice reply TTS unavailable; returning text only")
+
+
+def _handle_voice_upload(services: MobileApiServices) -> Any:
+    cfg = services.config
+    if request.content_length is not None and request.content_length > (
+        cfg.max_audio_bytes + 128 * 1024
+    ):
+        raise MobileApiError(merr.PAYLOAD_TOO_LARGE, "The upload is too large.", 413)
+    services.stt.require_available()
+    data = _validate_upload_form()
+    if not data:
+        raise MobileApiError(merr.INVALID_MEDIA, "The audio file is empty.", 415)
+    if len(data) > cfg.max_audio_bytes:
+        raise MobileApiError(merr.PAYLOAD_TOO_LARGE, "The audio file is too large.", 413)
+    transcript = _decode_upload(services, data)
+    if not transcript:
+        raise MobileApiError(merr.INVALID_MEDIA, "No speech was recognized in the audio.", 415)
+    response_text = services.chat_service.generate(
+        transcript, user_id=g.mobile_principal.user_id, voice_mode=True
+    )
+    body: dict[str, Any] = {
+        "request_id": getattr(g, "request_id", None),
+        "transcript": transcript,
+        "response": response_text,
+        "status": STATUS_COMPLETED,
+        "tool_used": None,
+    }
+    _add_optional_tts(services, body)
+    return jsonify(body), 200
+
+
+def _handle_tts_playback(services: MobileApiServices) -> Any:
+    from rex.mobile_api.validation import parse_json_body  # noqa: PLC0415
+
+    payload = parse_json_body()
+    unknown = set(payload) - {"text", "voice"}
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise MobileApiError(merr.BAD_REQUEST, f"Unsupported field(s): {names}.", 400)
+    text = payload.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'text' is required.", 400)
+    text = text.strip()
+    if len(text) > MAX_TTS_TEXT_CHARS:
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'text' is too long.", 400)
+    voice = payload.get("voice")
+    if voice is not None and not isinstance(voice, str):
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'voice' must be a string.", 400)
+    services.tts.require_available()
+    voice_id = services.tts.resolve_voice(voice)
+    audio_bytes = services.tts.synthesize(text, voice_id)
+    return (
+        jsonify(
+            {
+                "request_id": getattr(g, "request_id", None),
+                "audio_base64": base64.b64encode(audio_bytes).decode("ascii"),
+                "mime_type": services.tts.mime_type(),
+                "voice": voice_id,
+                "requested_voice": voice.strip() if voice and voice.strip() else "default",
+            }
+        ),
+        200,
+    )
+
+
 def build_voice_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint:
     bp = Blueprint("mobile_voice", __name__, url_prefix="/mobile")
-    cfg = services.config
 
     @bp.post("/voice/upload")
-    @limiter.limit(cfg.rate_limit_voice)
+    @limiter.limit(services.config.rate_limit_voice)
     @require_mobile_auth
     def voice_upload() -> Any:
-        principal = g.mobile_principal
-
-        # Cheap size gate before reading the body where possible.
-        if request.content_length is not None and request.content_length > (
-            cfg.max_audio_bytes + 128 * 1024
-        ):
-            raise MobileApiError(merr.PAYLOAD_TOO_LARGE, "The upload is too large.", 413)
-
-        # STT availability gate before any temp file or decode work — a
-        # missing dependency/model is a truthful 503, never a mock.
-        services.stt.require_available()
-
-        data = _validate_upload_form()
-        if not data:
-            raise MobileApiError(merr.INVALID_MEDIA, "The audio file is empty.", 415)
-        if len(data) > cfg.max_audio_bytes:
-            raise MobileApiError(merr.PAYLOAD_TOO_LARGE, "The audio file is too large.", 413)
-
-        container = sniff_audio_container(data)
-        if container is None:
-            raise MobileApiError(
-                merr.INVALID_MEDIA,
-                "Unsupported audio format. Use M4A/MP4, AAC, MP3, or WAV.",
-                415,
-            )
-
-        # Private per-request temp directory; always removed in finally.
-        with tempfile.TemporaryDirectory(prefix="rex-mobile-voice-") as tmp_dir:
-            tmp_path = Path(tmp_dir) / f"upload.{container}"
-            tmp_path.write_bytes(data)
-            audio = services.stt.decode(str(tmp_path))
-            duration_seconds = float(len(audio)) / WHISPER_SAMPLE_RATE
-            if duration_seconds > cfg.max_audio_seconds:
-                raise MobileApiError(
-                    merr.PAYLOAD_TOO_LARGE,
-                    f"Audio is longer than {cfg.max_audio_seconds} seconds.",
-                    413,
-                )
-            transcript = services.stt.transcribe(audio)
-
-        if not transcript:
-            raise MobileApiError(merr.INVALID_MEDIA, "No speech was recognized in the audio.", 415)
-
-        # Canonical Assistant with the explicit validated identity — real
-        # runtime output only; conversational replies are 'completed'.
-        response_text = services.chat_service.generate(
-            transcript, user_id=principal.user_id, voice_mode=True
-        )
-
-        body: dict[str, Any] = {
-            "request_id": getattr(g, "request_id", None),
-            "transcript": transcript,
-            "response": response_text,
-            "status": STATUS_COMPLETED,
-            "tool_used": None,
-        }
-
-        # Optional TTS of the reply — only when the configured engine is
-        # genuinely available; a synthesis failure never fails the upload
-        # and never fabricates audio.
-        tts_available, _ = services.tts.availability()
-        if tts_available and response_text:
-            try:
-                voice_id = services.tts.resolve_voice(None)
-                audio_bytes = services.tts.synthesize(response_text, voice_id)
-                body["tts_base64"] = base64.b64encode(audio_bytes).decode("ascii")
-                body["tts_mime_type"] = services.tts.mime_type()
-            except MobileApiError:
-                logger.info("Voice reply TTS unavailable; returning text only")
-
-        return jsonify(body), 200
+        return _handle_voice_upload(services)
 
     @bp.post("/tts/playback")
-    @limiter.limit(cfg.rate_limit_voice)
+    @limiter.limit(services.config.rate_limit_voice)
     @require_mobile_auth
     def tts_playback() -> Any:
-        from rex.mobile_api.validation import parse_json_body  # noqa: PLC0415
-
-        payload = parse_json_body()
-        unknown = set(payload) - {"text", "voice"}
-        if unknown:
-            names = ", ".join(sorted(unknown))
-            raise MobileApiError(merr.BAD_REQUEST, f"Unsupported field(s): {names}.", 400)
-
-        text = payload.get("text")
-        if not isinstance(text, str) or not text.strip():
-            raise MobileApiError(merr.BAD_REQUEST, "Field 'text' is required.", 400)
-        text = text.strip()
-        if len(text) > MAX_TTS_TEXT_CHARS:
-            raise MobileApiError(merr.BAD_REQUEST, "Field 'text' is too long.", 400)
-
-        voice = payload.get("voice")
-        if voice is not None and not isinstance(voice, str):
-            raise MobileApiError(merr.BAD_REQUEST, "Field 'voice' must be a string.", 400)
-
-        # Availability gate, then honest voice resolution (no fallback that
-        # pretends the requested voice was used).
-        services.tts.require_available()
-        voice_id = services.tts.resolve_voice(voice)
-        audio_bytes = services.tts.synthesize(text, voice_id)
-
-        requested_label = voice if voice and voice.strip() not in ("", "default") else "default"
-        return (
-            jsonify(
-                {
-                    "request_id": getattr(g, "request_id", None),
-                    "audio_base64": base64.b64encode(audio_bytes).decode("ascii"),
-                    "mime_type": services.tts.mime_type(),
-                    "voice": requested_label,
-                }
-            ),
-            200,
-        )
+        return _handle_tts_playback(services)
 
     return bp
 

--- a/rex/mobile_api/routes/voice.py
+++ b/rex/mobile_api/routes/voice.py
@@ -1,0 +1,218 @@
+"""Authenticated mobile voice and TTS routes (issue #323, Session 2).
+
+``POST /mobile/voice/upload``  — multipart audio → STT → canonical
+Assistant → optional TTS of the reply.
+``POST /mobile/tts/playback``  — JSON text → existing configured TTS →
+authenticated JSON base64 audio.
+
+Security and truthfulness:
+
+- Bearer authentication is required before any multipart parsing, temp
+  file, STT, or synthesis work.
+- The declared MIME type and filename are never trusted: actual byte
+  signatures are sniffed and a successful decode is required.
+- Limits: 15 MiB and 60 seconds for uploads (config), bounded TTS text.
+- Temporary audio lives in a private per-request directory and is deleted
+  on every success, failure, timeout, and cancellation path.
+- Missing STT/TTS runtime dependencies return truthful
+  ``BACKEND_UNAVAILABLE`` — no model downloads mid-request, no mock
+  transcripts, no fake verified actions.
+- Audio bytes, transcripts, chat text, and TTS text are never logged.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from flask import Blueprint, g, jsonify, request
+
+from rex.mobile_api import errors as merr
+from rex.mobile_api.auth import require_mobile_auth
+from rex.mobile_api.chat import STATUS_COMPLETED
+from rex.mobile_api.errors import MobileApiError
+from rex.mobile_api.services import MobileApiServices
+from rex.mobile_api.voice import (
+    MAX_TTS_TEXT_CHARS,
+    WHISPER_SAMPLE_RATE,
+    sniff_audio_container,
+)
+
+logger = logging.getLogger(__name__)
+
+# Fields that must never appear in the upload form (identity comes from the
+# validated principal only).
+_FORBIDDEN_FORM_FIELDS = {"user_id", "role", "permissions", "risk", "approval", "biometric"}
+_VOICE_MODE = "mobile_voice"
+
+
+def _reject_forbidden_form_fields() -> None:
+    present = _FORBIDDEN_FORM_FIELDS.intersection(request.form.keys())
+    if present:
+        names = ", ".join(sorted(present))
+        raise MobileApiError(merr.BAD_REQUEST, f"Unsupported field(s): {names}.", 400)
+
+
+def _validate_upload_form() -> bytes:
+    """Validate the multipart form and return the raw audio bytes."""
+    if not request.content_type or "multipart/form-data" not in request.content_type:
+        raise MobileApiError(merr.INVALID_MEDIA, "Content-Type must be multipart/form-data.", 415)
+    _reject_forbidden_form_fields()
+
+    mode = request.form.get("mode", _VOICE_MODE)
+    if mode != _VOICE_MODE:
+        raise MobileApiError(merr.BAD_REQUEST, f"Field 'mode' must be '{_VOICE_MODE}'.", 400)
+
+    context_raw = request.form.get("client_context")
+    if context_raw:
+        try:
+            parsed_context = json.loads(context_raw)
+        except ValueError as exc:
+            raise MobileApiError(
+                merr.BAD_REQUEST, "Field 'client_context' must be JSON.", 400
+            ) from exc
+        if not isinstance(parsed_context, dict):
+            raise MobileApiError(
+                merr.BAD_REQUEST, "Field 'client_context' must be a JSON object.", 400
+            )
+
+    audio_parts = request.files.getlist("audio")
+    if len(audio_parts) != 1:
+        raise MobileApiError(merr.BAD_REQUEST, "Exactly one 'audio' file part is required.", 400)
+    extra_files = [key for key in request.files if key != "audio"]
+    if extra_files:
+        raise MobileApiError(merr.BAD_REQUEST, "Unexpected file part(s) in upload.", 400)
+
+    return bytes(audio_parts[0].read())
+
+
+def build_voice_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint:
+    bp = Blueprint("mobile_voice", __name__, url_prefix="/mobile")
+    cfg = services.config
+
+    @bp.post("/voice/upload")
+    @limiter.limit(cfg.rate_limit_voice)
+    @require_mobile_auth
+    def voice_upload() -> Any:
+        principal = g.mobile_principal
+
+        # Cheap size gate before reading the body where possible.
+        if request.content_length is not None and request.content_length > (
+            cfg.max_audio_bytes + 128 * 1024
+        ):
+            raise MobileApiError(merr.PAYLOAD_TOO_LARGE, "The upload is too large.", 413)
+
+        # STT availability gate before any temp file or decode work — a
+        # missing dependency/model is a truthful 503, never a mock.
+        services.stt.require_available()
+
+        data = _validate_upload_form()
+        if not data:
+            raise MobileApiError(merr.INVALID_MEDIA, "The audio file is empty.", 415)
+        if len(data) > cfg.max_audio_bytes:
+            raise MobileApiError(merr.PAYLOAD_TOO_LARGE, "The audio file is too large.", 413)
+
+        container = sniff_audio_container(data)
+        if container is None:
+            raise MobileApiError(
+                merr.INVALID_MEDIA,
+                "Unsupported audio format. Use M4A/MP4, AAC, MP3, or WAV.",
+                415,
+            )
+
+        # Private per-request temp directory; always removed in finally.
+        with tempfile.TemporaryDirectory(prefix="rex-mobile-voice-") as tmp_dir:
+            tmp_path = Path(tmp_dir) / f"upload.{container}"
+            tmp_path.write_bytes(data)
+            audio = services.stt.decode(str(tmp_path))
+            duration_seconds = float(len(audio)) / WHISPER_SAMPLE_RATE
+            if duration_seconds > cfg.max_audio_seconds:
+                raise MobileApiError(
+                    merr.PAYLOAD_TOO_LARGE,
+                    f"Audio is longer than {cfg.max_audio_seconds} seconds.",
+                    413,
+                )
+            transcript = services.stt.transcribe(audio)
+
+        if not transcript:
+            raise MobileApiError(merr.INVALID_MEDIA, "No speech was recognized in the audio.", 415)
+
+        # Canonical Assistant with the explicit validated identity — real
+        # runtime output only; conversational replies are 'completed'.
+        response_text = services.chat_service.generate(
+            transcript, user_id=principal.user_id, voice_mode=True
+        )
+
+        body: dict[str, Any] = {
+            "request_id": getattr(g, "request_id", None),
+            "transcript": transcript,
+            "response": response_text,
+            "status": STATUS_COMPLETED,
+            "tool_used": None,
+        }
+
+        # Optional TTS of the reply — only when the configured engine is
+        # genuinely available; a synthesis failure never fails the upload
+        # and never fabricates audio.
+        tts_available, _ = services.tts.availability()
+        if tts_available and response_text:
+            try:
+                voice_id = services.tts.resolve_voice(None)
+                audio_bytes = services.tts.synthesize(response_text, voice_id)
+                body["tts_base64"] = base64.b64encode(audio_bytes).decode("ascii")
+                body["tts_mime_type"] = services.tts.mime_type()
+            except MobileApiError:
+                logger.info("Voice reply TTS unavailable; returning text only")
+
+        return jsonify(body), 200
+
+    @bp.post("/tts/playback")
+    @limiter.limit(cfg.rate_limit_voice)
+    @require_mobile_auth
+    def tts_playback() -> Any:
+        from rex.mobile_api.validation import parse_json_body  # noqa: PLC0415
+
+        payload = parse_json_body()
+        unknown = set(payload) - {"text", "voice"}
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            raise MobileApiError(merr.BAD_REQUEST, f"Unsupported field(s): {names}.", 400)
+
+        text = payload.get("text")
+        if not isinstance(text, str) or not text.strip():
+            raise MobileApiError(merr.BAD_REQUEST, "Field 'text' is required.", 400)
+        text = text.strip()
+        if len(text) > MAX_TTS_TEXT_CHARS:
+            raise MobileApiError(merr.BAD_REQUEST, "Field 'text' is too long.", 400)
+
+        voice = payload.get("voice")
+        if voice is not None and not isinstance(voice, str):
+            raise MobileApiError(merr.BAD_REQUEST, "Field 'voice' must be a string.", 400)
+
+        # Availability gate, then honest voice resolution (no fallback that
+        # pretends the requested voice was used).
+        services.tts.require_available()
+        voice_id = services.tts.resolve_voice(voice)
+        audio_bytes = services.tts.synthesize(text, voice_id)
+
+        requested_label = voice if voice and voice.strip() not in ("", "default") else "default"
+        return (
+            jsonify(
+                {
+                    "request_id": getattr(g, "request_id", None),
+                    "audio_base64": base64.b64encode(audio_bytes).decode("ascii"),
+                    "mime_type": services.tts.mime_type(),
+                    "voice": requested_label,
+                }
+            ),
+            200,
+        )
+
+    return bp
+
+
+__all__ = ["build_voice_blueprint"]

--- a/rex/mobile_api/services.py
+++ b/rex/mobile_api/services.py
@@ -42,6 +42,7 @@ class MobileApiServices:
     stt: SpeechToTextAdapter
     tts: TextToSpeechAdapter
     id_generator: Callable[[], str] = field(default=_default_id_generator)
+    websocket_registered: bool = False
 
     @property
     def clock(self) -> Callable[[], datetime]:

--- a/rex/mobile_api/services.py
+++ b/rex/mobile_api/services.py
@@ -3,7 +3,9 @@
 Holds neutral, reusable dependencies only.  User-private state is never
 cached here — every private operation receives a validated user ID
 explicitly.  Clock, token, and ID generators are injectable so tests are
-deterministic.
+deterministic, and the runtime adapters (Assistant chat service, STT, TTS,
+idempotency store) are injectable so tests never touch heavy ML
+dependencies.
 """
 
 from __future__ import annotations
@@ -16,8 +18,11 @@ from pathlib import Path
 
 from rex.config import MobileApiConfig
 from rex.mobile_api.auth import load_jwt_secret
+from rex.mobile_api.chat import MobileChatService
 from rex.mobile_api.db import default_users_db_path
+from rex.mobile_api.idempotency import MobileMessageStore
 from rex.mobile_api.sessions import MobileSessionStore
+from rex.mobile_api.voice import SpeechToTextAdapter, TextToSpeechAdapter
 
 
 def _default_id_generator() -> str:
@@ -32,6 +37,10 @@ class MobileApiServices:
     db_path: Path
     jwt_secret: str
     session_store: MobileSessionStore
+    message_store: MobileMessageStore
+    chat_service: MobileChatService
+    stt: SpeechToTextAdapter
+    tts: TextToSpeechAdapter
     id_generator: Callable[[], str] = field(default=_default_id_generator)
 
     @property
@@ -50,6 +59,10 @@ class MobileApiServices:
         token_generator: Callable[[], str] | None = None,
         id_generator: Callable[[], str] | None = None,
         audit_logger: object | None = None,
+        message_store: MobileMessageStore | None = None,
+        chat_service: MobileChatService | None = None,
+        stt: SpeechToTextAdapter | None = None,
+        tts: TextToSpeechAdapter | None = None,
     ) -> MobileApiServices:
         """Build the default production container with optional test overrides."""
         cfg = config or MobileApiConfig()
@@ -63,11 +76,20 @@ class MobileApiServices:
             id_generator=id_generator,
             audit_logger=audit_logger,
         )
+        messages = message_store or MobileMessageStore(
+            resolved_db_path,
+            retention_hours=cfg.idempotency_retention_hours,
+            clock=clock,
+        )
         return cls(
             config=cfg,
             db_path=resolved_db_path,
             jwt_secret=secret,
             session_store=store,
+            message_store=messages,
+            chat_service=chat_service or MobileChatService(),
+            stt=stt or SpeechToTextAdapter(),
+            tts=tts or TextToSpeechAdapter(),
             id_generator=id_generator or _default_id_generator,
         )
 

--- a/rex/mobile_api/validation.py
+++ b/rex/mobile_api/validation.py
@@ -20,6 +20,8 @@ from rex.mobile_api.sessions import DeviceInfo
 
 _DEVICE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _MAX_DEVICE_TEXT_LENGTH = 128
+_MAX_APP_VERSION_LENGTH = 64
+_WS_CLIENT_PLATFORMS = {"ios", "android", "web"}
 _MAX_TOKEN_LENGTH = 512
 _MAX_CREDENTIAL_LENGTH = 512
 
@@ -138,6 +140,41 @@ def parse_device_info(payload: dict[str, Any]) -> DeviceInfo:
     )
 
 
+def parse_websocket_client(client: Any) -> dict[str, str]:
+    """Validate required WebSocket client metadata without trusting it as identity."""
+    if not isinstance(client, dict):
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'client' must be an object.", 400)
+    allowed = {"platform", "app_version", "device_id"}
+    unknown = set(client) - allowed
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise MobileApiError(merr.BAD_REQUEST, f"Unsupported client field(s): {names}.", 400)
+    if set(client) != allowed:
+        raise MobileApiError(
+            merr.BAD_REQUEST,
+            "Fields 'client.platform', 'client.app_version', and 'client.device_id' are required.",
+            400,
+        )
+    platform = client["platform"]
+    if not isinstance(platform, str) or platform not in _WS_CLIENT_PLATFORMS:
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'client.platform' is invalid.", 400)
+    app_version = client["app_version"]
+    if (
+        not isinstance(app_version, str)
+        or not app_version.strip()
+        or len(app_version) > _MAX_APP_VERSION_LENGTH
+    ):
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'client.app_version' is invalid.", 400)
+    device_id = client["device_id"]
+    if not isinstance(device_id, str) or not _DEVICE_ID_PATTERN.fullmatch(device_id):
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'client.device_id' is invalid.", 400)
+    return {
+        "platform": platform,
+        "app_version": app_version.strip(),
+        "device_id": device_id,
+    }
+
+
 @dataclass(frozen=True)
 class ChatRequest:
     """A validated mobile chat request (HTTP body or WebSocket frame)."""
@@ -251,6 +288,7 @@ __all__ = [
     "parse_chat_payload",
     "parse_device_info",
     "parse_json_body",
+    "parse_websocket_client",
     "parse_refresh_token_field",
     "require_string_field",
 ]

--- a/rex/mobile_api/validation.py
+++ b/rex/mobile_api/validation.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import re
 import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 
 from rex.mobile_api import errors as merr
@@ -21,15 +23,44 @@ _MAX_DEVICE_TEXT_LENGTH = 128
 _MAX_TOKEN_LENGTH = 512
 _MAX_CREDENTIAL_LENGTH = 512
 
+# Chat payload bounds (issue #323 Session 2).
+MAX_CHAT_MESSAGE_CHARS = 8_000
+_MAX_CLIENT_CONTEXT_KEYS = 16
+_MAX_CLIENT_CONTEXT_VALUE_CHARS = 256
+_CHAT_MODE = "mobile_text"
+
+# The only fields a chat request may carry.  Client-supplied identity or
+# authorization fields (user_id, role, permissions, risk, approval,
+# biometric, ...) are rejected outright — identity comes exclusively from
+# validated credentials.
+_ALLOWED_CHAT_FIELDS = {
+    "type",
+    "message_id",
+    "conversation_id",
+    "sent_at",
+    "message",
+    "mode",
+    "client_context",
+}
+
 
 def parse_json_body() -> dict[str, Any]:
     """Return the request's JSON object, failing closed on bad input.
 
     Raises:
         MobileApiError: 415 ``INVALID_MEDIA`` for a non-JSON content type,
-            400 ``BAD_REQUEST`` for malformed JSON or a non-object payload.
+            400 ``BAD_REQUEST`` for malformed JSON or a non-object payload,
+            413 ``PAYLOAD_TOO_LARGE`` beyond the configured JSON body limit.
     """
-    from flask import request  # noqa: PLC0415
+    from flask import current_app, request  # noqa: PLC0415
+
+    # The Flask-level MAX_CONTENT_LENGTH admits large multipart voice
+    # uploads; JSON bodies keep the tighter configured limit, checked
+    # before any parsing work.
+    services = current_app.extensions.get("mobile_api_services")
+    if services is not None and request.content_length is not None:
+        if request.content_length > services.config.max_json_bytes:
+            raise MobileApiError(merr.PAYLOAD_TOO_LARGE, "Request body is too large.", 413)
 
     if request.mimetype != "application/json":
         raise MobileApiError(
@@ -107,7 +138,117 @@ def parse_device_info(payload: dict[str, Any]) -> DeviceInfo:
     )
 
 
+@dataclass(frozen=True)
+class ChatRequest:
+    """A validated mobile chat request (HTTP body or WebSocket frame)."""
+
+    message_id: str
+    conversation_id: str
+    sent_at: str
+    message: str
+    mode: str = _CHAT_MODE
+    client_context: dict[str, str] = field(default_factory=dict)
+
+    def semantic_fields(self) -> dict[str, Any]:
+        """Return the semantic execution fields used for the request hash."""
+        return {
+            "message_id": self.message_id,
+            "conversation_id": self.conversation_id,
+            "sent_at": self.sent_at,
+            "message": self.message,
+            "mode": self.mode,
+            "client_context": self.client_context,
+        }
+
+
+def _require_uuid_field(payload: dict[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise MobileApiError(merr.BAD_REQUEST, f"Field '{name}' is required.", 400)
+    value = value.strip()
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise MobileApiError(merr.BAD_REQUEST, f"Field '{name}' must be a UUID.", 400) from exc
+    return value
+
+
+def _require_iso_timestamp(payload: dict[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise MobileApiError(merr.BAD_REQUEST, f"Field '{name}' is required.", 400)
+    value = value.strip()
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise MobileApiError(
+            merr.BAD_REQUEST, f"Field '{name}' must be an ISO-8601 timestamp.", 400
+        ) from exc
+    return value
+
+
+def _parse_client_context(payload: dict[str, Any]) -> dict[str, str]:
+    context = payload.get("client_context")
+    if context is None:
+        return {}
+    if not isinstance(context, dict):
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'client_context' must be an object.", 400)
+    if len(context) > _MAX_CLIENT_CONTEXT_KEYS:
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'client_context' has too many keys.", 400)
+    parsed: dict[str, str] = {}
+    for key, value in context.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise MobileApiError(
+                merr.BAD_REQUEST, "Field 'client_context' must map strings to strings.", 400
+            )
+        if len(value) > _MAX_CLIENT_CONTEXT_VALUE_CHARS:
+            raise MobileApiError(
+                merr.BAD_REQUEST, "Field 'client_context' contains an oversized value.", 400
+            )
+        parsed[key] = value
+    return parsed
+
+
+def parse_chat_payload(payload: dict[str, Any]) -> ChatRequest:
+    """Validate a chat request payload (HTTP body or WebSocket chat frame).
+
+    Rejects unknown fields outright, which covers every client-supplied
+    identity/authorization field (``user_id``, ``role``, ``permissions``,
+    risk, approval, and biometric claims) — the server principal is the only
+    identity.
+
+    Raises:
+        MobileApiError: 400 ``BAD_REQUEST`` on any invalid field.
+    """
+    unknown = set(payload) - _ALLOWED_CHAT_FIELDS
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise MobileApiError(merr.BAD_REQUEST, f"Unsupported field(s): {names}.", 400)
+
+    message = payload.get("message")
+    if not isinstance(message, str) or not message.strip():
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'message' is required.", 400)
+    if len(message) > MAX_CHAT_MESSAGE_CHARS:
+        raise MobileApiError(merr.BAD_REQUEST, "Field 'message' is too long.", 400)
+
+    mode = payload.get("mode", _CHAT_MODE)
+    if mode != _CHAT_MODE:
+        raise MobileApiError(merr.BAD_REQUEST, f"Field 'mode' must be '{_CHAT_MODE}'.", 400)
+
+    return ChatRequest(
+        message_id=_require_uuid_field(payload, "message_id"),
+        conversation_id=_require_uuid_field(payload, "conversation_id"),
+        sent_at=_require_iso_timestamp(payload, "sent_at"),
+        message=message.strip(),
+        mode=mode,
+        client_context=_parse_client_context(payload),
+    )
+
+
 __all__ = [
+    "MAX_CHAT_MESSAGE_CHARS",
+    "ChatRequest",
+    "parse_chat_payload",
     "parse_device_info",
     "parse_json_body",
     "parse_refresh_token_field",

--- a/rex/mobile_api/voice.py
+++ b/rex/mobile_api/voice.py
@@ -233,16 +233,25 @@ class TextToSpeechAdapter:
         if provider == "xtts":
             if find_spec("TTS") is None:
                 return False, "Coqui TTS is not installed"
-            return True, "ok"
-        if provider == "edge-tts":
+        elif provider == "edge-tts":
             if find_spec("edge_tts") is None:
                 return False, "edge-tts is not installed"
-            return True, "ok"
-        if provider == "pyttsx3":
+        elif provider == "pyttsx3":
             if find_spec("pyttsx3") is None:
                 return False, "pyttsx3 is not installed"
-            return True, "ok"
-        return False, f"unsupported TTS provider '{provider}'"
+        else:
+            return False, f"unsupported TTS provider '{provider}'"
+
+        configured = self._configured_default_voice()
+        try:
+            voices = self._list_voice_ids()
+        except Exception:
+            return False, "configured TTS voice list is unavailable"
+        if configured and configured not in voices:
+            return False, "configured default TTS voice is unavailable"
+        if not configured and provider != "edge-tts" and not voices:
+            return False, "no default TTS voice is available"
+        return True, "ok"
 
     def require_available(self) -> None:
         available, reason = self.availability()

--- a/rex/mobile_api/voice.py
+++ b/rex/mobile_api/voice.py
@@ -1,0 +1,367 @@
+"""Voice upload validation, STT adapter, and TTS adapter (issue #323, S2).
+
+The mobile gateway reuses the existing Rex speech stack — it does not create
+a second STT or TTS engine:
+
+- Decoding uses Whisper's ffmpeg-based ``whisper.audio.load_audio`` (the
+  same decode path the repository's STT already depends on), which is what
+  genuinely handles M4A/MP4, AAC, MP3, and WAV.
+- Transcription reuses :class:`rex.voice.stt.SpeechToText` with the
+  configured model/device.
+- Synthesis reuses the per-provider helpers in :mod:`rex.tts_voices`
+  (XTTS / edge-tts / pyttsx3) selected by ``config.voice.tts_engine``.
+
+Truthfulness rules: filename and declared MIME type are never trusted —
+actual byte signatures are sniffed and a successful decode is required.
+Missing runtime dependencies (whisper, ffmpeg, a locally cached model, the
+configured TTS engine) produce ``BACKEND_UNAVAILABLE``; models are never
+downloaded during a request and no mock transcript or audio is ever
+returned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import threading
+from importlib.util import find_spec
+from typing import Any
+
+from rex.mobile_api import errors as merr
+from rex.mobile_api.errors import MobileApiError
+
+logger = logging.getLogger(__name__)
+
+# Whisper's ffmpeg decode path resamples to 16 kHz mono float32.
+WHISPER_SAMPLE_RATE = 16_000
+
+# TTS bounds.
+MAX_TTS_TEXT_CHARS = 2_000
+MAX_TTS_AUDIO_BYTES = 10 * 1024 * 1024
+TTS_TIMEOUT_SECONDS = 120.0
+
+# Supported upload containers (sniffed from actual bytes, never declared
+# metadata): M4A/MP4, AAC (ADTS), MP3, WAV.
+SUPPORTED_CONTAINERS = ("m4a", "aac", "mp3", "wav")
+
+_EDGE_DEFAULT_VOICE = "en-US-AriaNeural"
+
+
+def sniff_audio_container(data: bytes) -> str | None:
+    """Identify the audio container from file signatures (magic bytes).
+
+    Returns one of :data:`SUPPORTED_CONTAINERS` or ``None`` when the bytes
+    do not match any supported signature.  The declared MIME type and the
+    filename are deliberately not consulted.
+    """
+    if len(data) < 12:
+        return None
+    if data[:4] == b"RIFF" and data[8:12] == b"WAVE":
+        return "wav"
+    if data[:3] == b"ID3":
+        return "mp3"
+    if data[4:8] == b"ftyp":
+        return "m4a"
+    b0, b1 = data[0], data[1]
+    if b0 == 0xFF and (b1 & 0xE0) == 0xE0:
+        # 11-bit MPEG sync.  ADTS AAC uses layer bits '00'; MP3 does not.
+        layer_bits = (b1 >> 1) & 0x03
+        return "aac" if layer_bits == 0 else "mp3"
+    return None
+
+
+def _stt_unavailable(reason: str) -> MobileApiError:
+    logger.warning("Mobile voice upload unavailable: %s", reason)
+    return MobileApiError(
+        merr.BACKEND_UNAVAILABLE,
+        "Speech-to-text is not available on this server.",
+        503,
+        retryable=False,
+    )
+
+
+def _tts_unavailable(reason: str) -> MobileApiError:
+    logger.warning("Mobile TTS unavailable: %s", reason)
+    return MobileApiError(
+        merr.BACKEND_UNAVAILABLE,
+        "Text-to-speech is not available on this server.",
+        503,
+        retryable=False,
+    )
+
+
+def _whisper_cache_dir() -> str:
+    default_cache = os.path.join(os.path.expanduser("~"), ".cache")
+    return os.path.join(os.getenv("XDG_CACHE_HOME", default_cache), "whisper")
+
+
+class SpeechToTextAdapter:
+    """Adapter over the existing Whisper STT stack for file uploads."""
+
+    def __init__(self, model_name: str | None = None, device: str | None = None) -> None:
+        self._model_name = model_name
+        self._device = device
+        self._stt: Any = None
+        self._lock = threading.Lock()
+
+    def _resolved_model_name(self) -> str:
+        if self._model_name:
+            return self._model_name
+        from rex.config import settings  # noqa: PLC0415
+
+        return str(getattr(settings.voice, "stt_model", "base"))
+
+    def _resolved_device(self) -> str:
+        if self._device:
+            return self._device
+        from rex.config import settings  # noqa: PLC0415
+
+        return str(getattr(settings.voice, "whisper_device", "auto"))
+
+    def availability(self) -> tuple[bool, str]:
+        """Return (available, reason).  Never triggers a model download."""
+        if find_spec("whisper") is None:
+            return False, "openai-whisper is not installed"
+        if find_spec("numpy") is None:
+            return False, "numpy is not installed"
+        if shutil.which("ffmpeg") is None:
+            return False, "ffmpeg is not on PATH"
+        model_name = self._resolved_model_name()
+        model_path = os.path.join(_whisper_cache_dir(), f"{model_name}.pt")
+        if not os.path.exists(model_path):
+            # Models are downloaded by explicit setup, never mid-request.
+            return False, f"whisper model '{model_name}' is not downloaded"
+        return True, "ok"
+
+    def require_available(self) -> None:
+        available, reason = self.availability()
+        if not available:
+            raise _stt_unavailable(reason)
+
+    def decode(self, path: str) -> Any:
+        """Decode an audio file to a 16 kHz mono float32 array.
+
+        Uses Whisper's ffmpeg decode (the existing decode stack).  A decode
+        failure means the media is invalid regardless of its signature.
+
+        Raises:
+            MobileApiError: 415 ``INVALID_MEDIA`` when decoding fails,
+                ``BACKEND_UNAVAILABLE`` when the decoder is missing.
+        """
+        self.require_available()
+        try:
+            from whisper.audio import load_audio  # noqa: PLC0415
+
+            audio = load_audio(path)
+        except MobileApiError:
+            raise
+        except Exception as exc:
+            logger.info("Mobile voice decode failed: %s", type(exc).__name__)
+            raise MobileApiError(
+                merr.INVALID_MEDIA,
+                "The audio could not be decoded.",
+                415,
+            ) from exc
+        if audio is None or getattr(audio, "size", 0) == 0:
+            raise MobileApiError(merr.INVALID_MEDIA, "The audio contains no samples.", 415)
+        return audio
+
+    def _get_stt(self) -> Any:
+        if self._stt is not None:
+            return self._stt
+        with self._lock:
+            if self._stt is None:
+                from rex.voice.stt import SpeechToText  # noqa: PLC0415
+
+                self._stt = SpeechToText(
+                    self._resolved_model_name(),
+                    self._resolved_device(),
+                )
+        return self._stt
+
+    def transcribe(self, audio: Any) -> str:
+        """Transcribe a decoded 16 kHz audio array via the existing STT."""
+        self.require_available()
+        try:
+            stt = self._get_stt()
+            return str(asyncio.run(stt.transcribe(audio, WHISPER_SAMPLE_RATE))).strip()
+        except MobileApiError:
+            raise
+        except Exception as exc:
+            logger.error("Mobile voice transcription failed: %s", exc)
+            raise MobileApiError(
+                merr.BACKEND_UNAVAILABLE,
+                "Speech-to-text failed on this server.",
+                503,
+                retryable=True,
+            ) from exc
+
+
+class TextToSpeechAdapter:
+    """Adapter over the existing configured TTS providers."""
+
+    def __init__(self, provider: str | None = None, default_voice: str | None = None) -> None:
+        self._provider_override = provider
+        self._default_voice_override = default_voice
+
+    def provider(self) -> str:
+        """Return the normalized configured provider name."""
+        raw = self._provider_override
+        if raw is None:
+            from rex.config import settings  # noqa: PLC0415
+
+            raw = str(getattr(settings.voice, "tts_engine", "xtts"))
+        p = raw.lower().strip()
+        if p in ("edge", "edge-tts", "edge_tts", "edgetts"):
+            return "edge-tts"
+        if p in ("xtts", "coqui", "coqui-tts"):
+            return "xtts"
+        return p
+
+    def _configured_default_voice(self) -> str | None:
+        if self._default_voice_override:
+            return self._default_voice_override
+        from rex.config import settings  # noqa: PLC0415
+
+        voice = getattr(settings.voice, "tts_voice", None)
+        return str(voice) if voice else None
+
+    def availability(self) -> tuple[bool, str]:
+        provider = self.provider()
+        if provider == "xtts":
+            if find_spec("TTS") is None:
+                return False, "Coqui TTS is not installed"
+            return True, "ok"
+        if provider == "edge-tts":
+            if find_spec("edge_tts") is None:
+                return False, "edge-tts is not installed"
+            return True, "ok"
+        if provider == "pyttsx3":
+            if find_spec("pyttsx3") is None:
+                return False, "pyttsx3 is not installed"
+            return True, "ok"
+        return False, f"unsupported TTS provider '{provider}'"
+
+    def require_available(self) -> None:
+        available, reason = self.availability()
+        if not available:
+            raise _tts_unavailable(reason)
+
+    def mime_type(self) -> str:
+        return "audio/mpeg" if self.provider() == "edge-tts" else "audio/wav"
+
+    def _list_voice_ids(self) -> list[str]:
+        from rex.tts_voices import list_voices  # noqa: PLC0415
+
+        return [str(v.get("id", "")) for v in list_voices(self.provider())]
+
+    def resolve_voice(self, requested: str | None) -> str:
+        """Resolve the requested voice to a concrete provider voice ID.
+
+        ``None`` / ``"default"`` selects the configured or provider-default
+        voice.  An explicit voice must exist for the provider — there is no
+        silent fallback that pretends the requested voice was used.
+
+        Raises:
+            MobileApiError: 400 when the requested voice is unknown,
+                ``BACKEND_UNAVAILABLE`` when no voice can be resolved.
+        """
+        self.require_available()
+        provider = self.provider()
+        if requested is None or requested.strip() in ("", "default"):
+            configured = self._configured_default_voice()
+            if configured:
+                return configured
+            if provider == "edge-tts":
+                return _EDGE_DEFAULT_VOICE
+            voices = self._list_voice_ids()
+            if not voices:
+                raise _tts_unavailable(f"no voices available for provider '{provider}'")
+            return voices[0]
+
+        requested = requested.strip()
+        try:
+            known = self._list_voice_ids()
+        except Exception as exc:
+            raise _tts_unavailable("voice list is unavailable") from exc
+        if requested not in known:
+            raise MobileApiError(
+                merr.BAD_REQUEST,
+                "The requested voice is not available.",
+                400,
+            )
+        return requested
+
+    def synthesize(self, text: str, voice_id: str) -> bytes:
+        """Synthesize ``text`` with the existing provider implementation.
+
+        Raises:
+            MobileApiError: ``BACKEND_UNAVAILABLE`` on engine failure or
+                timeout; ``PAYLOAD_TOO_LARGE`` when output exceeds the cap.
+        """
+        self.require_available()
+        provider = self.provider()
+
+        async def _run() -> bytes:
+            # Reuse of the existing per-provider synthesis implementations
+            # (rex.tts_voices) — not a parallel engine.
+            from rex import tts_voices  # noqa: PLC0415
+
+            if provider == "xtts":
+                coro = tts_voices._synthesize_xtts(voice_id, text)
+            elif provider == "edge-tts":
+                coro = tts_voices._synthesize_edge_tts(voice_id, text)
+            elif provider == "pyttsx3":
+                coro = tts_voices._synthesize_pyttsx3(voice_id, text)
+            else:  # pragma: no cover - guarded by require_available
+                raise RuntimeError(f"unsupported TTS provider '{provider}'")
+            return await asyncio.wait_for(coro, timeout=TTS_TIMEOUT_SECONDS)
+
+        try:
+            audio = asyncio.run(_run())
+        except TimeoutError as exc:
+            raise MobileApiError(
+                merr.BACKEND_UNAVAILABLE,
+                "Text-to-speech timed out.",
+                503,
+                retryable=True,
+            ) from exc
+        except MobileApiError:
+            raise
+        except Exception as exc:
+            logger.error("Mobile TTS synthesis failed: %s", exc)
+            raise MobileApiError(
+                merr.BACKEND_UNAVAILABLE,
+                "Text-to-speech failed on this server.",
+                503,
+                retryable=True,
+            ) from exc
+
+        if not audio:
+            raise MobileApiError(
+                merr.BACKEND_UNAVAILABLE,
+                "Text-to-speech produced no audio.",
+                503,
+                retryable=True,
+            )
+        if len(audio) > MAX_TTS_AUDIO_BYTES:
+            raise MobileApiError(
+                merr.PAYLOAD_TOO_LARGE,
+                "The synthesized audio is too large.",
+                413,
+            )
+        return audio
+
+
+__all__ = [
+    "MAX_TTS_AUDIO_BYTES",
+    "MAX_TTS_TEXT_CHARS",
+    "SUPPORTED_CONTAINERS",
+    "TTS_TIMEOUT_SECONDS",
+    "WHISPER_SAMPLE_RATE",
+    "SpeechToTextAdapter",
+    "TextToSpeechAdapter",
+    "sniff_audio_container",
+]

--- a/rex/mobile_api/websocket.py
+++ b/rex/mobile_api/websocket.py
@@ -42,7 +42,7 @@ from rex.mobile_api.auth import MobilePrincipal, authenticate_token
 from rex.mobile_api.chat import STATUS_COMPLETED
 from rex.mobile_api.errors import MobileApiError
 from rex.mobile_api.services import MobileApiServices
-from rex.mobile_api.validation import parse_chat_payload
+from rex.mobile_api.validation import parse_chat_payload, parse_websocket_client
 
 logger = logging.getLogger(__name__)
 
@@ -150,16 +150,26 @@ class MobileWebSocketServer:
             return None
 
         token = frame.get("access_token")
-        client = frame.get("client")
         if (
             not isinstance(token, str)
             or not token.strip()
-            or (client is not None and not isinstance(client, dict))
+            or set(frame)
+            != {
+                "type",
+                "access_token",
+                "client",
+            }
         ):
             self._send(
                 ws,
                 mev.auth_error_event(merr.AUTH_TOKEN_INVALID, "Invalid auth frame."),
             )
+            self._close(ws, CLOSE_UNAUTHENTICATED, "Not authenticated")
+            return None
+        try:
+            parse_websocket_client(frame.get("client"))
+        except MobileApiError as exc:
+            self._send(ws, mev.auth_error_event(exc.code, exc.message))
             self._close(ws, CLOSE_UNAUTHENTICATED, "Not authenticated")
             return None
 
@@ -204,58 +214,70 @@ class MobileWebSocketServer:
             try:
                 raw = ws.receive(timeout=IDLE_POLL_SECONDS)
             except Exception:
-                return  # closed by the client
-
-            # Bounded-interval session revalidation, including while idle.
+                return
             now = time.monotonic()
             if now - last_session_check >= SESSION_RECHECK_SECONDS:
-                if not self._session_active(principal):
-                    self._close(ws, CLOSE_UNAUTHENTICATED, "Session revoked")
+                if not self._require_active_session(ws, principal):
                     return
                 last_session_check = now
-            if raw is None:
+            frame = self._parse_authenticated_frame(ws, raw)
+            if frame is None:
                 continue
-
-            if isinstance(raw, (bytes, bytearray)):
-                raw = raw.decode("utf-8", errors="replace")
-            if len(raw) > MAX_FRAME_BYTES:
-                # Oversized frames are rejected without processing.
-                self._protocol_error(ws, merr.BAD_REQUEST, "Frame too large.")
-                continue
-
-            try:
-                frame = json.loads(raw)
-            except ValueError:
-                self._protocol_error(ws, merr.BAD_REQUEST, "Frame is not valid JSON.")
-                continue
-            if not isinstance(frame, dict) or not isinstance(frame.get("type"), str):
-                self._protocol_error(ws, merr.BAD_REQUEST, "Frame must have a type.")
-                continue
-
-            frame_type = frame["type"]
-            if frame_type == "ping":
-                self._send(ws, mev.pong_event(self._now_iso()))
-                continue
-            if frame_type == "auth":
-                # The connection principal is immutable.
-                self._protocol_error(ws, merr.BAD_REQUEST, "Connection is already authenticated.")
-                continue
-            if frame_type != "chat":
-                self._protocol_error(ws, merr.BAD_REQUEST, "Unsupported frame type.")
-                continue
-
-            if not message_limiter.allow(principal.session_id):
-                self._close(ws, CLOSE_RATE_LIMITED, "Message rate limited")
+            keep_open, checked_session = self._dispatch_authenticated_frame(
+                ws, principal, frame, message_limiter
+            )
+            if not keep_open:
                 return
+            if checked_session:
+                last_session_check = time.monotonic()
 
-            # Session must still be live before every privileged message.
-            if not self._session_active(principal):
-                self._close(ws, CLOSE_UNAUTHENTICATED, "Session revoked")
-                return
-            last_session_check = time.monotonic()
+    def _require_active_session(self, ws: Any, principal: MobilePrincipal) -> bool:
+        if self._session_active(principal):
+            return True
+        self._close(ws, CLOSE_UNAUTHENTICATED, "Session revoked")
+        return False
 
-            if not self._handle_chat_frame(ws, principal, frame):
-                return
+    def _parse_authenticated_frame(self, ws: Any, raw: Any) -> dict[str, Any] | None:
+        if raw is None:
+            return None
+        if isinstance(raw, (bytes, bytearray)):
+            raw = raw.decode("utf-8", errors="replace")
+        if len(raw) > MAX_FRAME_BYTES:
+            self._protocol_error(ws, merr.BAD_REQUEST, "Frame too large.")
+            return None
+        try:
+            frame = json.loads(raw)
+        except ValueError:
+            self._protocol_error(ws, merr.BAD_REQUEST, "Frame is not valid JSON.")
+            return None
+        if not isinstance(frame, dict) or not isinstance(frame.get("type"), str):
+            self._protocol_error(ws, merr.BAD_REQUEST, "Frame must have a type.")
+            return None
+        return frame
+
+    def _dispatch_authenticated_frame(
+        self,
+        ws: Any,
+        principal: MobilePrincipal,
+        frame: dict[str, Any],
+        message_limiter: SlidingWindowLimiter,
+    ) -> tuple[bool, bool]:
+        frame_type = frame["type"]
+        if frame_type == "ping":
+            self._send(ws, mev.pong_event(self._now_iso()))
+            return True, False
+        if frame_type == "auth":
+            self._protocol_error(ws, merr.BAD_REQUEST, "Connection is already authenticated.")
+            return True, False
+        if frame_type != "chat":
+            self._protocol_error(ws, merr.BAD_REQUEST, "Unsupported frame type.")
+            return True, False
+        if not message_limiter.allow(principal.session_id):
+            self._close(ws, CLOSE_RATE_LIMITED, "Message rate limited")
+            return False, False
+        if not self._require_active_session(ws, principal):
+            return False, False
+        return self._handle_chat_frame(ws, principal, frame), True
 
     def _now_iso(self) -> str:
         return self._services.clock().isoformat()

--- a/rex/mobile_api/websocket.py
+++ b/rex/mobile_api/websocket.py
@@ -1,0 +1,458 @@
+"""Authenticated WebSocket chat transport (issue #323, Session 2).
+
+``WebSocket /mobile/chat/stream`` served through Flask-Sock /
+simple-websocket (validated on Windows + Python 3.11) inside the same Flask
+runtime — no second API framework.
+
+Protocol (master spec §7):
+
+- The URL never carries a token.  The first frame must be
+  ``{"type": "auth", "access_token": ..., "client": {...}}`` within the
+  authentication timeout; nothing else is processed before authentication.
+- Token validation is byte-for-byte the same service as HTTP
+  (:func:`rex.mobile_api.auth.authenticate_token`); success binds an
+  immutable principal to the connection — later frames can never replace
+  identity.
+- ``auth_ok`` / ``auth_error`` frames; close codes ``4401`` (missing,
+  invalid, expired, or revoked authentication), ``4403`` (authenticated but
+  forbidden), ``4408`` (auth timeout), ``4429`` (connection/message rate
+  limits).
+- Chat frames validate the canonical schema, reserve the shared
+  ``(user_id, message_id)`` idempotency record, then ``ack`` with
+  ``message_id``/``accepted_at`` — reservation strictly precedes the ack.
+- Session status is revalidated before every chat frame and on a bounded
+  idle interval; a revoked session closes with 4401.
+- Malformed frames produce structured protocol errors, never assistant
+  text.  Frames, tokens, and message bodies are never logged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from importlib.util import find_spec
+from typing import Any
+
+from rex.mobile_api import errors as merr
+from rex.mobile_api import events as mev
+from rex.mobile_api import idempotency as idem
+from rex.mobile_api.auth import MobilePrincipal, authenticate_token
+from rex.mobile_api.chat import STATUS_COMPLETED
+from rex.mobile_api.errors import MobileApiError
+from rex.mobile_api.services import MobileApiServices
+from rex.mobile_api.validation import parse_chat_payload
+
+logger = logging.getLogger(__name__)
+
+# Close codes (master spec §7.1).
+CLOSE_UNAUTHENTICATED = 4401
+CLOSE_FORBIDDEN = 4403
+CLOSE_AUTH_TIMEOUT = 4408
+CLOSE_RATE_LIMITED = 4429
+
+AUTH_TIMEOUT_SECONDS = 10.0
+IDLE_POLL_SECONDS = 5.0
+SESSION_RECHECK_SECONDS = 30.0
+MAX_FRAME_BYTES = 64 * 1024
+CONNECTIONS_PER_MINUTE = 30
+
+# Stored when the socket drops mid-execution (mirrors the SSE transport).
+CLIENT_DISCONNECTED = idem.CLIENT_DISCONNECTED
+
+
+class SlidingWindowLimiter:
+    """Small thread-safe sliding-window rate limiter (per arbitrary key)."""
+
+    def __init__(self, limit: int, window_seconds: float = 60.0) -> None:
+        self._limit = limit
+        self._window = window_seconds
+        self._events: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def allow(self, key: str, now: float | None = None) -> bool:
+        stamp = time.monotonic() if now is None else now
+        cutoff = stamp - self._window
+        with self._lock:
+            events = [t for t in self._events.get(key, []) if t > cutoff]
+            if len(events) >= self._limit:
+                self._events[key] = events
+                return False
+            events.append(stamp)
+            self._events[key] = events
+            return True
+
+
+def _messages_per_minute(rate_limit: str) -> int:
+    """Parse the leading integer of a Flask-Limiter rate string."""
+    try:
+        return max(1, int(rate_limit.strip().split()[0]))
+    except (ValueError, IndexError):
+        return 30
+
+
+class MobileWebSocketServer:
+    """Per-app WebSocket protocol handler (connection state machine)."""
+
+    def __init__(self, services: MobileApiServices) -> None:
+        self._services = services
+        self._connection_limiter = SlidingWindowLimiter(CONNECTIONS_PER_MINUTE)
+        self._message_limit = _messages_per_minute(services.config.rate_limit_chat)
+
+    # ── Frame helpers (no bodies or tokens are ever logged) ─────────────
+
+    @staticmethod
+    def _send(ws: Any, event: dict[str, Any]) -> None:
+        ws.send(mev.encode_event(event))
+
+    @staticmethod
+    def _close(ws: Any, code: int, reason: str) -> None:
+        try:
+            ws.close(code, reason)
+        except Exception:  # pragma: no cover - already closed
+            logger.debug("WebSocket close failed", exc_info=True)
+
+    def _protocol_error(
+        self, ws: Any, code: str, message: str, *, message_id: str | None = None
+    ) -> None:
+        self._send(ws, mev.error_event(code, message, message_id=message_id))
+
+    # ── Authentication ───────────────────────────────────────────────────
+
+    def _authenticate(self, ws: Any) -> MobilePrincipal | None:
+        """Run the first-frame auth handshake; None means the socket closed."""
+        try:
+            raw = ws.receive(timeout=AUTH_TIMEOUT_SECONDS)
+        except Exception:
+            return None
+        if raw is None:
+            self._close(ws, CLOSE_AUTH_TIMEOUT, "Authentication timeout")
+            return None
+        if isinstance(raw, (bytes, bytearray)):
+            raw = raw.decode("utf-8", errors="replace")
+        if len(raw) > MAX_FRAME_BYTES:
+            self._close(ws, CLOSE_UNAUTHENTICATED, "Authentication frame too large")
+            return None
+        try:
+            frame = json.loads(raw)
+        except ValueError:
+            frame = None
+        if not isinstance(frame, dict) or frame.get("type") != "auth":
+            # Chat/ping/malformed before authentication: reject and close.
+            self._send(
+                ws,
+                mev.auth_error_event(
+                    merr.AUTH_TOKEN_INVALID, "The first frame must be an auth frame."
+                ),
+            )
+            self._close(ws, CLOSE_UNAUTHENTICATED, "Not authenticated")
+            return None
+
+        token = frame.get("access_token")
+        client = frame.get("client")
+        if (
+            not isinstance(token, str)
+            or not token.strip()
+            or (client is not None and not isinstance(client, dict))
+        ):
+            self._send(
+                ws,
+                mev.auth_error_event(merr.AUTH_TOKEN_INVALID, "Invalid auth frame."),
+            )
+            self._close(ws, CLOSE_UNAUTHENTICATED, "Not authenticated")
+            return None
+
+        try:
+            principal = authenticate_token(self._services, token.strip())
+        except MobileApiError as exc:
+            self._send(ws, mev.auth_error_event(exc.code, exc.message))
+            self._close(ws, CLOSE_UNAUTHENTICATED, "Not authenticated")
+            return None
+
+        from rex.mobile_api import users as musers  # noqa: PLC0415
+
+        projection = musers.build_user_projection(
+            self._services.db_path, principal.user_id, principal.username
+        )
+        self._send(ws, mev.auth_ok_event(principal.session_id, projection))
+        return principal
+
+    def _session_active(self, principal: MobilePrincipal) -> bool:
+        store = self._services.session_store
+        session = store.get_session(principal.session_id)
+        if session is None or session["revoked_at"] is not None:
+            return False
+        return store.session_is_active(session, store.now())
+
+    # ── Connection loop ─────────────────────────────────────────────────
+
+    def handle(self, ws: Any, remote_addr: str) -> None:
+        if not self._connection_limiter.allow(remote_addr or "unknown"):
+            self._close(ws, CLOSE_RATE_LIMITED, "Connection rate limited")
+            return
+
+        principal = self._authenticate(ws)
+        if principal is None:
+            return
+
+        message_limiter = SlidingWindowLimiter(self._message_limit)
+        last_session_check = time.monotonic()
+        logger.info("Mobile WebSocket authenticated (session=%s)", principal.session_id)
+
+        while True:
+            try:
+                raw = ws.receive(timeout=IDLE_POLL_SECONDS)
+            except Exception:
+                return  # closed by the client
+
+            # Bounded-interval session revalidation, including while idle.
+            now = time.monotonic()
+            if now - last_session_check >= SESSION_RECHECK_SECONDS:
+                if not self._session_active(principal):
+                    self._close(ws, CLOSE_UNAUTHENTICATED, "Session revoked")
+                    return
+                last_session_check = now
+            if raw is None:
+                continue
+
+            if isinstance(raw, (bytes, bytearray)):
+                raw = raw.decode("utf-8", errors="replace")
+            if len(raw) > MAX_FRAME_BYTES:
+                # Oversized frames are rejected without processing.
+                self._protocol_error(ws, merr.BAD_REQUEST, "Frame too large.")
+                continue
+
+            try:
+                frame = json.loads(raw)
+            except ValueError:
+                self._protocol_error(ws, merr.BAD_REQUEST, "Frame is not valid JSON.")
+                continue
+            if not isinstance(frame, dict) or not isinstance(frame.get("type"), str):
+                self._protocol_error(ws, merr.BAD_REQUEST, "Frame must have a type.")
+                continue
+
+            frame_type = frame["type"]
+            if frame_type == "ping":
+                self._send(ws, mev.pong_event(self._now_iso()))
+                continue
+            if frame_type == "auth":
+                # The connection principal is immutable.
+                self._protocol_error(ws, merr.BAD_REQUEST, "Connection is already authenticated.")
+                continue
+            if frame_type != "chat":
+                self._protocol_error(ws, merr.BAD_REQUEST, "Unsupported frame type.")
+                continue
+
+            if not message_limiter.allow(principal.session_id):
+                self._close(ws, CLOSE_RATE_LIMITED, "Message rate limited")
+                return
+
+            # Session must still be live before every privileged message.
+            if not self._session_active(principal):
+                self._close(ws, CLOSE_UNAUTHENTICATED, "Session revoked")
+                return
+            last_session_check = time.monotonic()
+
+            if not self._handle_chat_frame(ws, principal, frame):
+                return
+
+    def _now_iso(self) -> str:
+        return self._services.clock().isoformat()
+
+    def _handle_chat_frame(
+        self, ws: Any, principal: MobilePrincipal, frame: dict[str, Any]
+    ) -> bool:
+        """Process one chat frame.  Returns False when the socket is gone."""
+        services = self._services
+        try:
+            chat_request = parse_chat_payload(frame)
+        except MobileApiError as exc:
+            self._protocol_error(
+                ws,
+                exc.code,
+                exc.message,
+                message_id=str(frame.get("message_id") or "") or None,
+            )
+            return True
+
+        request_hash = idem.compute_request_hash(chat_request.semantic_fields())
+        reservation = services.message_store.reserve(
+            principal.user_id,
+            chat_request.message_id,
+            chat_request.conversation_id,
+            request_hash,
+        )
+
+        if reservation.outcome == idem.CONFLICT:
+            self._protocol_error(
+                ws,
+                merr.IDEMPOTENCY_CONFLICT,
+                "This message ID was already used with a different request.",
+                message_id=chat_request.message_id,
+            )
+            return True
+
+        # Reservation is durable — acknowledge (original ack for duplicates).
+        self._send(ws, mev.ack_event(chat_request.message_id, self._now_iso()))
+
+        if reservation.outcome == idem.DUPLICATE_COMPLETED:
+            stored = json.loads(reservation.response_json or "{}")
+            self._send(
+                ws,
+                mev.message_done_event(
+                    chat_request.message_id,
+                    chat_request.conversation_id,
+                    str(stored.get("response", "")),
+                    status=str(stored.get("status", STATUS_COMPLETED)),
+                ),
+            )
+            return True
+        if reservation.outcome == idem.DUPLICATE_FAILED:
+            self._send(
+                ws,
+                mev.error_event(
+                    reservation.error_code or merr.INTERNAL_ERROR,
+                    "A previous attempt of this message failed. " "Send a new message ID to retry.",
+                    message_id=chat_request.message_id,
+                ),
+            )
+            return True
+        if reservation.outcome == idem.DUPLICATE_PROCESSING:
+            self._send(
+                ws,
+                mev.error_event(
+                    merr.REQUEST_IN_PROGRESS,
+                    "This message is already being processed.",
+                    message_id=chat_request.message_id,
+                    retryable=True,
+                ),
+            )
+            return True
+
+        # New reservation: execute exactly once via the canonical Assistant
+        # with the connection's immutable principal identity.
+        store = services.message_store
+        collected: list[str] = []
+        try:
+            for chunk in services.chat_service.stream(
+                chat_request.message, user_id=principal.user_id
+            ):
+                collected.append(chunk)
+                self._send(ws, mev.token_event(chat_request.message_id, chunk))
+        except MobileApiError as exc:
+            store.fail(principal.user_id, chat_request.message_id, exc.code)
+            try:
+                self._send(
+                    ws,
+                    mev.error_event(
+                        exc.code,
+                        exc.message,
+                        message_id=chat_request.message_id,
+                        retryable=exc.retryable,
+                    ),
+                )
+            except Exception:
+                return False
+            return True
+        except Exception as exc:
+            if _is_connection_closed(exc):
+                # Socket dropped mid-stream: coherent terminal state so a
+                # replayed ID never re-executes the Assistant or tools.
+                store.fail(principal.user_id, chat_request.message_id, CLIENT_DISCONNECTED)
+                return False
+            logger.exception("Mobile WebSocket chat failed (session=%s)", principal.session_id)
+            store.fail(principal.user_id, chat_request.message_id, merr.INTERNAL_ERROR)
+            try:
+                self._send(
+                    ws,
+                    mev.error_event(
+                        merr.INTERNAL_ERROR,
+                        "An unexpected error occurred.",
+                        message_id=chat_request.message_id,
+                    ),
+                )
+            except Exception:
+                return False
+            return True
+
+        full_content = "".join(collected)
+        body: dict[str, object] = {
+            "request_id": None,
+            "message_id": chat_request.message_id,
+            "conversation_id": chat_request.conversation_id,
+            "response": full_content,
+            "status": STATUS_COMPLETED,
+            "events": [],
+        }
+        # Terminal result is stored before message_done is announced.
+        store.complete(
+            principal.user_id, chat_request.message_id, json.dumps(body, ensure_ascii=True)
+        )
+        try:
+            self._send(
+                ws,
+                mev.message_done_event(
+                    chat_request.message_id,
+                    chat_request.conversation_id,
+                    full_content,
+                    status=STATUS_COMPLETED,
+                ),
+            )
+        except Exception:
+            return False
+        return True
+
+
+def _is_connection_closed(exc: Exception) -> bool:
+    try:
+        from simple_websocket import ConnectionClosed, ConnectionError  # noqa: PLC0415
+
+        return isinstance(exc, (ConnectionClosed, ConnectionError))
+    except ImportError:  # pragma: no cover - only without the dependency
+        return False
+
+
+def websocket_dependency_available() -> bool:
+    """True when the validated Flask WebSocket stack is importable."""
+    return find_spec("flask_sock") is not None and find_spec("simple_websocket") is not None
+
+
+def register_websocket(app: Any, services: MobileApiServices) -> bool:
+    """Register ``WebSocket /mobile/chat/stream`` when the stack is present.
+
+    Returns True when the route was registered; False (and the
+    ``websocket_chat`` capability stays false) when the dependency is
+    missing.
+    """
+    if not websocket_dependency_available():
+        logger.info("flask-sock not installed; mobile WebSocket chat disabled")
+        return False
+
+    from flask import request  # noqa: PLC0415
+    from flask_sock import Sock  # noqa: PLC0415
+
+    sock = Sock(app)
+    server = MobileWebSocketServer(services)
+    app.extensions["mobile_api_websocket"] = server
+
+    @sock.route("/mobile/chat/stream")
+    def mobile_chat_stream(ws: Any) -> None:  # pragma: no cover - thin wiring
+        server.handle(ws, request.remote_addr or "unknown")
+
+    return True
+
+
+__all__ = [
+    "AUTH_TIMEOUT_SECONDS",
+    "CLOSE_AUTH_TIMEOUT",
+    "CLOSE_FORBIDDEN",
+    "CLOSE_RATE_LIMITED",
+    "CLOSE_UNAUTHENTICATED",
+    "CONNECTIONS_PER_MINUTE",
+    "MAX_FRAME_BYTES",
+    "MobileWebSocketServer",
+    "SlidingWindowLimiter",
+    "register_websocket",
+    "websocket_dependency_available",
+]

--- a/rex/mobile_api/websocket.py
+++ b/rex/mobile_api/websocket.py
@@ -14,9 +14,12 @@ Protocol (master spec §7):
   immutable principal to the connection — later frames can never replace
   identity.
 - ``auth_ok`` / ``auth_error`` frames; close codes ``4401`` (missing,
-  invalid, expired, or revoked authentication), ``4403`` (authenticated but
-  forbidden), ``4408`` (auth timeout), ``4429`` (connection/message rate
-  limits).
+  invalid, expired, or revoked authentication), ``4408`` (auth timeout),
+  ``4429`` (connection/message rate limits).  ``4403`` is RESERVED for a
+  future authenticated authorization denial: the canonical permission model
+  (``rex.permissions``) gates tools at dispatch time, not chat access, so
+  Session 2 has no real authenticated-but-forbidden condition and no code
+  path emits 4403.  Clients must still handle it defensively.
 - Chat frames validate the canonical schema, reserve the shared
   ``(user_id, message_id)`` idempotency record, then ``ack`` with
   ``message_id``/``accepted_at`` — reservation strictly precedes the ack.
@@ -48,6 +51,10 @@ logger = logging.getLogger(__name__)
 
 # Close codes (master spec §7.1).
 CLOSE_UNAUTHENTICATED = 4401
+# RESERVED: no Session 2 code path closes with 4403.  Chat access is not
+# gated by rex.permissions (permissions authorize tools at dispatch), so an
+# authenticated principal is never "forbidden" from chat today.  The code
+# stays in the wire contract for future server-side authorization denial.
 CLOSE_FORBIDDEN = 4403
 CLOSE_AUTH_TIMEOUT = 4408
 CLOSE_RATE_LIMITED = 4429

--- a/tests/mobile_api/conftest.py
+++ b/tests/mobile_api/conftest.py
@@ -97,9 +97,13 @@ class FakeChatService:
     """
 
     def __init__(self) -> None:
+        self.available = True
         self.calls: list[tuple[str, str]] = []
         self.fail_with: Exception | None = None
         self.stream_fail_after_chunks: int | None = None
+
+    def availability(self) -> tuple[bool, str]:
+        return (self.available, "ok" if self.available else "fake chat disabled")
 
     def _reply(self, message: str, user_id: str) -> str:
         return f"echo[{user_id}]: {message}"

--- a/tests/mobile_api/conftest.py
+++ b/tests/mobile_api/conftest.py
@@ -83,12 +83,165 @@ def audit_recorder() -> RecordingAuditLogger:
     return RecordingAuditLogger()
 
 
+# ---------------------------------------------------------------------------
+# Fake runtime adapters (Session 2) — deterministic, no ML dependencies.
+# ---------------------------------------------------------------------------
+
+
+class FakeChatService:
+    """Deterministic stand-in for MobileChatService.
+
+    Replies embed the calling user's ID so cross-user isolation failures are
+    visible, and every execution is recorded so idempotency tests can assert
+    exactly-once behaviour.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.fail_with: Exception | None = None
+        self.stream_fail_after_chunks: int | None = None
+
+    def _reply(self, message: str, user_id: str) -> str:
+        return f"echo[{user_id}]: {message}"
+
+    def generate(self, message: str, *, user_id: str, voice_mode: bool = False) -> str:
+        if self.fail_with is not None:
+            raise self.fail_with
+        self.calls.append((message, user_id))
+        return self._reply(message, user_id)
+
+    def stream(self, message: str, *, user_id: str):
+        if self.fail_with is not None:
+            raise self.fail_with
+        self.calls.append((message, user_id))
+        text = self._reply(message, user_id)
+        chunks = [text[i : i + 6] for i in range(0, len(text), 6)]
+        for index, chunk in enumerate(chunks):
+            if self.stream_fail_after_chunks is not None and index >= self.stream_fail_after_chunks:
+                from rex.mobile_api import errors as merr
+                from rex.mobile_api.errors import MobileApiError
+
+                raise MobileApiError(
+                    merr.BACKEND_UNAVAILABLE,
+                    "Rex is temporarily unavailable.",
+                    503,
+                    retryable=True,
+                )
+            yield chunk
+
+
+class FakeSttAdapter:
+    """Deterministic stand-in for SpeechToTextAdapter."""
+
+    def __init__(self) -> None:
+        self.available = True
+        self.unavailable_reason = "fake STT disabled"
+        self.transcript = "turn off the downstairs lights"
+        self.decode_seconds = 2.0
+        self.decoded_paths: list[str] = []
+        self.decode_fails = False
+
+    def availability(self) -> tuple[bool, str]:
+        return (True, "ok") if self.available else (False, self.unavailable_reason)
+
+    def require_available(self) -> None:
+        if not self.available:
+            from rex.mobile_api import errors as merr
+            from rex.mobile_api.errors import MobileApiError
+
+            raise MobileApiError(
+                merr.BACKEND_UNAVAILABLE,
+                "Speech-to-text is not available on this server.",
+                503,
+                retryable=False,
+            )
+
+    def decode(self, path: str):
+        self.require_available()
+        self.decoded_paths.append(path)
+        if self.decode_fails:
+            from rex.mobile_api import errors as merr
+            from rex.mobile_api.errors import MobileApiError
+
+            raise MobileApiError(merr.INVALID_MEDIA, "The audio could not be decoded.", 415)
+        from rex.mobile_api.voice import WHISPER_SAMPLE_RATE
+
+        return [0.0] * int(self.decode_seconds * WHISPER_SAMPLE_RATE)
+
+    def transcribe(self, audio) -> str:
+        self.require_available()
+        return self.transcript
+
+
+class FakeTtsAdapter:
+    """Deterministic stand-in for TextToSpeechAdapter."""
+
+    def __init__(self) -> None:
+        self.available = True
+        self.known_voices = ["fake-default-voice", "fake-alt-voice"]
+        self.audio = b"FAKE-TTS-AUDIO"
+        self.synthesized: list[tuple[str, str]] = []
+
+    def availability(self) -> tuple[bool, str]:
+        return (True, "ok") if self.available else (False, "fake TTS disabled")
+
+    def require_available(self) -> None:
+        if not self.available:
+            from rex.mobile_api import errors as merr
+            from rex.mobile_api.errors import MobileApiError
+
+            raise MobileApiError(
+                merr.BACKEND_UNAVAILABLE,
+                "Text-to-speech is not available on this server.",
+                503,
+                retryable=False,
+            )
+
+    def mime_type(self) -> str:
+        return "audio/wav"
+
+    def resolve_voice(self, requested: str | None) -> str:
+        self.require_available()
+        if requested is None or requested.strip() in ("", "default"):
+            return self.known_voices[0]
+        requested = requested.strip()
+        if requested not in self.known_voices:
+            from rex.mobile_api import errors as merr
+            from rex.mobile_api.errors import MobileApiError
+
+            raise MobileApiError(merr.BAD_REQUEST, "The requested voice is not available.", 400)
+        return requested
+
+    def synthesize(self, text: str, voice_id: str) -> bytes:
+        self.require_available()
+        self.synthesized.append((text, voice_id))
+        return self.audio
+
+
+@pytest.fixture()
+def fake_chat_service() -> FakeChatService:
+    return FakeChatService()
+
+
+@pytest.fixture()
+def fake_stt() -> FakeSttAdapter:
+    return FakeSttAdapter()
+
+
+@pytest.fixture()
+def fake_tts() -> FakeTtsAdapter:
+    return FakeTtsAdapter()
+
+
 @pytest.fixture()
 def services(
     mobile_env: Path,
     clock: FakeClock,
     mobile_config,
     audit_recorder: RecordingAuditLogger,
+    fake_chat_service: FakeChatService,
+    fake_stt: FakeSttAdapter,
+    fake_tts: FakeTtsAdapter,
 ):
     from rex.mobile_api.db import migrate_users_db
     from rex.mobile_api.services import MobileApiServices
@@ -96,7 +249,13 @@ def services(
     db_path = mobile_env / "users.db"
     migrate_users_db(db_path)
     return MobileApiServices.build(
-        mobile_config, db_path=db_path, clock=clock, audit_logger=audit_recorder
+        mobile_config,
+        db_path=db_path,
+        clock=clock,
+        audit_logger=audit_recorder,
+        chat_service=fake_chat_service,
+        stt=fake_stt,
+        tts=fake_tts,
     )
 
 
@@ -159,3 +318,33 @@ def login_tokens(client, username: str, password: str) -> dict:
     response = login(client, username, password)
     assert response.status_code == 200, response.get_json()
     return response.get_json()
+
+
+def chat_payload(message: str = "Hello Rex", **overrides) -> dict:
+    """Canonical valid chat request body with fresh UUIDs."""
+    import uuid
+
+    payload = {
+        "message_id": str(uuid.uuid4()),
+        "conversation_id": str(uuid.uuid4()),
+        "sent_at": "2026-07-15T12:00:00+00:00",
+        "message": message,
+        "mode": "mobile_text",
+        "client_context": {"device": "iphone", "response_preference": "brief"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def parse_sse_events(body: bytes) -> list[dict]:
+    """Parse an SSE body into its JSON event payloads (strict)."""
+    import json as _json
+
+    events = []
+    for line in body.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        assert line.startswith("data: "), f"non-SSE line in stream: {line!r}"
+        events.append(_json.loads(line[len("data: ") :]))
+    return events

--- a/tests/mobile_api/contract_vectors.json
+++ b/tests/mobile_api/contract_vectors.json
@@ -1,0 +1,237 @@
+{
+  "contract_version": "2026-07-15.323.2",
+  "api_version": "1.0",
+  "statuses": {
+    "normal_chat": "completed",
+    "action_statuses": ["attempted", "completed", "verified", "failed", "needs_confirmation"]
+  },
+  "http": {
+    "login_request": {
+      "username": "james",
+      "password": "<password>",
+      "device": {
+        "device_id": "b6a7f7e4-0c3d-4c19-9d8b-3f45f4f0a111",
+        "name": "James's iPhone",
+        "platform": "ios",
+        "app_version": "0.1.0"
+      }
+    },
+    "login_response": {
+      "access_token": "<jwt>",
+      "refresh_token": "<opaque-token>",
+      "token_type": "Bearer",
+      "expires_in": 900,
+      "refresh_expires_in": 2592000,
+      "session_id": "0d9c3a52-6f4e-4e91-8b7c-2f81f3f0a222",
+      "user": {
+        "id": "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "James",
+        "role": "owner",
+        "permissions": ["admin"],
+        "color": "#2D7FF9"
+      }
+    },
+    "refresh_request": {
+      "refresh_token": "<opaque-token>"
+    },
+    "refresh_response": {
+      "access_token": "<jwt>",
+      "refresh_token": "<rotated-opaque-token>",
+      "token_type": "Bearer",
+      "expires_in": 900,
+      "refresh_expires_in": 2592000,
+      "session_id": "0d9c3a52-6f4e-4e91-8b7c-2f81f3f0a222",
+      "user": {
+        "id": "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "James",
+        "role": "owner",
+        "permissions": ["admin"],
+        "color": "#2D7FF9"
+      }
+    },
+    "session_response": {
+      "session_id": "0d9c3a52-6f4e-4e91-8b7c-2f81f3f0a222",
+      "user": {
+        "id": "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "James",
+        "role": "owner",
+        "permissions": ["admin"],
+        "color": "#2D7FF9"
+      }
+    },
+    "error_envelope": {
+      "error": {
+        "code": "AUTH_INVALID_CREDENTIALS",
+        "message": "Invalid username or password.",
+        "retryable": false,
+        "request_id": "9a2b1c3d-4444-4444-8444-444444444444"
+      }
+    },
+    "chat_request": {
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "conversation_id": "5f8f1f2a-2222-4222-8222-222222222222",
+      "sent_at": "2026-07-15T12:00:00+00:00",
+      "message": "Turn off the downstairs lights",
+      "mode": "mobile_text",
+      "client_context": {
+        "device": "iphone",
+        "location_hint": "home",
+        "response_preference": "brief"
+      }
+    },
+    "chat_response": {
+      "request_id": "9a2b1c3d-4444-4444-8444-444444444444",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "conversation_id": "5f8f1f2a-2222-4222-8222-222222222222",
+      "response": "The downstairs lights are off.",
+      "status": "completed",
+      "events": []
+    },
+    "sse": {
+      "content_type": "text/event-stream",
+      "data_prefix": "data: ",
+      "terminal_events": ["message_done", "error"],
+      "idempotency_header": "Idempotency-Key"
+    },
+    "voice_response": {
+      "request_id": "9a2b1c3d-4444-4444-8444-444444444444",
+      "transcript": "Turn off the downstairs lights",
+      "response": "The downstairs lights are off.",
+      "status": "completed",
+      "tool_used": null,
+      "tts_base64": "<base64-audio>",
+      "tts_mime_type": "audio/mpeg"
+    },
+    "tts_request": {
+      "text": "The downstairs lights are off.",
+      "voice": "default"
+    },
+    "tts_response": {
+      "request_id": "9a2b1c3d-4444-4444-8444-444444444444",
+      "audio_base64": "<base64-audio>",
+      "mime_type": "audio/mpeg",
+      "voice": "default"
+    },
+    "capabilities_response": {
+      "api_version": "1.0",
+      "minimum_app_version": "0.1.0",
+      "server_version": "<package-version>",
+      "features": {
+        "authentication": true,
+        "chat": true,
+        "chat_streaming": true,
+        "websocket_chat": true,
+        "voice_upload": true,
+        "tts": true,
+        "live_voice": false,
+        "notifications": false,
+        "approvals": false,
+        "home_assistant": false
+      }
+    }
+  },
+  "websocket": {
+    "url_path": "/mobile/chat/stream",
+    "auth_frame": {
+      "type": "auth",
+      "access_token": "<jwt>",
+      "client": {
+        "platform": "ios",
+        "app_version": "0.1.0",
+        "device_id": "b6a7f7e4-0c3d-4c19-9d8b-3f45f4f0a111"
+      }
+    },
+    "auth_ok": {
+      "type": "auth_ok",
+      "session_id": "0d9c3a52-6f4e-4e91-8b7c-2f81f3f0a222",
+      "user": {
+        "id": "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "James",
+        "role": "owner",
+        "permissions": ["admin"],
+        "color": "#2D7FF9"
+      }
+    },
+    "auth_error": {
+      "type": "auth_error",
+      "code": "AUTH_TOKEN_EXPIRED",
+      "message": "Access token expired."
+    },
+    "chat_frame": {
+      "type": "chat",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "conversation_id": "5f8f1f2a-2222-4222-8222-222222222222",
+      "sent_at": "2026-07-15T12:00:00+00:00",
+      "message": "Hello Rex",
+      "mode": "mobile_text",
+      "client_context": {
+        "device": "iphone",
+        "location_hint": "home",
+        "response_preference": "brief"
+      }
+    },
+    "ack": {
+      "type": "ack",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "accepted_at": "2026-07-15T12:00:01+00:00"
+    },
+    "token": {
+      "type": "token",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "content": "."
+    },
+    "tool_call": {
+      "type": "tool_call",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "tool": "home_assistant",
+      "action": "turn_off",
+      "target": "downstairs lights"
+    },
+    "tool_result": {
+      "type": "tool_result",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "tool": "home_assistant",
+      "action": "turn_off",
+      "status": "verified",
+      "message": "Downstairs lights are off."
+    },
+    "approval_required": {
+      "type": "approval_required",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "approval_id": "7c1d2e3f-5555-4555-8555-555555555555",
+      "risk_level": "critical",
+      "action": "unlock_front_door",
+      "requires_biometric": true,
+      "expires_at": "2026-07-15T12:05:00+00:00"
+    },
+    "message_done": {
+      "type": "message_done",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "conversation_id": "5f8f1f2a-2222-4222-8222-222222222222",
+      "full_content": "Hello! How can I help?",
+      "status": "completed"
+    },
+    "error": {
+      "type": "error",
+      "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+      "code": "BACKEND_UNAVAILABLE",
+      "message": "Rex is temporarily unavailable.",
+      "retryable": true,
+      "request_id": "9a2b1c3d-4444-4444-8444-444444444444"
+    },
+    "ping": {
+      "type": "ping",
+      "sent_at": "2026-07-15T12:00:00+00:00"
+    },
+    "pong": {
+      "type": "pong",
+      "sent_at": "2026-07-15T12:00:00+00:00"
+    },
+    "close_codes": {
+      "unauthenticated": 4401,
+      "forbidden": 4403,
+      "auth_timeout": 4408,
+      "rate_limited": 4429
+    }
+  }
+}

--- a/tests/mobile_api/contract_vectors.json
+++ b/tests/mobile_api/contract_vectors.json
@@ -110,7 +110,8 @@
       "request_id": "9a2b1c3d-4444-4444-8444-444444444444",
       "audio_base64": "<base64-audio>",
       "mime_type": "audio/mpeg",
-      "voice": "default"
+      "voice": "en-US-AriaNeural",
+      "requested_voice": "default"
     },
     "capabilities_response": {
       "api_version": "1.0",

--- a/tests/mobile_api/test_chat_http.py
+++ b/tests/mobile_api/test_chat_http.py
@@ -1,0 +1,191 @@
+"""HTTP chat route tests (POST /mobile/chat).
+
+Matrix rows: CHAT-001..CHAT-009, CHAT-013..CHAT-017, IDP-002, IDP-007.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from rex.mobile_api import errors as merr
+from rex.mobile_api.errors import MobileApiError
+from tests.mobile_api.conftest import (
+    auth_header,
+    chat_payload,
+    create_user,
+    login_tokens,
+)
+
+
+def _authed(client, username: str = "james", password: str = "pw-123456") -> tuple[str, dict]:
+    user_id = create_user(username, password)
+    tokens = login_tokens(client, username, password)
+    return user_id, auth_header(tokens["access_token"])
+
+
+class TestChatAuthentication:
+    def test_missing_auth_rejected_before_execution(self, client, fake_chat_service) -> None:
+        """CHAT-002: no principal → no idempotency, no Assistant call."""
+        response = client.post("/mobile/chat", json=chat_payload())
+        assert response.status_code == 401
+        assert fake_chat_service.calls == []
+
+    def test_client_user_id_rejected(self, client, fake_chat_service) -> None:
+        """CHAT-003: client identity fields are rejected outright."""
+        _, headers = _authed(client)
+        response = client.post(
+            "/mobile/chat", json=chat_payload(user_id="someone-else"), headers=headers
+        )
+        assert response.status_code == 400
+        assert fake_chat_service.calls == []
+
+    def test_client_authorization_fields_rejected(self, client, fake_chat_service) -> None:
+        """CHAT-004: role/permissions/risk/approval claims never execute."""
+        _, headers = _authed(client)
+        for field in ("role", "permissions", "risk", "approval", "biometric_verified"):
+            response = client.post(
+                "/mobile/chat", json=chat_payload(**{field: "admin"}), headers=headers
+            )
+            assert response.status_code == 400, field
+        assert fake_chat_service.calls == []
+
+
+class TestChatValidation:
+    def test_empty_message_rejected(self, client) -> None:
+        _, headers = _authed(client)
+        response = client.post("/mobile/chat", json=chat_payload(message="  "), headers=headers)
+        assert response.status_code == 400
+
+    def test_oversized_message_rejected(self, client, fake_chat_service) -> None:
+        """CHAT-005: size validation happens before the Assistant."""
+        _, headers = _authed(client)
+        response = client.post(
+            "/mobile/chat", json=chat_payload(message="x" * 8_001), headers=headers
+        )
+        assert response.status_code == 400
+        assert fake_chat_service.calls == []
+
+    def test_invalid_message_id_rejected(self, client, services) -> None:
+        """CHAT-006: invalid IDs fail before reservation."""
+        _, headers = _authed(client)
+        payload = chat_payload(message_id="not-a-uuid")
+        response = client.post("/mobile/chat", json=payload, headers=headers)
+        assert response.status_code == 400
+
+    def test_invalid_conversation_id_rejected(self, client) -> None:
+        """CHAT-007."""
+        _, headers = _authed(client)
+        response = client.post(
+            "/mobile/chat", json=chat_payload(conversation_id="nope"), headers=headers
+        )
+        assert response.status_code == 400
+
+    def test_invalid_sent_at_rejected(self, client) -> None:
+        _, headers = _authed(client)
+        response = client.post(
+            "/mobile/chat", json=chat_payload(sent_at="yesterday"), headers=headers
+        )
+        assert response.status_code == 400
+
+    def test_wrong_mode_rejected(self, client) -> None:
+        _, headers = _authed(client)
+        response = client.post("/mobile/chat", json=chat_payload(mode="desktop"), headers=headers)
+        assert response.status_code == 400
+
+    def test_idempotency_header_mismatch_conflicts(self, client, fake_chat_service) -> None:
+        """CHAT-008: header/body message ID mismatch → conflict, no execution."""
+        _, headers = _authed(client)
+        headers["Idempotency-Key"] = str(uuid.uuid4())
+        response = client.post("/mobile/chat", json=chat_payload(), headers=headers)
+        assert response.status_code == 409
+        assert response.get_json()["error"]["code"] == "IDEMPOTENCY_CONFLICT"
+        assert fake_chat_service.calls == []
+
+
+class TestChatExecution:
+    def test_valid_chat_calls_assistant_once_with_principal(
+        self, client, fake_chat_service
+    ) -> None:
+        """CHAT-001/CHAT-016: canonical Assistant, explicit principal identity."""
+        user_id, headers = _authed(client)
+        payload = chat_payload("What time is it?")
+        headers["Idempotency-Key"] = payload["message_id"]
+        response = client.post("/mobile/chat", json=payload, headers=headers)
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["message_id"] == payload["message_id"]
+        assert body["conversation_id"] == payload["conversation_id"]
+        assert body["status"] == "completed"
+        assert body["events"] == []
+        assert body["request_id"]
+        assert body["response"] == f"echo[{user_id}]: What time is it?"
+        assert fake_chat_service.calls == [("What time is it?", user_id)]
+
+    def test_normal_response_status_is_completed_not_verified(self, client) -> None:
+        """CHAT-009."""
+        _, headers = _authed(client)
+        response = client.post("/mobile/chat", json=chat_payload(), headers=headers)
+        assert response.get_json()["status"] == "completed"
+
+    def test_exact_duplicate_replays_without_second_execution(
+        self, client, fake_chat_service
+    ) -> None:
+        """IDP-002: one Assistant execution for repeated delivery."""
+        _, headers = _authed(client)
+        payload = chat_payload("only once")
+        first = client.post("/mobile/chat", json=payload, headers=headers)
+        second = client.post("/mobile/chat", json=payload, headers=headers)
+        assert first.status_code == 200 and second.status_code == 200
+        assert first.get_json()["response"] == second.get_json()["response"]
+        assert len(fake_chat_service.calls) == 1
+
+    def test_same_id_different_payload_conflicts(self, client, fake_chat_service) -> None:
+        """IDP-007."""
+        _, headers = _authed(client)
+        payload = chat_payload("original")
+        client.post("/mobile/chat", json=payload, headers=headers)
+        changed = dict(payload, message="tampered")
+        response = client.post("/mobile/chat", json=changed, headers=headers)
+        assert response.status_code == 409
+        assert response.get_json()["error"]["code"] == "IDEMPOTENCY_CONFLICT"
+        assert len(fake_chat_service.calls) == 1
+
+    def test_backend_failure_is_structured_never_mock(self, client, fake_chat_service) -> None:
+        """CHAT-013: BACKEND_UNAVAILABLE, and a retry replays the failure."""
+        _, headers = _authed(client)
+        fake_chat_service.fail_with = MobileApiError(
+            merr.BACKEND_UNAVAILABLE, "Rex is temporarily unavailable.", 503, retryable=True
+        )
+        payload = chat_payload()
+        response = client.post("/mobile/chat", json=payload, headers=headers)
+        assert response.status_code == 503
+        error = response.get_json()["error"]
+        assert error["code"] == "BACKEND_UNAVAILABLE"
+        assert error["retryable"] is True
+
+        # The failure is terminal for this message ID; no re-execution.
+        fake_chat_service.fail_with = None
+        retry = client.post("/mobile/chat", json=payload, headers=headers)
+        assert retry.status_code == 503
+        assert retry.get_json()["error"]["code"] == "BACKEND_UNAVAILABLE"
+        assert fake_chat_service.calls == []
+
+    def test_two_users_are_isolated(self, client, fake_chat_service) -> None:
+        """CHAT-014/IDP-008: same message ID, both execute, separate identity."""
+        user_a, headers_a = _authed(client, "james", "pw-123456")
+        user_b, headers_b = _authed(client, "cole", "pw-abcdef")
+        payload = chat_payload("shared prompt")
+        response_a = client.post("/mobile/chat", json=payload, headers=headers_a)
+        response_b = client.post("/mobile/chat", json=payload, headers=headers_b)
+        assert response_a.status_code == 200 and response_b.status_code == 200
+        assert response_a.get_json()["response"] == f"echo[{user_a}]: shared prompt"
+        assert response_b.get_json()["response"] == f"echo[{user_b}]: shared prompt"
+        assert {call[1] for call in fake_chat_service.calls} == {user_a, user_b}
+
+    def test_message_body_not_logged(self, client, caplog) -> None:
+        """CHAT-017: chat text never appears in server logs."""
+        _, headers = _authed(client)
+        secret_text = "the-vault-code-is-9137"
+        with caplog.at_level("DEBUG"):
+            client.post("/mobile/chat", json=chat_payload(secret_text), headers=headers)
+        assert secret_text not in caplog.text

--- a/tests/mobile_api/test_chat_http.py
+++ b/tests/mobile_api/test_chat_http.py
@@ -185,7 +185,7 @@ class TestChatExecution:
     def test_message_body_not_logged(self, client, caplog) -> None:
         """CHAT-017: chat text never appears in server logs."""
         _, headers = _authed(client)
-        secret_text = "the-vault-code-is-9137"
+        secret_text = "the-vault-code-is-9137"  # pragma: allowlist secret
         with caplog.at_level("DEBUG"):
             client.post("/mobile/chat", json=chat_payload(secret_text), headers=headers)
         assert secret_text not in caplog.text

--- a/tests/mobile_api/test_chat_stream.py
+++ b/tests/mobile_api/test_chat_stream.py
@@ -1,0 +1,128 @@
+"""SSE streaming chat tests (POST /mobile/chat/stream).
+
+Matrix rows: SSE-001..SSE-004, SSE-006, SSE-008, SSE-009.
+"""
+
+from __future__ import annotations
+
+from tests.mobile_api.conftest import (
+    auth_header,
+    chat_payload,
+    create_user,
+    login_tokens,
+    parse_sse_events,
+)
+
+
+def _authed(client, username: str = "james", password: str = "pw-123456") -> tuple[str, dict]:
+    user_id = create_user(username, password)
+    tokens = login_tokens(client, username, password)
+    return user_id, auth_header(tokens["access_token"])
+
+
+class TestSseGrammar:
+    def test_content_type_and_no_cache(self, client) -> None:
+        """SSE-001."""
+        _, headers = _authed(client)
+        response = client.post("/mobile/chat/stream", json=chat_payload(), headers=headers)
+        assert response.status_code == 200
+        assert response.mimetype == "text/event-stream"
+        assert response.headers["Cache-Control"] == "no-cache"
+
+    def test_token_events_are_canonical_json(self, client) -> None:
+        """SSE-002: every data payload is valid canonical snake_case JSON."""
+        user_id, headers = _authed(client)
+        payload = chat_payload("stream me")
+        response = client.post("/mobile/chat/stream", json=payload, headers=headers)
+        events = parse_sse_events(response.data)
+        assert events, "stream produced no events"
+        token_events = [e for e in events if e["type"] == "token"]
+        assert token_events, "no token events"
+        for event in token_events:
+            assert set(event.keys()) == {"type", "message_id", "content"}
+            assert event["message_id"] == payload["message_id"]
+        reconstructed = "".join(e["content"] for e in token_events)
+        assert reconstructed == f"echo[{user_id}]: stream me"
+
+    def test_exactly_one_terminal_message_done(self, client) -> None:
+        """SSE-003."""
+        _, headers = _authed(client)
+        payload = chat_payload()
+        response = client.post("/mobile/chat/stream", json=payload, headers=headers)
+        events = parse_sse_events(response.data)
+        done_events = [e for e in events if e["type"] == "message_done"]
+        assert len(done_events) == 1
+        done = done_events[0]
+        assert events[-1] == done
+        assert done["message_id"] == payload["message_id"]
+        assert done["conversation_id"] == payload["conversation_id"]
+        assert done["status"] == "completed"
+        assert done["full_content"]
+
+    def test_midstream_failure_emits_structured_terminal_error(
+        self, client, fake_chat_service
+    ) -> None:
+        """SSE-004/SSE-006: failures are structured errors, never prose."""
+        _, headers = _authed(client)
+        fake_chat_service.stream_fail_after_chunks = 1
+        payload = chat_payload("this will break")
+        response = client.post("/mobile/chat/stream", json=payload, headers=headers)
+        events = parse_sse_events(response.data)
+        assert events[-1]["type"] == "error"
+        assert events[-1]["code"] == "BACKEND_UNAVAILABLE"
+        assert events[-1]["retryable"] is True
+        assert all(e["type"] != "message_done" for e in events)
+
+
+class TestSseIdempotency:
+    def test_completed_duplicate_replays_without_execution(self, client, fake_chat_service) -> None:
+        """SSE-008: stored terminal result is replayed; one execution total."""
+        _, headers = _authed(client)
+        payload = chat_payload("stream once")
+        first = client.post("/mobile/chat/stream", json=payload, headers=headers)
+        first_events = parse_sse_events(first.data)
+        second = client.post("/mobile/chat/stream", json=payload, headers=headers)
+        second_events = parse_sse_events(second.data)
+        assert len(fake_chat_service.calls) == 1
+        assert [e["type"] for e in second_events] == ["message_done"]
+        assert (
+            second_events[0]["full_content"]
+            == [e for e in first_events if e["type"] == "message_done"][0]["full_content"]
+        )
+
+    def test_cross_transport_duplicate_with_http(self, client, fake_chat_service) -> None:
+        """IDP-004 (HTTP↔SSE half): same ID over both HTTP routes runs once."""
+        _, headers = _authed(client)
+        payload = chat_payload("cross transport")
+        http_response = client.post("/mobile/chat", json=payload, headers=headers)
+        assert http_response.status_code == 200
+        sse_response = client.post("/mobile/chat/stream", json=payload, headers=headers)
+        events = parse_sse_events(sse_response.data)
+        assert [e["type"] for e in events] == ["message_done"]
+        assert events[0]["full_content"] == http_response.get_json()["response"]
+        assert len(fake_chat_service.calls) == 1
+
+    def test_processing_duplicate_reports_in_progress(self, client, services) -> None:
+        """SSE-009: an in-flight duplicate never executes a second time."""
+        from rex.mobile_api import idempotency as idem
+
+        user_id, headers = _authed(client)
+        payload = chat_payload("in flight")
+        # Simulate an in-flight reservation from another transport.
+        request_hash = idem.compute_request_hash(
+            {
+                "message_id": payload["message_id"],
+                "conversation_id": payload["conversation_id"],
+                "sent_at": payload["sent_at"],
+                "message": payload["message"],
+                "mode": payload["mode"],
+                "client_context": payload["client_context"],
+            }
+        )
+        services.message_store.reserve(
+            user_id, payload["message_id"], payload["conversation_id"], request_hash
+        )
+        response = client.post("/mobile/chat/stream", json=payload, headers=headers)
+        assert response.status_code == 409
+        assert response.get_json()["error"]["code"] == "REQUEST_IN_PROGRESS"
+        assert response.get_json()["error"]["retryable"] is True

--- a/tests/mobile_api/test_chat_websocket.py
+++ b/tests/mobile_api/test_chat_websocket.py
@@ -149,6 +149,25 @@ class TestAuthentication:
         assert ws.sent[0]["type"] == "auth_error"
         assert ws.closed[0] == CLOSE_UNAUTHENTICATED
 
+    def test_4403_is_reserved_chat_is_not_permission_gated(self, client, services) -> None:
+        """4403 contract truthfulness: no Session 2 path emits it.
+
+        The canonical permission model (rex.permissions) authorizes tools at
+        dispatch time, not chat access — so an authenticated user with ZERO
+        granted permissions still chats normally and is never closed with
+        4403.  The code remains reserved in the wire contract for a future
+        server-side authorization denial.
+        """
+        from rex.mobile_api.websocket import CLOSE_FORBIDDEN
+        from rex.permissions import get_permissions
+
+        user_id, token = _login(client)  # created without any permissions
+        assert get_permissions(user_id) == []
+        ws = _run(services, [_auth_frame(token), _chat_frame("hello with no permissions")])
+        assert ws.sent[0]["type"] == "auth_ok"
+        assert [e["type"] for e in ws.sent][-1] == "message_done"
+        assert ws.closed is None or ws.closed[0] != CLOSE_FORBIDDEN
+
     def test_revoked_session_token_closes_4401(self, client, services) -> None:
         _, token = _login(client)
         from tests.mobile_api.conftest import auth_header

--- a/tests/mobile_api/test_chat_websocket.py
+++ b/tests/mobile_api/test_chat_websocket.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import json
 import uuid
 
+import pytest
+
 from rex.mobile_api.websocket import (
     CLOSE_AUTH_TIMEOUT,
     CLOSE_RATE_LIMITED,
@@ -109,6 +111,42 @@ class TestAuthentication:
         ws = _run(services, [_auth_frame("not-a-real-token")])
         assert ws.sent[0]["type"] == "auth_error"
         assert ws.sent[0]["code"] in ("AUTH_TOKEN_INVALID", "AUTH_TOKEN_EXPIRED")
+        assert ws.closed[0] == CLOSE_UNAUTHENTICATED
+
+    @pytest.mark.parametrize(
+        "client_metadata",
+        [
+            None,
+            {},
+            {"platform": "ios", "app_version": "0.1.0"},
+            {"platform": "desktop", "app_version": "0.1.0", "device_id": "dev-1"},
+            {"platform": "ios", "app_version": 1, "device_id": "dev-1"},
+            {"platform": "ios", "app_version": "0.1.0", "device_id": "bad id"},
+            {
+                "platform": "ios",
+                "app_version": "0.1.0",
+                "device_id": "dev-1",
+                "unknown": "field",
+            },
+        ],
+    )
+    def test_client_metadata_is_required_and_strict(
+        self, client, services, client_metadata
+    ) -> None:
+        _, token = _login(client)
+        frame = {"type": "auth", "access_token": token}
+        if client_metadata is not None:
+            frame["client"] = client_metadata
+        ws = _run(services, [json.dumps(frame)])
+        assert ws.sent[0]["type"] == "auth_error"
+        assert ws.closed[0] == CLOSE_UNAUTHENTICATED
+
+    def test_unknown_auth_frame_field_is_rejected(self, client, services) -> None:
+        _, token = _login(client)
+        frame = json.loads(_auth_frame(token))
+        frame["user_id"] = "attacker-controlled"
+        ws = _run(services, [json.dumps(frame)])
+        assert ws.sent[0]["type"] == "auth_error"
         assert ws.closed[0] == CLOSE_UNAUTHENTICATED
 
     def test_revoked_session_token_closes_4401(self, client, services) -> None:

--- a/tests/mobile_api/test_chat_websocket.py
+++ b/tests/mobile_api/test_chat_websocket.py
@@ -1,0 +1,330 @@
+"""WebSocket protocol state-machine tests (WebSocket /mobile/chat/stream).
+
+Matrix rows: WS-002..WS-005, WS-007..WS-019, WS-021, IDP-003..IDP-005.
+
+The protocol handler is exercised directly with a fake socket so the tests
+are deterministic; one live loopback integration is exercised separately in
+the local smoke run.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from rex.mobile_api.websocket import (
+    CLOSE_AUTH_TIMEOUT,
+    CLOSE_RATE_LIMITED,
+    CLOSE_UNAUTHENTICATED,
+    MAX_FRAME_BYTES,
+    MobileWebSocketServer,
+    SlidingWindowLimiter,
+)
+from tests.mobile_api.conftest import chat_payload, create_user, login_tokens
+
+TIMEOUT = object()
+
+
+class FakeWs:
+    """Scripted WebSocket connection for protocol tests."""
+
+    def __init__(self, frames: list) -> None:
+        self.incoming = list(frames)
+        self.sent: list[dict] = []
+        self.closed: tuple[int, str] | None = None
+
+    def receive(self, timeout: float | None = None):
+        if self.closed is not None or not self.incoming:
+            raise RuntimeError("connection closed")
+        item = self.incoming.pop(0)
+        if item is TIMEOUT:
+            return None
+        return item
+
+    def send(self, data: str) -> None:
+        if self.closed is not None:
+            raise RuntimeError("connection closed")
+        self.sent.append(json.loads(data))
+
+    def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed = (code, reason)
+
+
+def _auth_frame(token: str) -> str:
+    return json.dumps(
+        {
+            "type": "auth",
+            "access_token": token,
+            "client": {"platform": "ios", "app_version": "0.1.0", "device_id": "dev-1"},
+        }
+    )
+
+
+def _chat_frame(message: str = "Hello Rex", **overrides) -> str:
+    return json.dumps({"type": "chat", **chat_payload(message, **overrides)})
+
+
+def _login(client, username: str = "james", password: str = "pw-123456") -> tuple[str, str]:
+    user_id = create_user(username, password)
+    tokens = login_tokens(client, username, password)
+    return user_id, tokens["access_token"]
+
+
+def _run(services, frames: list, remote: str = "10.0.0.1") -> FakeWs:
+    ws = FakeWs(frames)
+    MobileWebSocketServer(services).handle(ws, remote)
+    return ws
+
+
+class TestAuthentication:
+    def test_valid_auth_gets_auth_ok(self, client, services) -> None:
+        """WS-002: snake_case auth_ok with session and user projection."""
+        user_id, token = _login(client)
+        ws = _run(services, [_auth_frame(token)])
+        assert ws.sent[0]["type"] == "auth_ok"
+        assert ws.sent[0]["session_id"]
+        assert ws.sent[0]["user"]["id"] == user_id
+        assert {"id", "name", "role", "permissions"} <= set(ws.sent[0]["user"].keys())
+
+    def test_first_frame_chat_is_rejected(self, client, services, fake_chat_service) -> None:
+        """WS-003: nothing is processed before authentication."""
+        _login(client)
+        ws = _run(services, [_chat_frame()])
+        assert ws.sent[0]["type"] == "auth_error"
+        assert ws.closed[0] == CLOSE_UNAUTHENTICATED
+        assert fake_chat_service.calls == []
+
+    def test_first_frame_ping_is_rejected(self, client, services) -> None:
+        _login(client)
+        ws = _run(services, [json.dumps({"type": "ping"})])
+        assert ws.closed[0] == CLOSE_UNAUTHENTICATED
+
+    def test_auth_timeout_closes_4408(self, services) -> None:
+        """WS-004."""
+        ws = _run(services, [TIMEOUT])
+        assert ws.closed[0] == CLOSE_AUTH_TIMEOUT
+
+    def test_invalid_token_closes_4401(self, services) -> None:
+        """WS-005."""
+        ws = _run(services, [_auth_frame("not-a-real-token")])
+        assert ws.sent[0]["type"] == "auth_error"
+        assert ws.sent[0]["code"] in ("AUTH_TOKEN_INVALID", "AUTH_TOKEN_EXPIRED")
+        assert ws.closed[0] == CLOSE_UNAUTHENTICATED
+
+    def test_revoked_session_token_closes_4401(self, client, services) -> None:
+        _, token = _login(client)
+        from tests.mobile_api.conftest import auth_header
+
+        client.post("/mobile/auth/logout", headers=auth_header(token))
+        ws = _run(services, [_auth_frame(token)])
+        assert ws.sent[0]["type"] == "auth_error"
+        assert ws.closed[0] == CLOSE_UNAUTHENTICATED
+
+    def test_second_auth_frame_cannot_replace_identity(self, client, services) -> None:
+        """WS-008."""
+        _, token_a = _login(client, "james", "pw-123456")
+        _, token_b = _login(client, "cole", "pw-abcdef")
+        ws = _run(services, [_auth_frame(token_a), _auth_frame(token_b)])
+        errors = [e for e in ws.sent if e["type"] == "error"]
+        assert errors and "authenticated" in errors[0]["message"].lower()
+
+    def test_connection_rate_limit_closes_4429(self, client, services) -> None:
+        """WS-007."""
+        _, token = _login(client)
+        server = MobileWebSocketServer(services)
+        server._connection_limiter = SlidingWindowLimiter(1)
+        first = FakeWs([_auth_frame(token)])
+        server.handle(first, "9.9.9.9")
+        assert first.sent[0]["type"] == "auth_ok"
+        second = FakeWs([_auth_frame(token)])
+        server.handle(second, "9.9.9.9")
+        assert second.closed[0] == CLOSE_RATE_LIMITED
+        assert second.sent == []
+
+
+class TestFrames:
+    def test_valid_chat_reserves_acks_streams_and_completes(
+        self, client, services, fake_chat_service
+    ) -> None:
+        """WS-010/WS-011/WS-012/WS-013: reservation → ack → events → done."""
+        user_id, token = _login(client)
+        frame = _chat_frame("Hello Rex")
+        message_id = json.loads(frame)["message_id"]
+        ws = _run(services, [_auth_frame(token), frame])
+
+        types = [e["type"] for e in ws.sent]
+        assert types[0] == "auth_ok"
+        assert types[1] == "ack"
+        assert types[-1] == "message_done"
+        ack = ws.sent[1]
+        assert set(ack.keys()) == {"type", "message_id", "accepted_at"}
+        assert ack["message_id"] == message_id
+        done = ws.sent[-1]
+        assert done["status"] == "completed"
+        assert done["full_content"] == f"echo[{user_id}]: Hello Rex"
+        for event in ws.sent:
+            for key in event:
+                assert key == key.lower() and " " not in key
+        assert fake_chat_service.calls == [("Hello Rex", user_id)]
+
+    def test_client_identity_fields_in_chat_rejected(
+        self, client, services, fake_chat_service
+    ) -> None:
+        """WS-009: bound principal cannot be altered by frame fields."""
+        _, token = _login(client)
+        bad = json.dumps({"type": "chat", **chat_payload(), "user_id": "someone-else"})
+        ws = _run(services, [_auth_frame(token), bad])
+        errors = [e for e in ws.sent if e["type"] == "error"]
+        assert errors and errors[0]["code"] == "BAD_REQUEST"
+        assert fake_chat_service.calls == []
+
+    def test_malformed_json_is_structured_protocol_error(self, client, services) -> None:
+        """WS-014: never rendered as assistant text."""
+        _, token = _login(client)
+        ws = _run(services, [_auth_frame(token), "this is {not json"])
+        errors = [e for e in ws.sent if e["type"] == "error"]
+        assert errors and errors[0]["code"] == "BAD_REQUEST"
+        assert all(e["type"] != "token" for e in ws.sent)
+
+    def test_oversized_frame_rejected_without_processing(
+        self, client, services, fake_chat_service
+    ) -> None:
+        """WS-015."""
+        _, token = _login(client)
+        huge = json.dumps({"type": "chat", **chat_payload("x" * (MAX_FRAME_BYTES + 10))})
+        ws = _run(services, [_auth_frame(token), huge])
+        errors = [e for e in ws.sent if e["type"] == "error"]
+        assert errors
+        assert fake_chat_service.calls == []
+
+    def test_message_flood_closes_4429(self, client, services, fake_chat_service) -> None:
+        """WS-016."""
+        _, token = _login(client)
+        server = MobileWebSocketServer(services)
+        server._message_limit = 2
+        frames = [_auth_frame(token)] + [_chat_frame(f"m{i}") for i in range(4)]
+        ws = FakeWs(frames)
+        server.handle(ws, "10.0.0.2")
+        assert ws.closed[0] == CLOSE_RATE_LIMITED
+        assert len(fake_chat_service.calls) == 2
+
+    def test_ping_gets_pong_without_private_content(self, client, services) -> None:
+        """WS-017."""
+        _, token = _login(client)
+        ws = _run(
+            services,
+            [_auth_frame(token), json.dumps({"type": "ping", "sent_at": "2026-07-15T00:00:00Z"})],
+        )
+        pongs = [e for e in ws.sent if e["type"] == "pong"]
+        assert len(pongs) == 1
+        assert set(pongs[0].keys()) == {"type", "sent_at"}
+
+    def test_session_revoked_mid_connection_closes_4401(self, client, services) -> None:
+        """WS-018: the next privileged message is rejected."""
+        _, token = _login(client)
+        from tests.mobile_api.conftest import auth_header
+
+        ws = FakeWs([_auth_frame(token)])
+        server = MobileWebSocketServer(services)
+        server.handle(ws, "10.0.0.3")
+        assert ws.sent[0]["type"] == "auth_ok"
+
+        # Revoke, then deliver a chat frame on a still-open connection.
+        client.post("/mobile/auth/logout", headers=auth_header(token))
+        ws2 = FakeWs([_auth_frame(token)])
+        server.handle(ws2, "10.0.0.4")
+        assert ws2.sent[0]["type"] == "auth_error"
+
+
+class TestWsIdempotency:
+    def test_ws_duplicate_executes_once_and_replays(
+        self, client, services, fake_chat_service
+    ) -> None:
+        """IDP-003/WS-019: reconnect replay never re-executes."""
+        _, token = _login(client)
+        frame = _chat_frame("dedupe me")
+        ws = _run(services, [_auth_frame(token), frame, frame])
+        done_events = [e for e in ws.sent if e["type"] == "message_done"]
+        ack_events = [e for e in ws.sent if e["type"] == "ack"]
+        assert len(done_events) == 2  # replayed terminal result
+        assert done_events[0]["full_content"] == done_events[1]["full_content"]
+        assert len(ack_events) == 2  # duplicate receives the original ack
+        assert len(fake_chat_service.calls) == 1
+
+    def test_ws_then_http_fallback_executes_once(self, client, services, fake_chat_service) -> None:
+        """IDP-004: same ID over WS then HTTP → one execution, same result."""
+        _, token = _login(client)
+        payload = chat_payload("ws first")
+        ws = _run(services, [_auth_frame(token), json.dumps({"type": "chat", **payload})])
+        done = [e for e in ws.sent if e["type"] == "message_done"][0]
+
+        tokens = login_tokens(client, "james", "pw-123456")
+        from tests.mobile_api.conftest import auth_header
+
+        response = client.post(
+            "/mobile/chat", json=payload, headers=auth_header(tokens["access_token"])
+        )
+        assert response.status_code == 200
+        assert response.get_json()["response"] == done["full_content"]
+        assert len(fake_chat_service.calls) == 1
+
+    def test_http_then_ws_reconnect_executes_once(
+        self, client, services, fake_chat_service
+    ) -> None:
+        """IDP-005."""
+        _, token = _login(client)
+        payload = chat_payload("http first")
+        from tests.mobile_api.conftest import auth_header
+
+        response = client.post("/mobile/chat", json=payload, headers=auth_header(token))
+        assert response.status_code == 200
+        ws = _run(services, [_auth_frame(token), json.dumps({"type": "chat", **payload})])
+        done = [e for e in ws.sent if e["type"] == "message_done"]
+        assert len(done) == 1
+        assert done[0]["full_content"] == response.get_json()["response"]
+        assert len(fake_chat_service.calls) == 1
+
+    def test_same_id_different_payload_conflicts(self, client, services, fake_chat_service) -> None:
+        _, token = _login(client)
+        payload = chat_payload("original")
+        tampered = dict(payload, message="tampered")
+        ws = _run(
+            services,
+            [
+                _auth_frame(token),
+                json.dumps({"type": "chat", **payload}),
+                json.dumps({"type": "chat", **tampered}),
+            ],
+        )
+        errors = [e for e in ws.sent if e["type"] == "error"]
+        assert errors and errors[0]["code"] == "IDEMPOTENCY_CONFLICT"
+        assert len(fake_chat_service.calls) == 1
+
+    def test_two_users_same_message_id_are_isolated(
+        self, client, services, fake_chat_service
+    ) -> None:
+        """WS-021: connection principals and results stay isolated."""
+        user_a, token_a = _login(client, "james", "pw-123456")
+        user_b, token_b = _login(client, "cole", "pw-abcdef")
+        shared = chat_payload("who am I")
+        shared["message_id"] = str(uuid.uuid4())
+        frame = json.dumps({"type": "chat", **shared})
+        ws_a = _run(services, [_auth_frame(token_a), frame])
+        ws_b = _run(services, [_auth_frame(token_b), frame])
+        done_a = [e for e in ws_a.sent if e["type"] == "message_done"][0]
+        done_b = [e for e in ws_b.sent if e["type"] == "message_done"][0]
+        assert done_a["full_content"] == f"echo[{user_a}]: who am I"
+        assert done_b["full_content"] == f"echo[{user_b}]: who am I"
+        assert len(fake_chat_service.calls) == 2
+
+    def test_no_tokens_or_bodies_in_logs(self, client, services, caplog) -> None:
+        """WS-022: only safe correlation data is logged."""
+        _, token = _login(client)
+        secret_message = "my-secret-garage-code-4242"
+        with caplog.at_level("DEBUG"):
+            _run(
+                services,
+                [_auth_frame(token), _chat_frame(secret_message)],
+            )
+        assert token not in caplog.text
+        assert secret_message not in caplog.text

--- a/tests/mobile_api/test_chat_websocket.py
+++ b/tests/mobile_api/test_chat_websocket.py
@@ -320,7 +320,7 @@ class TestWsIdempotency:
     def test_no_tokens_or_bodies_in_logs(self, client, services, caplog) -> None:
         """WS-022: only safe correlation data is logged."""
         _, token = _login(client)
-        secret_message = "my-secret-garage-code-4242"
+        secret_message = "my-secret-garage-code-4242"  # pragma: allowlist secret
         with caplog.at_level("DEBUG"):
             _run(
                 services,

--- a/tests/mobile_api/test_chat_websocket_live.py
+++ b/tests/mobile_api/test_chat_websocket_live.py
@@ -1,0 +1,131 @@
+"""Live loopback WebSocket integration through Flask-Sock/simple-websocket."""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+
+import pytest
+import requests
+from simple_websocket import Client, ConnectionClosed
+from werkzeug.serving import make_server
+
+from tests.mobile_api.conftest import chat_payload, create_user
+
+
+def _auth_frame(token: str) -> dict:
+    return {
+        "type": "auth",
+        "access_token": token,
+        "client": {"platform": "ios", "app_version": "0.1.0", "device_id": "live-dev-1"},
+    }
+
+
+@pytest.fixture()
+def live_server(app):
+    server = make_server("127.0.0.1", 0, app, threaded=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def _login(base_url: str) -> str:
+    response = requests.post(
+        f"{base_url}/mobile/auth/login",
+        json={
+            "username": "james",
+            "password": "pw-123456",
+            "device": {
+                "device_id": str(uuid.uuid4()),
+                "name": "loopback",
+                "platform": "ios",
+                "app_version": "0.1.0",
+            },
+        },
+        timeout=5,
+    )
+    response.raise_for_status()
+    return str(response.json()["access_token"])
+
+
+def _ws_url(base_url: str) -> str:
+    return base_url.replace("http://", "ws://") + "/mobile/chat/stream"
+
+
+def _receive_json(ws: Client, timeout: float = 3) -> dict:
+    return json.loads(ws.receive(timeout=timeout))
+
+
+def test_live_upgrade_auth_chat_dedupe_close_codes_and_revocation(
+    live_server, fake_chat_service, monkeypatch
+) -> None:
+    """Actual upgrade/auth/chat plus HTTP dedupe and security close paths."""
+    create_user("james", "pw-123456")
+    token = _login(live_server)
+    url = _ws_url(live_server)
+    assert "token" not in url.lower()
+
+    ws = Client.connect(url)
+    ws.send(json.dumps(_auth_frame(token)))
+    assert _receive_json(ws)["type"] == "auth_ok"
+
+    payload = {"type": "chat", **chat_payload("live loopback")}
+    ws.send(json.dumps(payload))
+    events = []
+    while not events or events[-1]["type"] != "message_done":
+        events.append(_receive_json(ws))
+    assert events[0]["type"] == "ack"
+    assert any(event["type"] == "token" for event in events)
+    assert events[-1]["message_id"] == payload["message_id"]
+
+    # Same ID through authenticated HTTP returns the stored result and does
+    # not execute the Assistant a second time.
+    http_body = {key: value for key, value in payload.items() if key != "type"}
+    replay = requests.post(
+        f"{live_server}/mobile/chat",
+        json=http_body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Idempotency-Key": payload["message_id"],
+        },
+        timeout=5,
+    )
+    assert replay.status_code == 200
+    assert replay.json()["message_id"] == payload["message_id"]
+    assert len(fake_chat_service.calls) == 1
+    assert fake_chat_service.calls[0][0] == "live loopback"
+    ws.close()
+
+    invalid = Client.connect(url)
+    invalid.send(json.dumps(_auth_frame("invalid-token")))
+    assert _receive_json(invalid)["type"] == "auth_error"
+    with pytest.raises(ConnectionClosed) as invalid_close:
+        invalid.receive(timeout=3)
+    assert int(invalid_close.value.reason) == 4401
+
+    monkeypatch.setattr("rex.mobile_api.websocket.AUTH_TIMEOUT_SECONDS", 0.1)
+    timed_out = Client.connect(url)
+    with pytest.raises(ConnectionClosed) as timeout_close:
+        timed_out.receive(timeout=3)
+    assert int(timeout_close.value.reason) == 4408
+
+    live_token = _login(live_server)
+    revoked = Client.connect(url)
+    revoked.send(json.dumps(_auth_frame(live_token)))
+    assert _receive_json(revoked)["type"] == "auth_ok"
+    logout = requests.post(
+        f"{live_server}/mobile/auth/logout",
+        headers={"Authorization": f"Bearer {live_token}"},
+        timeout=5,
+    )
+    assert logout.status_code == 200
+    revoked.send(json.dumps({"type": "chat", **chat_payload("must not run")}))
+    with pytest.raises(ConnectionClosed) as revoked_close:
+        revoked.receive(timeout=3)
+    assert int(revoked_close.value.reason) == 4401
+    assert len(fake_chat_service.calls) == 1

--- a/tests/mobile_api/test_chat_websocket_live.py
+++ b/tests/mobile_api/test_chat_websocket_live.py
@@ -39,7 +39,7 @@ def _login(base_url: str) -> str:
         f"{base_url}/mobile/auth/login",
         json={
             "username": "james",
-            "password": "pw-123456",
+            "password": "pw-123456",  # pragma: allowlist secret
             "device": {
                 "device_id": str(uuid.uuid4()),
                 "name": "loopback",

--- a/tests/mobile_api/test_config.py
+++ b/tests/mobile_api/test_config.py
@@ -155,6 +155,7 @@ class TestMobileApiConfigSerialization:
             "rate_limit_refresh",
             "rate_limit_chat",
             "rate_limit_voice",
+            "idempotency_retention_hours",
         }
 
     def test_show_config_output_includes_mobile_api(self, capsys) -> None:

--- a/tests/mobile_api/test_contract_vectors.py
+++ b/tests/mobile_api/test_contract_vectors.py
@@ -1,0 +1,244 @@
+"""Cross-repository contract-vector tests.
+
+``contract_vectors.json`` is the shared wire contract for issue #323 — an
+identical copy lives in the mobile repository (``tests/contract/``) and both
+test suites validate against it, so field-casing drift, ``auth`` vs
+``authenticate`` drift, missing required fields, token-in-URL regressions,
+client ``user_id`` regressions, and fake ``verified`` statuses fail on
+whichever side introduced them.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.mobile_api.conftest import auth_header, create_user, login_tokens, parse_sse_events
+
+VECTORS_PATH = Path(__file__).parent / "contract_vectors.json"
+_SNAKE_CASE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@pytest.fixture(scope="module")
+def vectors() -> dict:
+    return json.loads(VECTORS_PATH.read_text(encoding="utf-8"))
+
+
+def _assert_snake_case_keys(value, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            assert _SNAKE_CASE.fullmatch(key), f"non-snake_case key {key!r} at {path}"
+            _assert_snake_case_keys(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _assert_snake_case_keys(child, f"{path}[{index}]")
+
+
+class TestVectorHygiene:
+    def test_every_wire_key_is_snake_case(self, vectors) -> None:
+        """camelCase drift anywhere in the contract fails here."""
+        _assert_snake_case_keys(vectors["http"])
+        _assert_snake_case_keys(vectors["websocket"])
+
+    def test_auth_frame_type_is_auth_not_authenticate(self, vectors) -> None:
+        assert vectors["websocket"]["auth_frame"]["type"] == "auth"
+
+    def test_ws_url_contains_no_token(self, vectors) -> None:
+        url_path = vectors["websocket"]["url_path"]
+        assert "?" not in url_path
+        assert "token" not in url_path.lower()
+
+    def test_chat_request_has_no_client_identity_fields(self, vectors) -> None:
+        for shape in (vectors["http"]["chat_request"], vectors["websocket"]["chat_frame"]):
+            for forbidden in ("user_id", "role", "permissions", "risk", "approval"):
+                assert forbidden not in shape
+
+    def test_normal_chat_status_is_completed(self, vectors) -> None:
+        assert vectors["statuses"]["normal_chat"] == "completed"
+        assert vectors["http"]["chat_response"]["status"] == "completed"
+        assert vectors["websocket"]["message_done"]["status"] == "completed"
+
+    def test_close_codes(self, vectors) -> None:
+        from rex.mobile_api import websocket as ws
+
+        codes = vectors["websocket"]["close_codes"]
+        assert codes["unauthenticated"] == ws.CLOSE_UNAUTHENTICATED == 4401
+        assert codes["forbidden"] == ws.CLOSE_FORBIDDEN == 4403
+        assert codes["auth_timeout"] == ws.CLOSE_AUTH_TIMEOUT == 4408
+        assert codes["rate_limited"] == ws.CLOSE_RATE_LIMITED == 4429
+
+
+class TestEventBuilderConformance:
+    """The backend event builders must produce exactly the vector shapes."""
+
+    def test_token_event(self, vectors) -> None:
+        from rex.mobile_api import events as mev
+
+        built = mev.token_event("m", ".")
+        assert set(built.keys()) == set(vectors["websocket"]["token"].keys())
+
+    def test_message_done_event(self, vectors) -> None:
+        from rex.mobile_api import events as mev
+
+        built = mev.message_done_event("m", "c", "text")
+        assert set(built.keys()) == set(vectors["websocket"]["message_done"].keys())
+        assert built["status"] == "completed"
+
+    def test_error_event(self, vectors) -> None:
+        from rex.mobile_api import events as mev
+
+        built = mev.error_event("BACKEND_UNAVAILABLE", "msg", message_id="m", retryable=True)
+        assert set(built.keys()) == set(vectors["websocket"]["error"].keys())
+
+    def test_ack_event(self, vectors) -> None:
+        from rex.mobile_api import events as mev
+
+        built = mev.ack_event("m", "2026-07-15T00:00:00+00:00")
+        assert set(built.keys()) == set(vectors["websocket"]["ack"].keys())
+
+    def test_auth_ok_event(self, vectors) -> None:
+        from rex.mobile_api import events as mev
+
+        user = dict(vectors["websocket"]["auth_ok"]["user"])
+        built = mev.auth_ok_event("s", user)
+        assert set(built.keys()) == set(vectors["websocket"]["auth_ok"].keys())
+
+    def test_auth_error_event(self, vectors) -> None:
+        from rex.mobile_api import events as mev
+
+        built = mev.auth_error_event("AUTH_TOKEN_EXPIRED", "Access token expired.")
+        assert set(built.keys()) == set(vectors["websocket"]["auth_error"].keys())
+
+    def test_pong_event(self, vectors) -> None:
+        from rex.mobile_api import events as mev
+
+        built = mev.pong_event("2026-07-15T00:00:00+00:00")
+        assert set(built.keys()) == set(vectors["websocket"]["pong"].keys())
+
+
+class TestLiveResponseConformance:
+    """Real backend responses carry exactly the documented required fields."""
+
+    def test_login_and_refresh_and_session(self, client, vectors) -> None:
+        create_user("james", "pw-123456")
+        login_body = login_tokens(client, "james", "pw-123456")
+        assert set(login_body.keys()) == set(vectors["http"]["login_response"].keys())
+        assert set(login_body["user"].keys()) == set(
+            vectors["http"]["login_response"]["user"].keys()
+        )
+        assert login_body["token_type"] == "Bearer"
+
+        refresh = client.post(
+            "/mobile/auth/refresh", json={"refresh_token": login_body["refresh_token"]}
+        )
+        assert refresh.status_code == 200
+        assert set(refresh.get_json().keys()) == set(vectors["http"]["refresh_response"].keys())
+
+        session = client.get(
+            "/mobile/auth/session",
+            headers=auth_header(refresh.get_json()["access_token"]),
+        )
+        assert session.status_code == 200
+        assert set(session.get_json().keys()) == set(vectors["http"]["session_response"].keys())
+
+    def test_nested_error_envelope(self, client, vectors) -> None:
+        response = client.post(
+            "/mobile/auth/login", json={"username": "ghost", "password": "wrong-pass"}
+        )
+        assert response.status_code == 401
+        body = response.get_json()
+        assert set(body.keys()) == {"error"}
+        assert set(body["error"].keys()) == set(vectors["http"]["error_envelope"]["error"].keys())
+
+    def test_chat_request_vector_is_accepted_and_response_conforms(self, client, vectors) -> None:
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        response = client.post(
+            "/mobile/chat",
+            json=vectors["http"]["chat_request"],
+            headers=auth_header(tokens["access_token"]),
+        )
+        assert response.status_code == 200
+        assert set(response.get_json().keys()) == set(vectors["http"]["chat_response"].keys())
+
+    def test_sse_grammar_conforms(self, client, vectors) -> None:
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        chat_request = dict(vectors["http"]["chat_request"])
+        chat_request["message_id"] = "5f8f1f2a-9999-4999-8999-999999999999"
+        response = client.post(
+            "/mobile/chat/stream",
+            json=chat_request,
+            headers=auth_header(tokens["access_token"]),
+        )
+        assert response.mimetype == vectors["http"]["sse"]["content_type"]
+        events = parse_sse_events(response.data)
+        assert events[-1]["type"] in vectors["http"]["sse"]["terminal_events"]
+        for event in events:
+            _assert_snake_case_keys(event)
+
+    def test_ws_chat_frame_vector_is_accepted(self, client, vectors, services) -> None:
+        from rex.mobile_api.websocket import MobileWebSocketServer
+        from tests.mobile_api.test_chat_websocket import FakeWs
+
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        auth_frame = dict(vectors["websocket"]["auth_frame"])
+        auth_frame["access_token"] = tokens["access_token"]
+        ws = FakeWs([json.dumps(auth_frame), json.dumps(vectors["websocket"]["chat_frame"])])
+        MobileWebSocketServer(services).handle(ws, "10.1.1.1")
+        types = [e["type"] for e in ws.sent]
+        assert types[0] == "auth_ok"
+        assert "ack" in types
+        assert types[-1] == "message_done"
+        for event in ws.sent:
+            _assert_snake_case_keys(event)
+
+    def test_tts_response_conforms(self, client, vectors) -> None:
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        response = client.post(
+            "/mobile/tts/playback",
+            json={"text": vectors["http"]["tts_request"]["text"]},
+            headers=auth_header(tokens["access_token"]),
+        )
+        assert response.status_code == 200
+        assert set(response.get_json().keys()) == set(vectors["http"]["tts_response"].keys())
+
+    def test_voice_response_conforms(self, client, vectors) -> None:
+        import io
+        import struct
+        import wave
+
+        create_user("james", "pw-123456")
+        tokens = login_tokens(client, "james", "pw-123456")
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(16_000)
+            wav_file.writeframes(struct.pack("<16000h", *([0] * 16_000)))
+        response = client.post(
+            "/mobile/voice/upload",
+            data={
+                "audio": (io.BytesIO(buffer.getvalue()), "rec.wav", "audio/wav"),
+                "mode": "mobile_voice",
+            },
+            headers=auth_header(tokens["access_token"]),
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 200
+        assert set(response.get_json().keys()) == set(vectors["http"]["voice_response"].keys())
+
+    def test_capabilities_conform_and_unimplemented_stay_false(self, client, vectors) -> None:
+        response = client.get("/mobile/capabilities")
+        body = response.get_json()
+        vector = vectors["http"]["capabilities_response"]
+        assert set(body.keys()) == set(vector.keys())
+        assert set(body["features"].keys()) == set(vector["features"].keys())
+        assert body["api_version"] == vectors["api_version"]
+        for feature in ("live_voice", "notifications", "approvals", "home_assistant"):
+            assert body["features"][feature] is False

--- a/tests/mobile_api/test_contract_vectors.py
+++ b/tests/mobile_api/test_contract_vectors.py
@@ -146,7 +146,8 @@ class TestLiveResponseConformance:
 
     def test_nested_error_envelope(self, client, vectors) -> None:
         response = client.post(
-            "/mobile/auth/login", json={"username": "ghost", "password": "wrong-pass"}
+            "/mobile/auth/login",
+            json={"username": "ghost", "password": "wrong-pass"},  # pragma: allowlist secret
         )
         assert response.status_code == 401
         body = response.get_json()

--- a/tests/mobile_api/test_idempotency.py
+++ b/tests/mobile_api/test_idempotency.py
@@ -1,0 +1,197 @@
+"""Cross-transport idempotency store tests.
+
+Matrix rows: IDP-001, IDP-002, IDP-007, IDP-008, IDP-009, IDP-011, IDP-012.
+Transport-level duplicate rows (IDP-003..IDP-006, IDP-010) are covered in
+the HTTP/SSE/WebSocket test modules.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from pathlib import Path
+
+import pytest
+
+from rex.mobile_api import idempotency as idem
+from tests.mobile_api.conftest import FakeClock
+
+
+@pytest.fixture()
+def store(tmp_path: Path, clock: FakeClock) -> idem.MobileMessageStore:
+    from rex.mobile_api.db import migrate_users_db
+
+    db_path = tmp_path / "users.db"
+    migrate_users_db(db_path)
+    return idem.MobileMessageStore(db_path, retention_hours=48, clock=clock)
+
+
+def _fields(message: str = "hello", **overrides) -> dict:
+    fields = {
+        "message_id": "5f8f1f2a-1111-4111-8111-111111111111",
+        "conversation_id": "5f8f1f2a-2222-4222-8222-222222222222",
+        "sent_at": "2026-07-15T12:00:00+00:00",
+        "message": message,
+        "mode": "mobile_text",
+        "client_context": {"device": "iphone"},
+    }
+    fields.update(overrides)
+    return fields
+
+
+USER_A = "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+USER_B = "3d6f2c1e-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+
+class TestRequestHash:
+    def test_hash_is_deterministic_and_semantic(self) -> None:
+        """IDP-012: semantic fields drive the hash; key order does not."""
+        fields = _fields()
+        reordered = dict(reversed(list(fields.items())))
+        assert idem.compute_request_hash(fields) == idem.compute_request_hash(reordered)
+
+    def test_hash_changes_with_message(self) -> None:
+        assert idem.compute_request_hash(_fields("a")) != idem.compute_request_hash(_fields("b"))
+
+    def test_hash_ignores_transport_fields(self) -> None:
+        """IDP-012: transport-only fields are excluded."""
+        with_transport = _fields()
+        with_transport["type"] = "chat"
+        with_transport["authorization"] = "Bearer nope"
+        assert idem.compute_request_hash(with_transport) == idem.compute_request_hash(_fields())
+
+
+class TestReservation:
+    def test_first_reservation_is_new(self, store) -> None:
+        """IDP-001: the first reservation wins and is durable."""
+        fields = _fields()
+        result = store.reserve(
+            USER_A,
+            fields["message_id"],
+            fields["conversation_id"],
+            idem.compute_request_hash(fields),
+        )
+        assert result.outcome == idem.RESERVED
+        row = store.get(USER_A, fields["message_id"])
+        assert row is not None and row["status"] == idem.STATUS_PROCESSING
+
+    def test_exact_duplicate_of_processing(self, store) -> None:
+        fields = _fields()
+        request_hash = idem.compute_request_hash(fields)
+        store.reserve(USER_A, fields["message_id"], fields["conversation_id"], request_hash)
+        dup = store.reserve(USER_A, fields["message_id"], fields["conversation_id"], request_hash)
+        assert dup.outcome == idem.DUPLICATE_PROCESSING
+
+    def test_exact_duplicate_of_completed_replays_result(self, store) -> None:
+        """IDP-002: a completed duplicate returns the stored result."""
+        fields = _fields()
+        request_hash = idem.compute_request_hash(fields)
+        store.reserve(USER_A, fields["message_id"], fields["conversation_id"], request_hash)
+        store.complete(USER_A, fields["message_id"], '{"response": "done"}')
+        dup = store.reserve(USER_A, fields["message_id"], fields["conversation_id"], request_hash)
+        assert dup.outcome == idem.DUPLICATE_COMPLETED
+        assert dup.response_json == '{"response": "done"}'
+
+    def test_failed_duplicate_replays_error_code(self, store) -> None:
+        """IDP-010: a failed request's terminal code is replayed, not re-run."""
+        fields = _fields()
+        request_hash = idem.compute_request_hash(fields)
+        store.reserve(USER_A, fields["message_id"], fields["conversation_id"], request_hash)
+        store.fail(USER_A, fields["message_id"], "BACKEND_UNAVAILABLE")
+        dup = store.reserve(USER_A, fields["message_id"], fields["conversation_id"], request_hash)
+        assert dup.outcome == idem.DUPLICATE_FAILED
+        assert dup.error_code == "BACKEND_UNAVAILABLE"
+
+    def test_same_id_different_payload_conflicts(self, store) -> None:
+        """IDP-007: a reused ID with different semantics never executes."""
+        fields = _fields()
+        store.reserve(
+            USER_A,
+            fields["message_id"],
+            fields["conversation_id"],
+            idem.compute_request_hash(fields),
+        )
+        other = idem.compute_request_hash(_fields("something else"))
+        result = store.reserve(USER_A, fields["message_id"], fields["conversation_id"], other)
+        assert result.outcome == idem.CONFLICT
+
+    def test_same_id_different_user_is_independent(self, store) -> None:
+        """IDP-008: no cross-user reservation sharing or result leak."""
+        fields = _fields()
+        request_hash = idem.compute_request_hash(fields)
+        first = store.reserve(USER_A, fields["message_id"], fields["conversation_id"], request_hash)
+        second = store.reserve(
+            USER_B, fields["message_id"], fields["conversation_id"], request_hash
+        )
+        assert first.outcome == idem.RESERVED
+        assert second.outcome == idem.RESERVED
+        store.complete(USER_A, fields["message_id"], '{"response": "user-a-only"}')
+        dup_b = store.reserve(USER_B, fields["message_id"], fields["conversation_id"], request_hash)
+        assert dup_b.outcome == idem.DUPLICATE_PROCESSING
+        assert dup_b.response_json is None
+
+    def test_invalid_user_id_fails_before_db(self, store) -> None:
+        with pytest.raises(ValueError):
+            store.reserve("../evil", "m", "c", "h")
+
+    def test_concurrent_duplicates_yield_one_winner(self, tmp_path) -> None:
+        """IDP-006: exactly one concurrent reservation wins."""
+        from rex.mobile_api.db import migrate_users_db
+
+        db_path = tmp_path / "concurrent.db"
+        migrate_users_db(db_path)
+        real_store = idem.MobileMessageStore(db_path)
+        fields = _fields()
+        request_hash = idem.compute_request_hash(fields)
+        outcomes: list[str] = []
+        lock = threading.Lock()
+
+        def attempt() -> None:
+            result = real_store.reserve(
+                USER_A, fields["message_id"], fields["conversation_id"], request_hash
+            )
+            with lock:
+                outcomes.append(result.outcome)
+
+        threads = [threading.Thread(target=attempt) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert outcomes.count(idem.RESERVED) == 1
+        assert len(outcomes) == 8
+
+
+class TestRetention:
+    def test_completed_result_survives_new_store_instance(self, tmp_path, clock) -> None:
+        """IDP-009: terminal results persist across service restarts."""
+        from rex.mobile_api.db import migrate_users_db
+
+        db_path = tmp_path / "users.db"
+        migrate_users_db(db_path)
+        first = idem.MobileMessageStore(db_path, clock=clock)
+        fields = _fields()
+        request_hash = idem.compute_request_hash(fields)
+        first.reserve(USER_A, fields["message_id"], fields["conversation_id"], request_hash)
+        first.complete(USER_A, fields["message_id"], '{"response": "persisted"}')
+
+        restarted = idem.MobileMessageStore(db_path, clock=clock)
+        dup = restarted.reserve(
+            USER_A, fields["message_id"], fields["conversation_id"], request_hash
+        )
+        assert dup.outcome == idem.DUPLICATE_COMPLETED
+        assert dup.response_json == '{"response": "persisted"}'
+
+    def test_prune_removes_only_expired_rows(self, store, clock) -> None:
+        """IDP-011: expired rows go; active rows stay."""
+        old = _fields(message_id=str(uuid.uuid4()))
+        store.reserve(USER_A, old["message_id"], old["conversation_id"], "hash-old")
+        store.complete(USER_A, old["message_id"], "{}")
+        clock.advance(days=3)
+        removed = store.prune_expired()
+        assert removed == 1
+        assert store.get(USER_A, old["message_id"]) is None
+        fresh = _fields(message_id=str(uuid.uuid4()))
+        store.reserve(USER_A, fresh["message_id"], fresh["conversation_id"], "hash-new")
+        assert store.prune_expired() == 0
+        assert store.get(USER_A, fresh["message_id"]) is not None

--- a/tests/mobile_api/test_scaffolds.py
+++ b/tests/mobile_api/test_scaffolds.py
@@ -9,11 +9,9 @@ import pytest
 
 from tests.mobile_api.conftest import auth_header, create_user, login_tokens
 
+# Chat, streaming, voice, and TTS became real authenticated routes in
+# Session 2 and are covered by their own test modules.
 _SCAFFOLDS = [
-    ("post", "/mobile/chat"),
-    ("post", "/mobile/chat/stream"),
-    ("post", "/mobile/voice/upload"),
-    ("post", "/mobile/tts/playback"),
     ("get", "/mobile/home/entities"),
     ("post", "/mobile/home/command"),
     ("get", "/mobile/notifications"),

--- a/tests/mobile_api/test_status_capabilities.py
+++ b/tests/mobile_api/test_status_capabilities.py
@@ -26,27 +26,44 @@ class TestStatus:
 
 
 class TestCapabilities:
-    def test_session_one_capabilities_are_truthful(self, client) -> None:
-        """CAP-001: authentication true; every runtime feature false."""
+    def test_capabilities_are_truthful(self, client) -> None:
+        """CAP-001/CAP-010: implemented+available features true; the rest false.
+
+        The test services inject available STT/TTS adapters and the
+        validated WebSocket stack is installed, so the Session 2 features
+        report true; unimplemented surfaces stay false.
+        """
         response = client.get("/mobile/capabilities")
         assert response.status_code == 200
         body = response.get_json()
         assert body["api_version"] == "1.0"
         assert body["minimum_app_version"] == "0.1.0"
         features = body["features"]
-        assert features["authentication"] is True
         for name in (
+            "authentication",
             "chat",
             "chat_streaming",
             "websocket_chat",
             "voice_upload",
             "tts",
+        ):
+            assert features[name] is True, name
+        for name in (
             "live_voice",
             "notifications",
             "approvals",
             "home_assistant",
         ):
             assert features[name] is False, name
+
+    def test_capabilities_reflect_runtime_dependencies(self, client, fake_stt, fake_tts) -> None:
+        """CAP-004/CAP-005: a missing runtime dependency turns a feature false."""
+        fake_stt.available = False
+        fake_tts.available = False
+        features = client.get("/mobile/capabilities").get_json()["features"]
+        assert features["voice_upload"] is False
+        assert features["tts"] is False
+        assert features["chat"] is True
 
     def test_capabilities_expose_no_sensitive_data(self, client) -> None:
         """CAP-009: no paths, tokens, account IDs, usernames, or model paths."""

--- a/tests/mobile_api/test_status_capabilities.py
+++ b/tests/mobile_api/test_status_capabilities.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import json
 
+from rex.mobile_api.voice import TextToSpeechAdapter
+
 
 class TestStatus:
     def test_status_is_minimal_and_public(self, client) -> None:
@@ -64,6 +66,35 @@ class TestCapabilities:
         assert features["voice_upload"] is False
         assert features["tts"] is False
         assert features["chat"] is True
+
+    def test_chat_and_websocket_require_runtime_and_registration(
+        self, client, services, fake_chat_service
+    ) -> None:
+        fake_chat_service.available = False
+        features = client.get("/mobile/capabilities").get_json()["features"]
+        assert features["chat"] is False
+        assert features["chat_streaming"] is False
+        assert features["websocket_chat"] is False
+
+        fake_chat_service.available = True
+        services.websocket_registered = False
+        features = client.get("/mobile/capabilities").get_json()["features"]
+        assert features["chat"] is True
+        assert features["websocket_chat"] is False
+
+    def test_capability_adapter_exception_fails_closed(self, client, fake_stt) -> None:
+        def explode():
+            raise RuntimeError("readiness probe failed")
+
+        fake_stt.availability = explode
+        features = client.get("/mobile/capabilities").get_json()["features"]
+        assert features["voice_upload"] is False
+
+    def test_tts_readiness_requires_configured_default_voice(self, monkeypatch) -> None:
+        adapter = TextToSpeechAdapter(provider="edge-tts", default_voice="missing-voice")
+        monkeypatch.setattr("rex.mobile_api.voice.find_spec", lambda _name: object())
+        monkeypatch.setattr(adapter, "_list_voice_ids", lambda: ["available-voice"])
+        assert adapter.availability()[0] is False
 
     def test_capabilities_expose_no_sensitive_data(self, client) -> None:
         """CAP-009: no paths, tokens, account IDs, usernames, or model paths."""

--- a/tests/mobile_api/test_tts.py
+++ b/tests/mobile_api/test_tts.py
@@ -32,10 +32,17 @@ class TestTtsPlayback:
         )
         assert response.status_code == 200
         body = response.get_json()
-        assert set(body.keys()) == {"request_id", "audio_base64", "mime_type", "voice"}
+        assert set(body.keys()) == {
+            "request_id",
+            "audio_base64",
+            "mime_type",
+            "voice",
+            "requested_voice",
+        }
         assert base64.b64decode(body["audio_base64"]) == fake_tts.audio
         assert body["mime_type"] == "audio/wav"
-        assert body["voice"] == "default"
+        assert body["voice"] == "fake-default-voice"
+        assert body["requested_voice"] == "default"
         assert body["request_id"]
         assert fake_tts.synthesized == [("The lights are off.", "fake-default-voice")]
 
@@ -74,6 +81,7 @@ class TestTtsPlayback:
         )
         assert response.status_code == 200
         assert response.get_json()["voice"] == "fake-alt-voice"
+        assert response.get_json()["requested_voice"] == "fake-alt-voice"
         assert fake_tts.synthesized == [("hello", "fake-alt-voice")]
 
     def test_engine_unavailable_is_truthful(self, client, fake_tts) -> None:

--- a/tests/mobile_api/test_tts.py
+++ b/tests/mobile_api/test_tts.py
@@ -1,0 +1,102 @@
+"""Protected TTS route tests (POST /mobile/tts/playback).
+
+Matrix rows: TTS-001..TTS-007, TTS-010..TTS-012, TTS-014 (rate limit shape
+is covered by the shared limiter tests in test_app.py).
+"""
+
+from __future__ import annotations
+
+import base64
+
+from tests.mobile_api.conftest import auth_header, create_user, login_tokens
+
+
+def _authed(client, username: str = "james", password: str = "pw-123456") -> dict:
+    create_user(username, password)
+    tokens = login_tokens(client, username, password)
+    return auth_header(tokens["access_token"])
+
+
+class TestTtsPlayback:
+    def test_missing_auth_rejected_before_synthesis(self, client, fake_tts) -> None:
+        """TTS-001."""
+        response = client.post("/mobile/tts/playback", json={"text": "hello"})
+        assert response.status_code == 401
+        assert fake_tts.synthesized == []
+
+    def test_valid_text_returns_base64_json(self, client, fake_tts) -> None:
+        """TTS-002/TTS-010: JSON base64 with MIME type and request ID."""
+        headers = _authed(client)
+        response = client.post(
+            "/mobile/tts/playback", json={"text": "The lights are off."}, headers=headers
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        assert set(body.keys()) == {"request_id", "audio_base64", "mime_type", "voice"}
+        assert base64.b64decode(body["audio_base64"]) == fake_tts.audio
+        assert body["mime_type"] == "audio/wav"
+        assert body["voice"] == "default"
+        assert body["request_id"]
+        assert fake_tts.synthesized == [("The lights are off.", "fake-default-voice")]
+
+    def test_empty_text_rejected(self, client, fake_tts) -> None:
+        """TTS-003."""
+        headers = _authed(client)
+        response = client.post("/mobile/tts/playback", json={"text": "   "}, headers=headers)
+        assert response.status_code == 400
+        assert fake_tts.synthesized == []
+
+    def test_oversized_text_rejected_before_synthesis(self, client, fake_tts) -> None:
+        """TTS-004."""
+        headers = _authed(client)
+        response = client.post("/mobile/tts/playback", json={"text": "x" * 2_001}, headers=headers)
+        assert response.status_code == 400
+        assert fake_tts.synthesized == []
+
+    def test_unknown_voice_is_an_error_not_a_silent_fallback(self, client, fake_tts) -> None:
+        """TTS-005."""
+        headers = _authed(client)
+        response = client.post(
+            "/mobile/tts/playback",
+            json={"text": "hello", "voice": "nonexistent-voice"},
+            headers=headers,
+        )
+        assert response.status_code == 400
+        assert fake_tts.synthesized == []
+
+    def test_allowed_voice_is_used(self, client, fake_tts) -> None:
+        """TTS-006."""
+        headers = _authed(client)
+        response = client.post(
+            "/mobile/tts/playback",
+            json={"text": "hello", "voice": "fake-alt-voice"},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert response.get_json()["voice"] == "fake-alt-voice"
+        assert fake_tts.synthesized == [("hello", "fake-alt-voice")]
+
+    def test_engine_unavailable_is_truthful(self, client, fake_tts) -> None:
+        """TTS-007."""
+        headers = _authed(client)
+        fake_tts.available = False
+        response = client.post("/mobile/tts/playback", json={"text": "hello"}, headers=headers)
+        assert response.status_code == 503
+        assert response.get_json()["error"]["code"] == "BACKEND_UNAVAILABLE"
+
+    def test_unknown_fields_rejected(self, client) -> None:
+        headers = _authed(client)
+        response = client.post(
+            "/mobile/tts/playback",
+            json={"text": "hello", "user_id": "someone"},
+            headers=headers,
+        )
+        assert response.status_code == 400
+
+    def test_text_never_in_logs(self, client, caplog) -> None:
+        """TTS-012 (and TTS-011 by construction: POST body, no query string)."""
+        headers = _authed(client)
+        private = "private-speech-text-5561"
+        with caplog.at_level("DEBUG"):
+            client.post("/mobile/tts/playback", json={"text": private}, headers=headers)
+        assert private not in caplog.text

--- a/tests/mobile_api/test_voice_upload.py
+++ b/tests/mobile_api/test_voice_upload.py
@@ -1,0 +1,209 @@
+"""Voice upload route tests (POST /mobile/voice/upload).
+
+Matrix rows: VOI-001, VOI-003..VOI-013, VOI-016..VOI-019.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import struct
+import wave
+
+from rex.mobile_api.voice import sniff_audio_container
+from tests.mobile_api.conftest import auth_header, create_user, login_tokens
+
+
+def _wav_bytes(seconds: float = 1.0, sample_rate: int = 16_000) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        frames = int(seconds * sample_rate)
+        wav_file.writeframes(struct.pack(f"<{frames}h", *([0] * frames)))
+    return buffer.getvalue()
+
+
+def _authed(client, username: str = "james", password: str = "pw-123456") -> tuple[str, dict]:
+    user_id = create_user(username, password)
+    tokens = login_tokens(client, username, password)
+    return user_id, auth_header(tokens["access_token"])
+
+
+def _upload(client, headers, data: bytes, *, filename="rec.wav", mimetype="audio/wav", extra=None):
+    form = {"audio": (io.BytesIO(data), filename, mimetype), "mode": "mobile_voice"}
+    if extra:
+        form.update(extra)
+    return client.post(
+        "/mobile/voice/upload",
+        data=form,
+        headers=headers,
+        content_type="multipart/form-data",
+    )
+
+
+class TestSniffing:
+    def test_signatures(self) -> None:
+        assert sniff_audio_container(_wav_bytes()) == "wav"
+        assert sniff_audio_container(b"ID3" + b"\x00" * 16) == "mp3"
+        assert sniff_audio_container(b"\xff\xfb\x90\x00" + b"\x00" * 16) == "mp3"
+        assert sniff_audio_container(b"\xff\xf1\x50\x80" + b"\x00" * 16) == "aac"
+        assert sniff_audio_container(b"\x00\x00\x00\x20ftypM4A " + b"\x00" * 8) == "m4a"
+        assert sniff_audio_container(b"GIF89a" + b"\x00" * 16) is None
+        assert sniff_audio_container(b"") is None
+
+
+class TestVoiceUpload:
+    def test_missing_auth_rejected_before_processing(self, client, fake_stt) -> None:
+        """VOI-001."""
+        response = client.post("/mobile/voice/upload", data={})
+        assert response.status_code == 401
+        assert fake_stt.decoded_paths == []
+
+    def test_valid_audio_transcribes_and_answers(
+        self, client, fake_stt, fake_chat_service, fake_tts
+    ) -> None:
+        """VOI-002: transcript → canonical Assistant with the principal ID."""
+        user_id, headers = _authed(client)
+        response = _upload(client, headers, _wav_bytes())
+        assert response.status_code == 200, response.get_json()
+        body = response.get_json()
+        assert body["transcript"] == fake_stt.transcript
+        assert body["response"] == f"echo[{user_id}]: {fake_stt.transcript}"
+        assert body["status"] == "completed"
+        assert body["tool_used"] is None
+        assert body["request_id"]
+        assert base64.b64decode(body["tts_base64"]) == fake_tts.audio
+        assert body["tts_mime_type"] == "audio/wav"
+        assert fake_chat_service.calls == [(fake_stt.transcript, user_id)]
+
+    def test_missing_audio_part(self, client) -> None:
+        """VOI-003."""
+        _, headers = _authed(client)
+        response = client.post(
+            "/mobile/voice/upload",
+            data={"mode": "mobile_voice"},
+            headers=headers,
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+
+    def test_multiple_audio_parts_rejected(self, client) -> None:
+        """VOI-004."""
+        import io as _io
+
+        from werkzeug.datastructures import MultiDict
+
+        _, headers = _authed(client)
+        form = MultiDict(
+            [
+                ("audio", (_io.BytesIO(_wav_bytes()), "a.wav", "audio/wav")),
+                ("audio", (_io.BytesIO(_wav_bytes()), "b.wav", "audio/wav")),
+                ("mode", "mobile_voice"),
+            ]
+        )
+        response = client.post(
+            "/mobile/voice/upload",
+            data=form,
+            headers=headers,
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+
+    def test_empty_file_rejected(self, client) -> None:
+        """VOI-005."""
+        _, headers = _authed(client)
+        response = _upload(client, headers, b"")
+        assert response.status_code == 415
+        assert response.get_json()["error"]["code"] == "INVALID_MEDIA"
+
+    def test_lying_mime_and_extension_are_ignored(self, client, fake_stt) -> None:
+        """VOI-006/VOI-007/VOI-008: signatures control, not declarations."""
+        _, headers = _authed(client)
+        junk = b"GIF89a" + b"\x00" * 64
+        response = _upload(client, headers, junk, filename="real.wav", mimetype="audio/wav")
+        assert response.status_code == 415
+        assert response.get_json()["error"]["code"] == "INVALID_MEDIA"
+        assert fake_stt.decoded_paths == []
+
+    def test_malformed_container_fails_after_decode(self, client, fake_stt) -> None:
+        """VOI-009: a valid signature with undecodable content is rejected."""
+        _, headers = _authed(client)
+        fake_stt.decode_fails = True
+        response = _upload(client, headers, _wav_bytes())
+        assert response.status_code == 415
+
+    def test_oversized_file_rejected_before_stt(self, client, fake_stt, services) -> None:
+        """VOI-010."""
+        _, headers = _authed(client)
+        big = _wav_bytes() + b"\x00" * services.config.max_audio_bytes
+        response = _upload(client, headers, big)
+        assert response.status_code == 413
+        assert fake_stt.decoded_paths == []
+
+    def test_overlong_duration_rejected_before_assistant(
+        self, client, fake_stt, fake_chat_service
+    ) -> None:
+        """VOI-011."""
+        _, headers = _authed(client)
+        fake_stt.decode_seconds = 61.0
+        response = _upload(client, headers, _wav_bytes())
+        assert response.status_code == 413
+        assert fake_chat_service.calls == []
+
+    def test_stt_unavailable_is_truthful(self, client, fake_stt, fake_chat_service) -> None:
+        """VOI-012/VOI-013: BACKEND_UNAVAILABLE, no mock transcript."""
+        _, headers = _authed(client)
+        fake_stt.available = False
+        response = _upload(client, headers, _wav_bytes())
+        assert response.status_code == 503
+        assert response.get_json()["error"]["code"] == "BACKEND_UNAVAILABLE"
+        assert fake_chat_service.calls == []
+
+    def test_client_user_id_field_rejected(self, client, fake_chat_service) -> None:
+        _, headers = _authed(client)
+        response = _upload(client, headers, _wav_bytes(), extra={"user_id": "someone-else"})
+        assert response.status_code == 400
+        assert fake_chat_service.calls == []
+
+    def test_two_users_get_separate_identity(self, client, fake_chat_service, fake_stt) -> None:
+        """VOI-016."""
+        user_a, headers_a = _authed(client, "james", "pw-123456")
+        user_b, headers_b = _authed(client, "cole", "pw-abcdef")
+        assert _upload(client, headers_a, _wav_bytes()).status_code == 200
+        assert _upload(client, headers_b, _wav_bytes()).status_code == 200
+        assert [call[1] for call in fake_chat_service.calls] == [user_a, user_b]
+
+    def test_temp_file_removed_after_request(self, client, fake_stt) -> None:
+        """VOI-017: the private temp path is gone on success."""
+        import os
+
+        _, headers = _authed(client)
+        assert _upload(client, headers, _wav_bytes()).status_code == 200
+        assert len(fake_stt.decoded_paths) == 1
+        assert not os.path.exists(fake_stt.decoded_paths[0])
+
+    def test_temp_file_removed_after_failure(self, client, fake_stt) -> None:
+        """VOI-017 (failure path)."""
+        import os
+
+        _, headers = _authed(client)
+        fake_stt.decode_fails = True
+        assert _upload(client, headers, _wav_bytes()).status_code == 415
+        assert len(fake_stt.decoded_paths) == 1
+        assert not os.path.exists(fake_stt.decoded_paths[0])
+
+    def test_transcript_and_response_not_logged(self, client, fake_stt, caplog) -> None:
+        """VOI-018."""
+        _, headers = _authed(client)
+        fake_stt.transcript = "extremely private transcript 7788"
+        with caplog.at_level("DEBUG"):
+            _upload(client, headers, _wav_bytes())
+        assert fake_stt.transcript not in caplog.text
+
+    def test_status_never_upgraded(self, client) -> None:
+        """VOI-019: conversational replies are 'completed', never 'verified'."""
+        _, headers = _authed(client)
+        body = _upload(client, headers, _wav_bytes()).get_json()
+        assert body["status"] == "completed"


### PR DESCRIPTION
## Summary
- completes and corrects Session 2 of the authenticated mobile gateway for issue #323
- hardens authoritative session/client metadata, runtime readiness, WebSocket recovery, voice/TTS truthfulness, and live integration evidence
- keeps the PR draft, unmerged, and scoped to the existing Session 2 branch

## Changes
- require strict WebSocket client metadata and reject missing, extra, mistyped, invalid-platform, invalid-version, or invalid-device fields
- report chat/WebSocket/STT/TTS capabilities only when the configured runtime and registered route are actually ready; readiness checks do not download models or synthesize audio
- return the concrete TTS voice used plus `requested_voice`, with shared fixtures updated
- add a real Flask-Sock/simple-websocket loopback integration covering upgrade, auth, chat ack/token/done, close codes 4401 (invalid token and revocation) and 4408 (auth timeout), and cross-transport exactly-once replay
- keep 4403 reserved and untested: Session 2 has no real authenticated-but-forbidden chat-denial condition
- reduce the two valid CodeFactor complexity findings by extracting WebSocket frame/session dispatch and voice/TTS route handlers
- document the correction-pass contract and validation truth

## Verification
- Backend head: `d1b56ff794f6e2bdddc463414604cb7a0bb78687`
- `python -m pytest -q tests/mobile_api` recorded result: 252 passed, 0 skipped, 1 warning
- live loopback test: passed actual auth/chat/dedupe, invalid-token 4401, auth-timeout 4408, logout-revocation 4401, and no URL token
- `ruff check rex tests/mobile_api`: passed
- `black --check rex tests/mobile_api`: passed
- `mypy rex`: passed (359 source files)
- Backend CI is successful for the current head (workflow run `29547392741`)
- full `pytest -q`: 8,001 passed, 102 skipped, 16 failed
  - 15 time/weather/workflow failures reproduce on untouched `master` SHA `482a051d`
  - the generated `coverage.txt` meta-test mismatch is the known base/local-report limitation

## Risk / Notes
- physical iPhone and LAN validation were not run
- real duplex live voice and public TLS/reverse-proxy deployment remain out of scope
- Expo/mobile PR CI must complete on the companion draft PR
- no broad dependency upgrades were made

## Screenshots / UI
- Not applicable; backend/runtime behavior only.

## References
- Related to #323 (does not close it)
- Companion mobile draft: Blueibear/AskRex#8
