### PR TITLE
feat(runtime): canonicalize application data roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,7 @@ data/shopping_list.json
 bridge/data/
 
 /gui/profiles/
+
+# Canonical AskRex runtime data
+data/household/
+data/users/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -267,7 +267,7 @@
         "filename": "rex/gui_app.py",
         "hashed_secret": "c81a6243fd91dd24adbc650fc11bc4d474cc5d64",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 139
       }
     ],
     "rex/llm_client.py": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,14 +121,25 @@ Runtime settings belong in:
 
 config/rex_config.json
 
-Core config, `.env`, and profile paths must resolve through
-`rex.runtime_paths`, not the process working directory. Electron must launch
-every Python bridge with `bridgeSpawnOptions()` so development uses the
-repository root and packaged builds use Electron `userData`; this also keeps
-legacy relative `data/` stores inside the canonical runtime root. New
-persistence code must use `rex.runtime_paths`, and existing legacy stores
-should be migrated when touched. Never write runtime state beneath `bridge/`,
-the application archive, or packaged resources.
+Core config, `.env`, profiles, and persistent data paths must resolve
+through `rex.runtime_paths`, not the process working directory. Electron must
+launch every Python bridge with `bridgeSpawnOptions()` so development uses the
+repository root and packaged builds use Electron `userData`.
+
+Persistent data is partitioned explicitly:
+
+- `data/household/` for shared service state, authentication, notifications,
+  schedules, and conversation-history databases whose rows are user-scoped.
+- `data/users/<validated-user-id>/` for private memory and learned autonomy
+  preferences/history.
+
+`REX_DATA_DIR` remains a compatibility override for the exact shared-data root.
+Managed Electron launches also set `ASKREX_HOUSEHOLD_DATA_DIR` and
+`ASKREX_USERS_DATA_DIR`. New persistence code must use `rex.runtime_paths`.
+Existing `data/` and `~/.rex` stores migrate with
+`scripts/migrate_runtime_data.py`, which is dry-run by default and must never
+overwrite conflicts. Never write runtime state beneath `bridge/`, the
+application archive, or packaged resources.
 
 Principles:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -177,6 +177,20 @@ Use:
 - `.env` for secrets: API keys, tokens, and shared service keys.
 - `profiles/*.json` for profile capabilities and runtime overrides.
 
+### Existing runtime data
+
+AskRex now separates shared state under `data/household/` from private state
+under `data/users/<user-id>/`. Before upgrading an existing installation,
+preview the migration plan:
+
+```bash
+python scripts/migrate_runtime_data.py --user <user-id>
+```
+
+After reviewing every source and destination, apply it with `--apply`. The tool
+creates adjacent backups, retains the original files, is safe to rerun, and
+refuses to overwrite conflicting targets.
+
 Useful commands:
 
 ```bash

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -29,6 +29,17 @@ source .venv/bin/activate
 | OpenClaw tool server | `rex-tool-server` | HTTP tool adapter service on port 18790 |
 | Windows computer agent | `rex-agent` | Optional remote PC control agent |
 
+## Runtime data locations
+
+Packaged Electron bridges write only beneath Electron's `userData` directory.
+Shared state resolves to `data/household/`; private state resolves to
+`data/users/<validated-user-id>/`. Developer source runs use the repository as
+the runtime root unless `ASKREX_RUNTIME_DIR` is set. `REX_DATA_DIR` remains a
+compatibility override for the exact shared-data root.
+
+Use `python scripts/migrate_runtime_data.py --user <user-id>` for a dry-run of
+legacy `data/` and `~/.rex` moves. Add `--apply` only after reviewing the plan.
+
 The old Tkinter launchers are archived under `archived/tkinter_gui/` and are not supported.
 
 ## Text Chat

--- a/docs/claude/CONFIG_AND_SECURITY.md
+++ b/docs/claude/CONFIG_AND_SECURITY.md
@@ -17,14 +17,37 @@ network exposure, service auth, packaging, or security controls.
 - Core config, `.env`, and profile defaults resolve through `rex.runtime_paths`.
 - `ASKREX_RUNTIME_DIR` overrides the runtime root for packaged or managed launches.
 - `ASKREX_CONFIG_PATH`, `ASKREX_ENV_PATH`, `ASKREX_PROFILES_DIR`, `REX_DATA_DIR`,
-  and `ASKREX_MEMORY_DIR` may override individual paths.
+  `ASKREX_HOUSEHOLD_DATA_DIR`, `ASKREX_USERS_DATA_DIR`, and `ASKREX_MEMORY_DIR`
+  may override individual paths.
 - Source checkouts default to the repository root. Installed Python use falls back
   to the platform user-data directory.
 - Electron development bridges use the repository root; packaged bridges use
-  `app.getPath('userData')` through `bridgeSpawnOptions()`. The canonical CWD keeps
-  legacy relative `data/` stores under that runtime root until they are migrated.
+  `app.getPath('userData')` through `bridgeSpawnOptions()`.
+- Shared state belongs under `data/household/`; private state belongs under
+  `data/users/<validated-user-id>/`. `REX_DATA_DIR` retains its historical
+  meaning as the exact shared-data root when the explicit household override is
+  absent; its private sibling is `<REX_DATA_DIR>/users/` unless overridden.
 - New persistence code must use `rex.runtime_paths`. Never use the bridge script
   directory, application archive, or packaged resources as writable storage.
+
+### Runtime-data migration
+
+Preview the known legacy `data/` and `~/.rex` moves without writing anything:
+
+```bash
+python scripts/migrate_runtime_data.py --user <user-id>
+```
+
+Apply only after reviewing the complete plan:
+
+```bash
+python scripts/migrate_runtime_data.py --user <user-id> --apply
+```
+
+The tool validates the owner, creates adjacent `.pre-runtime-root-migration.bak`
+backups, retains every source, copies through a temporary path, treats identical
+targets as already migrated, and refuses conflicting destinations. Re-running
+it is safe.
 
 ## Canonical Secret-Loading Path
 
@@ -297,7 +320,7 @@ Deprecated flat-field aliases that currently emit `DeprecationWarning`:
 | `error_log_path` | `runtime.error_log_path` | json-only | runtime | platform default |
 | `memory_max_bytes` | `runtime.memory_max_bytes` | json-only | runtime | `131072` |
 | `persist_history` | `runtime.persist_history` | json-only | runtime | `True` |
-| `history_db_path` | `runtime.history_db_path` | json-only | runtime | `"data/history.db"` |
+| `history_db_path` | `runtime.history_db_path` | json-only | runtime | canonical household `history.db` |
 | `history_retention_days` | `runtime.history_retention_days` | json-only | runtime | `30` |
 | `response_cache_ttl` | `response_cache.ttl` | json-only | runtime | `300.0` |
 

--- a/docs/planning/ASKREX_UNIFIED_DELIVERY_BACKLOG.md
+++ b/docs/planning/ASKREX_UNIFIED_DELIVERY_BACKLOG.md
@@ -93,6 +93,7 @@ Priority key: **P0** release blocker / security-critical, **P1** required for sh
 - Tests: `tests/test_memory_isolation.py`, `tests/test_electron_session_isolation.py`, `tests/test_command_history.py`
 - Validation commands: `py -3.11 -m pytest -q tests/test_memory_isolation.py tests/test_electron_session_isolation.py tests/test_command_history.py`; `cd gui; npm.cmd test; npm.cmd run build`
 - DoD: two Rex users and two Windows OS users cannot read each other's private data; migration is dry-run-first, idempotent, and backed up; packaged Electron writes only under the approved root
+- **Implemented 2026-08-01:** canonical runtime paths now separate `data/household/` from `data/users/<validated-user-id>/`; Electron passes explicit runtime, household, and users roots; legacy `REX_DATA_DIR` semantics remain compatible; `scripts/migrate_runtime_data.py` provides backed-up, conflict-safe dry-run/apply migration. Local evidence: 8,109 CI-selected tests passed at 82.49% coverage, 36 integration tests passed, 26 GUI tests passed, Electron streaming verification passed, and Ruff/Black/mypy/security gates passed. GitHub PR checks remain required before final completion.
 
 **S4 — Move desktop secrets into an OS-backed credential vault** (P1)
 - Files/areas: `gui/src/main/configStore.ts:59-114`; `gui/src/main/handlers/settings.ts:31-55`; `gui/src/main/settingsMirror.ts:95-116,143-145`; `rex/credentials.py:1-7,26-46,111-233`

--- a/gui/src/main/bridgeResolver.ts
+++ b/gui/src/main/bridgeResolver.ts
@@ -95,6 +95,8 @@ export function bridgeSpawnOptions(): { cwd: string; env: NodeJS.ProcessEnv } {
       ASKREX_ENV_PATH: join(runtimeRoot, '.env'),
       ASKREX_PROFILES_DIR: join(runtimeRoot, 'profiles'),
       REX_DATA_DIR: join(runtimeRoot, 'data'),
+      ASKREX_HOUSEHOLD_DATA_DIR: join(runtimeRoot, 'data', 'household'),
+      ASKREX_USERS_DATA_DIR: join(runtimeRoot, 'data', 'users'),
       ASKREX_MEMORY_DIR: join(runtimeRoot, 'Memory')
     }
   }

--- a/gui/tests/bridgeResolver.test.ts
+++ b/gui/tests/bridgeResolver.test.ts
@@ -101,6 +101,10 @@ describe('runtime path isolation', () => {
     const options = bridgeSpawnOptions()
     expect(options.cwd).toBe('/fake/user-data')
     expect(options.env.REX_DATA_DIR).toBe(join('/fake/user-data', 'data'))
+    expect(options.env.ASKREX_HOUSEHOLD_DATA_DIR).toBe(
+      join('/fake/user-data', 'data', 'household')
+    )
+    expect(options.env.ASKREX_USERS_DATA_DIR).toBe(join('/fake/user-data', 'data', 'users'))
     expect(options.env.ASKREX_MEMORY_DIR).toBe(join('/fake/user-data', 'Memory'))
   })
 })

--- a/gui/tmp_verify_chat_stream.cjs
+++ b/gui/tmp_verify_chat_stream.cjs
@@ -11,7 +11,11 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function registerDeterministicChatStreamHandler() {
+function registerDeterministicAppHandlers() {
+  ipcMain.removeHandler('rex:getSetupStatus');
+  ipcMain.handle('rex:getSetupStatus', async () => ({ ok: true, needs_setup: false }));
+  ipcMain.removeHandler('rex:getStatus');
+  ipcMain.handle('rex:getStatus', async () => ({ ok: true, status: 'ready' }));
   ipcMain.removeHandler('rex:startChatStream');
   ipcMain.handle('rex:startChatStream', async (event, { message, streamId }) => {
     process.stdout.write(JSON.stringify({ handler: 'rex:startChatStream', message }) + '\n');
@@ -39,8 +43,9 @@ app.whenReady().then(async () => {
   let ok = false;
   try {
     const win = await waitForWindow();
+    registerDeterministicAppHandlers();
+    await win.reload();
     await sleep(1500);
-    registerDeterministicChatStreamHandler();
     const result = await win.webContents.executeJavaScript(`
       (async () => {
         const prompt = 'Smoke test message';

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -24,6 +24,7 @@ from .llm_client import LanguageModel
 from .memory import trim_history
 from .model_router import ModelRouter
 from .plugins import PluginSpec
+from .runtime_paths import household_data_path
 
 logger = logging.getLogger(__name__)
 
@@ -128,9 +129,7 @@ class Assistant:
             try:
                 db_path = getattr(self._settings, "history_db_path", None)
                 if db_path is None:
-                    from pathlib import Path as _Path
-
-                    db_path = _Path("data/history.db")
+                    db_path = household_data_path("history.db")
                 self._history_store = HistoryStore(db_path=db_path)
                 if self._user_id is not None:
                     # Preload the last 50 turns into in-memory history

--- a/rex/auth.py
+++ b/rex/auth.py
@@ -20,9 +20,10 @@ from typing import Any
 import bcrypt
 import jwt
 
+from rex.runtime_paths import household_data_path
+
 logger = logging.getLogger(__name__)
 
-_DB_PATH = Path(os.getenv("REX_DATA_DIR", "data")) / "users.db"
 _JWT_ALGORITHM = "HS256"
 _TOKEN_EXPIRY_HOURS = 24
 
@@ -47,11 +48,8 @@ def get_jwt_secret() -> str:
 
 
 def _get_db_path() -> Path:
-    """Return the resolved path to the users database."""
-    raw = os.getenv("REX_DATA_DIR")
-    if raw:
-        return Path(raw) / "users.db"
-    return _DB_PATH
+    """Return the canonical household users database path."""
+    return household_data_path("users.db")
 
 
 def _open_db() -> sqlite3.Connection:

--- a/rex/autonomy/history.py
+++ b/rex/autonomy/history.py
@@ -6,8 +6,8 @@ Provides:
 - :class:`HistoryStore` — an async SQLite-backed store for
   :class:`ExecutionRecord` objects.
 
-The backing database is created automatically at ``~/.rex/execution_history.db``
-on first access.  The migration (table creation) also runs on first access so
+The backing database is created automatically beneath the validated user's private
+runtime directory on first access.  The migration (table creation) also runs on first access so
 callers never need to manage schema versions.
 """
 
@@ -23,14 +23,13 @@ import aiosqlite
 from pydantic import BaseModel, Field
 
 from rex.autonomy.models import Plan
+from rex.runtime_paths import user_data_path
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-_DEFAULT_DB_PATH = Path.home() / ".rex" / "execution_history.db"
 
 OutcomeType = Literal["success", "partial", "failed"]
 
@@ -93,13 +92,16 @@ class HistoryStore:
     """Async SQLite-backed store for :class:`ExecutionRecord` objects.
 
     Args:
-        db_path: Path to the SQLite database file.  Defaults to
-            ``~/.rex/execution_history.db``.  The parent directory is
-            created automatically if it does not exist.
+        db_path: Explicit SQLite path, primarily for tests and migrations.
+        user_id: Validated owner used when ``db_path`` is omitted.
     """
 
-    def __init__(self, db_path: Path | None = None) -> None:
-        self._db_path: Path = db_path or _DEFAULT_DB_PATH
+    def __init__(self, db_path: Path | None = None, *, user_id: str = "default") -> None:
+        self._db_path = (
+            Path(db_path)
+            if db_path is not None
+            else user_data_path(user_id, "autonomy", "execution_history.db")
+        )
 
     # ------------------------------------------------------------------
     # Migration / initialisation

--- a/rex/autonomy/preferences.py
+++ b/rex/autonomy/preferences.py
@@ -6,8 +6,8 @@ Provides:
 - :class:`PreferenceStore` — a JSON-backed store for loading and saving a
   :class:`UserPreferenceProfile`.
 
-The backing file is created automatically at ``~/.rex/preferences.json`` on
-first save.
+The backing file is created automatically beneath the validated user's private
+runtime directory on first save.
 """
 
 from __future__ import annotations
@@ -18,14 +18,13 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from rex.runtime_paths import user_data_path
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-_DEFAULT_PREFS_PATH = Path.home() / ".rex" / "preferences.json"
-
 
 # ---------------------------------------------------------------------------
 # UserPreferenceProfile
@@ -63,13 +62,16 @@ class PreferenceStore:
     """JSON-backed store for a :class:`UserPreferenceProfile`.
 
     Args:
-        prefs_path: Path to the JSON file.  Defaults to
-            ``~/.rex/preferences.json``.  The parent directory is created
-            automatically on :meth:`save`.
+        prefs_path: Explicit JSON path, primarily for tests and migrations.
+        user_id: Validated owner used when ``prefs_path`` is omitted.
     """
 
-    def __init__(self, prefs_path: Path | None = None) -> None:
-        self._path: Path = prefs_path or _DEFAULT_PREFS_PATH
+    def __init__(self, prefs_path: Path | None = None, *, user_id: str = "default") -> None:
+        self._path = (
+            Path(prefs_path)
+            if prefs_path is not None
+            else user_data_path(user_id, "autonomy", "preferences.json")
+        )
 
     def load(self) -> UserPreferenceProfile:
         """Load the preference profile from disk.

--- a/rex/command_history.py
+++ b/rex/command_history.py
@@ -12,22 +12,18 @@ Public API
 from __future__ import annotations
 
 import logging
-import os
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from rex.runtime_paths import household_data_path
 
-_DEFAULT_DB = Path("data") / "command_history.db"
+logger = logging.getLogger(__name__)
 
 
 def _get_db_path() -> Path:
-    raw = os.getenv("REX_DATA_DIR")
-    if raw:
-        return Path(raw) / "command_history.db"
-    return _DEFAULT_DB
+    return household_data_path("command_history.db")
 
 
 class CommandHistoryStore:
@@ -35,7 +31,7 @@ class CommandHistoryStore:
 
     Args:
         db_path: Path to the SQLite database file.
-                 Defaults to ``data/command_history.db``.
+                 Defaults to ``data/household/command_history.db``.
     """
 
     def __init__(self, db_path: str | Path | None = None) -> None:

--- a/rex/config.py
+++ b/rex/config.py
@@ -45,6 +45,7 @@ from rex.config_manager import get_legacy_env_warnings
 from rex.log_paths import DEFAULT_ERROR_LOG_FILE, DEFAULT_RUNTIME_LOG_FILE
 from rex.logging_utils import get_logger, set_global_level
 from rex.runtime_paths import env_path as resolve_env_path
+from rex.runtime_paths import household_data_path
 
 from rex.profile_manager import (
     DEFAULT_PROFILES_DIR,
@@ -458,7 +459,7 @@ class AppConfig:
 
     # Conversation history persistence
     persist_history: bool = True
-    history_db_path: Path = field(default_factory=lambda: Path("data/history.db"))
+    history_db_path: Path = field(default_factory=lambda: household_data_path("history.db"))
     history_retention_days: int = 30
 
     # Autonomy budget limits (0 = unlimited)
@@ -1233,7 +1234,11 @@ def build_app_config(json_config: dict) -> AppConfig:
         # History persistence
         persist_history=bool(_get_nested(json_config, "runtime.persist_history", True)),
         history_db_path=Path(
-            _get_nested(json_config, "runtime.history_db_path", "data/history.db")
+            _get_nested(
+                json_config,
+                "runtime.history_db_path",
+                str(household_data_path("history.db")),
+            )
         ),
         history_retention_days=_coerce_int(json_config, "runtime.history_retention_days", 30),
         # Model routing

--- a/rex/gui_app.py
+++ b/rex/gui_app.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from rex.audio.speaker_discovery import start_smart_speaker_discovery
+from rex.runtime_paths import household_data_dir
 
 _DEFAULT_HOST = "127.0.0.1"
 _DEFAULT_PORT = 8765
@@ -137,7 +138,7 @@ def _create_flask_app(ui_enabled: bool = True) -> Any:
     app = Flask(__name__, static_folder=None)
     app.secret_key = "rex-gui-local"  # local-only; not security-sensitive
     app.config["SETUP_TOKEN"] = secrets.token_urlsafe(32)
-    data_dir = Path(os.getenv("REX_DATA_DIR", "data"))
+    data_dir = household_data_dir()
     history_store = HistoryStore(db_path=data_dir / "history.db")
     _register_core_routes(app, ui_enabled=ui_enabled)
     _register_api_blueprints(app, data_dir=data_dir, history_store=history_store)

--- a/rex/ha/mutation_service.py
+++ b/rex/ha/mutation_service.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import hmac
 import json
-import os
 import sqlite3
 import time
 import uuid
@@ -18,6 +17,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from rex.identity import validate_user_id
+from rex.runtime_paths import household_data_dir
 
 
 class HARisk(StrEnum):
@@ -91,14 +91,7 @@ _PROHIBITED_DOMAINS = {
 
 
 def _runtime_data_dir() -> Path:
-    configured = os.environ.get("REX_DATA_DIR")
-    if configured:
-        return Path(configured)
-    if os.name == "nt":
-        base = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local")))
-    else:
-        base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
-    return base / "rex-ai"
+    return household_data_dir()
 
 
 def classify_ha_risk(domain: str, service: str) -> HARisk:

--- a/rex/history_store.py
+++ b/rex/history_store.py
@@ -3,7 +3,7 @@
 Stores conversation turns (user / assistant messages) per user so that
 sessions can be resumed after restarts.
 
-Default database path: ``data/history.db`` (configurable via ``db_path``).
+Default database path: ``data/household/history.db`` (configurable via ``db_path``).
 """
 
 from __future__ import annotations
@@ -15,10 +15,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from rex.identity import validate_user_id
+from rex.runtime_paths import household_data_path
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_DB_PATH = Path("data/history.db")
 
 _CREATE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS turns (
@@ -40,14 +40,14 @@ class HistoryStore:
 
     Args:
         db_path: Path to the SQLite database file.  Defaults to
-            ``data/history.db``.  Parent directories are created if they
+            ``data/household/history.db``. Parent directories are created if they
             do not exist.
     """
 
-    def __init__(self, db_path: Path = _DEFAULT_DB_PATH) -> None:
-        self._db_path = db_path
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._db_path = Path(db_path) if db_path is not None else household_data_path("history.db")
         self._lock = threading.Lock()
-        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
         with self._connect() as conn:
             conn.execute(_CREATE_TABLE_SQL)
             conn.execute(_CREATE_INDEX_SQL)

--- a/rex/integrations/message_router.py
+++ b/rex/integrations/message_router.py
@@ -2,11 +2,11 @@
 
 Routes a message to the correct channel based on an explicit
 ``preferred_channel`` argument, a contacts file
-(``~/.rex/contacts.json``), or availability of configured services.
+(the household contacts store), or availability of configured services.
 
 Priority:
 1. ``preferred_channel`` parameter — used directly if supplied.
-2. Contact entry in ``~/.rex/contacts.json`` — uses the stored
+2. Contact entry in the household contacts store — uses the stored
    ``preferred_channel`` for that contact (matched by name or number).
 3. Service availability — email if :class:`EmailService` is configured;
    SMS if :class:`SMSService` is configured; raises :exc:`NoChannelError`
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel
+
+from rex.runtime_paths import household_data_path
 
 logger = logging.getLogger(__name__)
 
@@ -79,14 +81,19 @@ class EmailChannel(Protocol):
 # Contacts helper
 # ---------------------------------------------------------------------------
 
-_CONTACTS_PATH = Path.home() / ".rex" / "contacts.json"
+_CONTACTS_PATH: Path | None = None
+
+
+def _contacts_path() -> Path:
+    return _CONTACTS_PATH or household_data_path("contacts.json")
 
 
 def _load_contacts() -> list[dict[str, str]]:
-    """Load contacts from ``~/.rex/contacts.json`` (returns empty list on error)."""
+    """Load household contacts, returning an empty list on error."""
+    path = _contacts_path()
     try:
-        if _CONTACTS_PATH.exists():
-            raw = _CONTACTS_PATH.read_text(encoding="utf-8")
+        if path.exists():
+            raw = path.read_text(encoding="utf-8")
             data = json.loads(raw)
             if isinstance(data, list):
                 return [c for c in data if isinstance(c, dict)]
@@ -147,7 +154,7 @@ class MessageRouter:
         Args:
             contact: Recipient identifier — an email address, a phone
                 number in E.164 format, or a display name that can be
-                looked up in ``~/.rex/contacts.json``.
+                looked up in the household contacts store.
             body: Message body text.
             preferred_channel: Explicit channel override (``"sms"`` or
                 ``"email"``).  When supplied, skips all routing logic.

--- a/rex/memory.py
+++ b/rex/memory.py
@@ -71,6 +71,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from rex.identity import validate_user_id
+from rex.runtime_paths import data_dir, user_data_dir, users_data_dir
 
 # Re-export existing memory utilities for backward compatibility
 from .memory_utils import (  # noqa: F401
@@ -87,8 +88,16 @@ from .memory_utils import (  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
-# Default data directory for structured memory
-_DATA_DIR = Path("data/memory")
+# Compatibility seam for callers/tests that replace the structured-memory
+# root. Production defaults use the canonical private-user layout.
+_DATA_DIR = data_dir() / "memory"
+_INITIAL_DATA_DIR = _DATA_DIR
+
+
+def _legacy_memory_dir() -> Path:
+    """Return the pre-canonical structured-memory root."""
+    return _DATA_DIR
+
 
 # The distinct profile that owns pre-isolation legacy data. Never used as an
 # implicit fallback; callers must select it explicitly.
@@ -122,8 +131,12 @@ def _reject_case_conflicts(user_id: str) -> None:
     """
     folded = user_id.casefold()
     known_ids: set[str] = set(_working_memories) | set(_long_term_memories)
-    if _DATA_DIR.is_dir():
-        known_ids.update(entry.name for entry in _DATA_DIR.iterdir() if entry.is_dir())
+    private_root = users_data_dir()
+    if private_root.is_dir():
+        known_ids.update(entry.name for entry in private_root.iterdir() if entry.is_dir())
+    legacy_root = _legacy_memory_dir()
+    if legacy_root.is_dir():
+        known_ids.update(entry.name for entry in legacy_root.iterdir() if entry.is_dir())
     for existing in known_ids:
         if existing != user_id and existing.casefold() == folded:
             raise ValueError(
@@ -132,10 +145,18 @@ def _reject_case_conflicts(user_id: str) -> None:
 
 
 def _user_memory_dir(user_id: str) -> Path:
-    """Return the per-user memory directory for a validated user ID."""
+    """Return private memory storage and copy a legacy user store on first access."""
     user_id = validate_user_id(user_id)
     _reject_case_conflicts(user_id)
-    return _DATA_DIR / user_id
+    target = (
+        _DATA_DIR / user_id if _DATA_DIR != _INITIAL_DATA_DIR else user_data_dir(user_id) / "memory"
+    )
+    legacy = _legacy_memory_dir() / user_id
+    if legacy.is_dir() and not target.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(legacy, target)
+        logger.info("Copied legacy memory profile '%s' into canonical private storage", user_id)
+    return target
 
 
 def _migrate_legacy_default_store(filename: str) -> None:
@@ -154,11 +175,12 @@ def _migrate_legacy_default_store(filename: str) -> None:
        If the move fails, the original stays in place and the move is
        retried later; migration itself is already complete.
     """
-    legacy = _DATA_DIR / filename
+    legacy_root = _legacy_memory_dir()
+    legacy = legacy_root / filename
     if not legacy.is_file():
         return
 
-    target = _DATA_DIR / DEFAULT_PROFILE / filename
+    target = _user_memory_dir(DEFAULT_PROFILE) / filename
     if not target.exists():
         target.parent.mkdir(parents=True, exist_ok=True)
         # PID-unique temp file: concurrent first-time migrations (e.g. two
@@ -172,7 +194,7 @@ def _migrate_legacy_default_store(filename: str) -> None:
             tmp_copy.unlink(missing_ok=True)
         logger.info("Migrated legacy shared %s into the 'default' profile store", filename)
 
-    backup = _DATA_DIR / (filename + LEGACY_BACKUP_SUFFIX)
+    backup = legacy_root / (filename + LEGACY_BACKUP_SUFFIX)
     if not backup.exists():
         try:
             legacy.rename(backup)
@@ -923,10 +945,11 @@ def list_memory_user_ids() -> list[str]:
     returned; anything else (including the legacy shared files and their
     backups at the data-dir root) is ignored and never treated as a user.
     """
-    if not _DATA_DIR.is_dir():
+    root = _DATA_DIR if _DATA_DIR != _INITIAL_DATA_DIR else users_data_dir()
+    if not root.is_dir():
         return []
     users: list[str] = []
-    for entry in sorted(_DATA_DIR.iterdir()):
+    for entry in sorted(root.iterdir()):
         if not entry.is_dir():
             continue
         try:

--- a/rex/mobile_api/db.py
+++ b/rex/mobile_api/db.py
@@ -15,9 +15,10 @@ Raw refresh tokens are never stored; only SHA-256 hashes.
 from __future__ import annotations
 
 import logging
-import os
 import sqlite3
 from pathlib import Path
+
+from rex.runtime_paths import household_data_path
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +26,8 @@ _BUSY_TIMEOUT_MS = 5000
 
 
 def default_users_db_path() -> Path:
-    """Return the canonical users database path (honours ``REX_DATA_DIR``)."""
-    return Path(os.getenv("REX_DATA_DIR", "data")) / "users.db"
+    """Return the canonical household users database path."""
+    return household_data_path("users.db")
 
 
 def connect(db_path: Path | str) -> sqlite3.Connection:

--- a/rex/notifications/models.py
+++ b/rex/notifications/models.py
@@ -3,7 +3,7 @@
 ``Notification`` holds all metadata needed by the notification engine to
 make routing, quiet-hours, and escalation decisions.
 
-``NotificationStore`` persists notifications to ``~/.rex/notifications.db``
+``NotificationStore`` persists notifications to the household runtime database
 using the standard library ``sqlite3`` module — no extra dependencies.
 """
 
@@ -17,6 +17,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from rex.runtime_paths import household_data_path
+
 # ---------------------------------------------------------------------------
 # Type aliases
 # ---------------------------------------------------------------------------
@@ -27,8 +29,6 @@ NotificationChannel = Literal["desktop", "digest", "sms", "email"]
 # ---------------------------------------------------------------------------
 # Notification model
 # ---------------------------------------------------------------------------
-
-_DB_PATH = Path.home() / ".rex" / "notifications.db"
 
 
 class Notification(BaseModel):
@@ -135,12 +135,13 @@ class NotificationStore:
     """SQLite-backed persistence for :class:`Notification` objects.
 
     Args:
-        db_path: Path to the SQLite database file.  Defaults to
-            ``~/.rex/notifications.db``.
+        db_path: Explicit SQLite path. Defaults to the household runtime store.
     """
 
-    def __init__(self, db_path: Path = _DB_PATH) -> None:
-        self._db_path = db_path
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._db_path = (
+            Path(db_path) if db_path is not None else household_data_path("notifications.db")
+        )
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         with self._connect() as con:
             con.execute(_CREATE_TABLE)

--- a/rex/permissions.py
+++ b/rex/permissions.py
@@ -16,14 +16,13 @@ The first registered user is automatically granted ``admin``.
 from __future__ import annotations
 
 import logging
-import os
 import sqlite3
 from enum import StrEnum
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from rex.runtime_paths import household_data_path
 
-_DB_PATH = Path(os.getenv("REX_DATA_DIR", "data")) / "users.db"
+logger = logging.getLogger(__name__)
 
 
 class Permission(StrEnum):
@@ -42,10 +41,8 @@ class Permission(StrEnum):
 
 
 def _get_db_path() -> Path:
-    raw = os.getenv("REX_DATA_DIR")
-    if raw:
-        return Path(raw) / "users.db"
-    return _DB_PATH
+    """Return the canonical household users database path."""
+    return household_data_path("users.db")
 
 
 def _open_db() -> sqlite3.Connection:

--- a/rex/runtime_paths.py
+++ b/rex/runtime_paths.py
@@ -4,6 +4,12 @@ Runtime state must never depend on the process working directory. Electron
 sets ``ASKREX_RUNTIME_DIR`` to its per-user data directory. Source checkouts
 fall back to the repository root, while installed CLI use falls back to the
 platform user-data directory.
+
+Within ``data/``, household-shared state and private per-Rex-user state are
+separated explicitly::
+
+    data/household/...          shared configuration and service state
+    data/users/<user_id>/...    private user-owned state
 """
 
 from __future__ import annotations
@@ -17,6 +23,8 @@ _CONFIG_PATH_ENV = "ASKREX_CONFIG_PATH"
 _ENV_PATH_ENV = "ASKREX_ENV_PATH"
 _PROFILES_DIR_ENV = "ASKREX_PROFILES_DIR"
 _DATA_DIR_ENV = "REX_DATA_DIR"
+_HOUSEHOLD_DATA_DIR_ENV = "ASKREX_HOUSEHOLD_DATA_DIR"
+_USERS_DATA_DIR_ENV = "ASKREX_USERS_DATA_DIR"
 _MEMORY_DIR_ENV = "ASKREX_MEMORY_DIR"
 
 
@@ -38,8 +46,10 @@ def source_checkout_root(start: Path | None = None) -> Path | None:
 def _platform_user_data_root() -> Path:
     home = Path.home()
     if sys.platform == "win32":
-        base = os.getenv("APPDATA") or os.getenv("LOCALAPPDATA")
-        return _expanded_path(base) / "AskRex" if base else home / "AppData" / "Roaming" / "AskRex"
+        # LOCALAPPDATA is the correct boundary for machine-local application
+        # state. APPDATA is only a compatibility fallback.
+        base = os.getenv("LOCALAPPDATA") or os.getenv("APPDATA")
+        return _expanded_path(base) / "AskRex" if base else home / "AppData" / "Local" / "AskRex"
     if sys.platform == "darwin":
         return home / "Library" / "Application Support" / "AskRex"
     base = os.getenv("XDG_DATA_HOME")
@@ -57,7 +67,7 @@ def runtime_root() -> Path:
 
 def _resolve(value: str | os.PathLike[str] | None, default: str) -> Path:
     if value is None:
-        return runtime_root() / default
+        return (runtime_root() / default).resolve(strict=False)
     path = Path(value).expanduser()
     return (
         path.resolve(strict=False)
@@ -90,6 +100,44 @@ def data_dir(value: str | os.PathLike[str] | None = None) -> Path:
     return _resolve(value, "data")
 
 
+def household_data_dir(value: str | os.PathLike[str] | None = None) -> Path:
+    """Return shared state, preserving the legacy ``REX_DATA_DIR`` contract."""
+    if value is None and os.getenv(_HOUSEHOLD_DATA_DIR_ENV):
+        value = os.environ[_HOUSEHOLD_DATA_DIR_ENV]
+    if value is not None:
+        return _resolve(value, "data/household")
+    if os.getenv(_DATA_DIR_ENV):
+        return data_dir()
+    return _resolve(None, "data/household")
+
+
+def users_data_dir(value: str | os.PathLike[str] | None = None) -> Path:
+    """Return the parent directory for private Rex-user state."""
+    if value is None and os.getenv(_USERS_DATA_DIR_ENV):
+        value = os.environ[_USERS_DATA_DIR_ENV]
+    if value is not None:
+        return _resolve(value, "data/users")
+    return (data_dir() / "users").resolve(strict=False)
+
+
+def user_data_dir(user_id: str) -> Path:
+    """Return private storage for a validated Rex user."""
+    # Lazy import avoids a config/runtime_paths import cycle.
+    from rex.identity import validate_user_id
+
+    return users_data_dir() / validate_user_id(user_id)
+
+
+def household_data_path(*parts: str | os.PathLike[str]) -> Path:
+    """Resolve a path beneath household-shared storage."""
+    return household_data_dir().joinpath(*map(Path, parts)).resolve(strict=False)
+
+
+def user_data_path(user_id: str, *parts: str | os.PathLike[str]) -> Path:
+    """Resolve a path beneath one validated user's private storage."""
+    return user_data_dir(user_id).joinpath(*map(Path, parts)).resolve(strict=False)
+
+
 def memory_dir(value: str | os.PathLike[str] | None = None) -> Path:
     if value is None and os.getenv(_MEMORY_DIR_ENV):
         value = os.environ[_MEMORY_DIR_ENV]
@@ -100,8 +148,13 @@ __all__ = [
     "config_path",
     "data_dir",
     "env_path",
+    "household_data_dir",
+    "household_data_path",
     "memory_dir",
     "profiles_dir",
     "runtime_root",
     "source_checkout_root",
+    "user_data_dir",
+    "user_data_path",
+    "users_data_dir",
 ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ not belong at the repository root.
 - `list_voices.py`: lists available Windows TTS voices
 - `manual_search_demo.py`: runs an interactive demo of the web search plugin
 - `manual_whisper_demo.py`: manually transcribes an audio file with Whisper
+- `migrate_runtime_data.py`: dry-run-first, backed-up migration from legacy `data/` and `~/.rex` stores into household/private runtime roots
 - `install_wakeword_asset.py`: copies a supplied custom ONNX or embedding wake asset into `config/wake_words/<slug>/` and validates it
 - `play_test.py`: plays the wake acknowledgment WAV with `simpleaudio`
 - `record_wakeword.py`: records and validates a custom ONNX wake-word asset with `openwakeword`

--- a/scripts/migrate_runtime_data.py
+++ b/scripts/migrate_runtime_data.py
@@ -1,0 +1,272 @@
+"""Dry-run-first migration into AskRex's canonical runtime data layout.
+
+The migration never deletes a legacy source. Applying a migration creates an
+adjacent backup, copies into an absent target atomically, and refuses to
+replace conflicting data. Re-running the migration is safe and reports items
+that already match their destination.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from rex.identity import validate_user_id
+from rex.runtime_paths import runtime_root
+
+BACKUP_SUFFIX = ".pre-runtime-root-migration.bak"
+
+
+@dataclass(frozen=True)
+class MigrationItem:
+    """One legacy source and its canonical destination."""
+
+    source: Path
+    target: Path
+    scope: str
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """Outcome for one migration item."""
+
+    source: str
+    target: str
+    scope: str
+    status: str
+    backup: str | None = None
+    detail: str | None = None
+
+
+def default_migration_items(
+    user_id: str,
+    *,
+    root: Path | None = None,
+    home: Path | None = None,
+) -> list[MigrationItem]:
+    """Build the known legacy-to-canonical migration inventory."""
+    owner = validate_user_id(user_id)
+    base = (root or runtime_root()).resolve(strict=False)
+    home_root = (home or Path.home()).resolve(strict=False)
+    legacy_data = base / "data"
+    household = legacy_data / "household"
+    private = legacy_data / "users" / owner
+
+    household_files = (
+        "users.db",
+        "history.db",
+        "command_history.db",
+        "dashboard_notifications.db",
+        "llm_usage.json",
+        "shopping_list.json",
+    )
+    household_dirs = (
+        "approvals",
+        "automations",
+        "browser_sessions",
+        "cues",
+        "knowledge_base",
+        "notifications",
+        "reminders",
+        "scheduler",
+        "workflows",
+    )
+
+    items = [
+        MigrationItem(legacy_data / name, household / name, "household") for name in household_files
+    ]
+    items.extend(
+        MigrationItem(legacy_data / name, household / name, "household") for name in household_dirs
+    )
+    items.extend(
+        (
+            MigrationItem(
+                legacy_data / "memory" / owner,
+                private / "memory",
+                "private",
+            ),
+            MigrationItem(
+                home_root / ".rex" / "preferences.json",
+                private / "autonomy" / "preferences.json",
+                "private",
+            ),
+            MigrationItem(
+                home_root / ".rex" / "execution_history.db",
+                private / "autonomy" / "execution_history.db",
+                "private",
+            ),
+            MigrationItem(
+                home_root / ".rex" / "notifications.db",
+                household / "notifications.db",
+                "household",
+            ),
+            MigrationItem(
+                home_root / ".rex" / "contacts.json",
+                household / "contacts.json",
+                "household",
+            ),
+        )
+    )
+    return items
+
+
+def _digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    if path.is_file():
+        digest.update(b"file\0")
+        digest.update(path.read_bytes())
+        return digest.hexdigest()
+    if path.is_dir():
+        digest.update(b"directory\0")
+        for child in sorted(path.rglob("*"), key=lambda item: item.as_posix()):
+            relative = child.relative_to(path).as_posix().encode("utf-8")
+            digest.update(relative)
+            digest.update(b"\0")
+            if child.is_symlink():
+                digest.update(b"symlink\0")
+                digest.update(os.readlink(child).encode("utf-8"))
+            elif child.is_file():
+                digest.update(b"file\0")
+                digest.update(child.read_bytes())
+            elif child.is_dir():
+                digest.update(b"directory\0")
+        return digest.hexdigest()
+    raise ValueError(f"Unsupported migration source: {path}")
+
+
+def _same_content(source: Path, target: Path) -> bool:
+    if source.is_file() != target.is_file() or source.is_dir() != target.is_dir():
+        return False
+    return _digest(source) == _digest(target)
+
+
+def _backup_path(source: Path) -> Path:
+    return source.with_name(source.name + BACKUP_SUFFIX)
+
+
+def _copy_absent(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(f"{target.name}.migrating.{os.getpid()}")
+    if temporary.exists():
+        if temporary.is_dir():
+            shutil.rmtree(temporary)
+        else:
+            temporary.unlink()
+    try:
+        if source.is_dir():
+            shutil.copytree(source, temporary, symlinks=True)
+            temporary.rename(target)
+        else:
+            shutil.copy2(source, temporary)
+            os.replace(temporary, target)
+    finally:
+        if temporary.exists():
+            if temporary.is_dir():
+                shutil.rmtree(temporary)
+            else:
+                temporary.unlink()
+
+
+def _ensure_backup(source: Path) -> Path:
+    backup = _backup_path(source)
+    if backup.exists():
+        if not _same_content(source, backup):
+            raise FileExistsError(f"Backup conflict: {backup}")
+        return backup
+    if source.is_dir():
+        shutil.copytree(source, backup, symlinks=True)
+    else:
+        shutil.copy2(source, backup)
+    return backup
+
+
+def migrate_items(
+    items: Iterable[MigrationItem],
+    *,
+    apply: bool = False,
+) -> list[MigrationResult]:
+    """Plan or apply migration items without overwriting any destination."""
+    results: list[MigrationResult] = []
+    for item in items:
+        source = item.source.resolve(strict=False)
+        target = item.target.resolve(strict=False)
+        common = {
+            "source": str(source),
+            "target": str(target),
+            "scope": item.scope,
+        }
+        if source == target:
+            results.append(MigrationResult(**common, status="already_canonical"))
+            continue
+        if not source.exists():
+            results.append(MigrationResult(**common, status="missing"))
+            continue
+        if source.is_symlink():
+            results.append(
+                MigrationResult(
+                    **common,
+                    status="unsupported",
+                    detail="Top-level symbolic links are not migrated",
+                )
+            )
+            continue
+        if target.exists():
+            status = "already_migrated" if _same_content(source, target) else "conflict"
+            results.append(MigrationResult(**common, status=status))
+            continue
+        if not apply:
+            results.append(MigrationResult(**common, status="planned"))
+            continue
+        try:
+            backup = _ensure_backup(source)
+            _copy_absent(source, target)
+        except (OSError, ValueError) as exc:
+            results.append(MigrationResult(**common, status="failed", detail=str(exc)))
+            continue
+        results.append(
+            MigrationResult(
+                **common,
+                status="migrated",
+                backup=str(backup.resolve(strict=False)),
+            )
+        )
+    return results
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user", required=True, help="Owner for legacy private data")
+    parser.add_argument("--runtime-root", type=Path, help="Override the AskRex runtime root")
+    parser.add_argument("--home", type=Path, help="Override the legacy home directory")
+    parser.add_argument("--apply", action="store_true", help="Create backups and copy data")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable results")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    items = default_migration_items(args.user, root=args.runtime_root, home=args.home)
+    results = migrate_items(items, apply=args.apply)
+    if args.json:
+        print(json.dumps([asdict(result) for result in results], indent=2))
+    else:
+        mode = "APPLY" if args.apply else "DRY RUN"
+        print(f"AskRex runtime data migration — {mode}")
+        for result in results:
+            detail = f" ({result.detail})" if result.detail else ""
+            print(f"[{result.status}] {result.source} -> {result.target}{detail}")
+    return (
+        1
+        if any(result.status in {"conflict", "failed", "unsupported"} for result in results)
+        else 0
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_migrate_runtime_data.py
+++ b/tests/test_migrate_runtime_data.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.migrate_runtime_data import (
+    BACKUP_SUFFIX,
+    MigrationItem,
+    default_migration_items,
+    main,
+    migrate_items,
+)
+
+
+def test_dry_run_reports_plan_without_writing(tmp_path: Path) -> None:
+    source = tmp_path / "legacy" / "history.db"
+    target = tmp_path / "runtime" / "data" / "household" / "history.db"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"history")
+
+    results = migrate_items([MigrationItem(source, target, "household")])
+
+    assert [result.status for result in results] == ["planned"]
+    assert not target.exists()
+    assert not source.with_name(source.name + BACKUP_SUFFIX).exists()
+
+
+def test_apply_backs_up_copies_and_is_idempotent(tmp_path: Path) -> None:
+    source = tmp_path / "legacy" / "scheduler"
+    target = tmp_path / "runtime" / "data" / "household" / "scheduler"
+    source.mkdir(parents=True)
+    (source / "jobs.json").write_text('{"jobs": []}', encoding="utf-8")
+    item = MigrationItem(source, target, "household")
+
+    first = migrate_items([item], apply=True)
+    second = migrate_items([item], apply=True)
+
+    backup = source.with_name(source.name + BACKUP_SUFFIX)
+    assert first[0].status == "migrated"
+    assert first[0].backup == str(backup.resolve())
+    assert (target / "jobs.json").read_text(encoding="utf-8") == '{"jobs": []}'
+    assert (backup / "jobs.json").read_text(encoding="utf-8") == '{"jobs": []}'
+    assert source.is_dir()
+    assert second[0].status == "already_migrated"
+
+
+def test_conflict_never_overwrites_target(tmp_path: Path) -> None:
+    source = tmp_path / "legacy.json"
+    target = tmp_path / "canonical.json"
+    source.write_text("legacy", encoding="utf-8")
+    target.write_text("canonical", encoding="utf-8")
+
+    result = migrate_items(
+        [MigrationItem(source, target, "household")],
+        apply=True,
+    )[0]
+
+    assert result.status == "conflict"
+    assert target.read_text(encoding="utf-8") == "canonical"
+    assert not source.with_name(source.name + BACKUP_SUFFIX).exists()
+
+
+def test_existing_backup_conflict_fails_closed(tmp_path: Path) -> None:
+    source = tmp_path / "preferences.json"
+    target = tmp_path / "private" / "preferences.json"
+    backup = source.with_name(source.name + BACKUP_SUFFIX)
+    source.write_text("current", encoding="utf-8")
+    backup.write_text("different", encoding="utf-8")
+
+    result = migrate_items(
+        [MigrationItem(source, target, "private")],
+        apply=True,
+    )[0]
+
+    assert result.status == "failed"
+    assert "Backup conflict" in (result.detail or "")
+    assert not target.exists()
+
+
+def test_default_inventory_separates_private_and_household_data(tmp_path: Path) -> None:
+    root = tmp_path / "runtime"
+    home = tmp_path / "home"
+
+    items = default_migration_items("james", root=root, home=home)
+    pairs = {(item.source, item.target, item.scope) for item in items}
+
+    assert (
+        root / "data" / "users.db",
+        root / "data" / "household" / "users.db",
+        "household",
+    ) in pairs
+    assert (
+        root / "data" / "memory" / "james",
+        root / "data" / "users" / "james" / "memory",
+        "private",
+    ) in pairs
+    assert (
+        home / ".rex" / "preferences.json",
+        root / "data" / "users" / "james" / "autonomy" / "preferences.json",
+        "private",
+    ) in pairs
+
+
+def test_default_inventory_rejects_unsafe_user_id(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        default_migration_items("../other-user", root=tmp_path)
+
+
+def test_cli_defaults_to_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    legacy = tmp_path / "data" / "users.db"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_bytes(b"users")
+
+    exit_code = main(["--user", "james", "--runtime-root", str(tmp_path)])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "DRY RUN" in output
+    assert "[planned]" in output
+    assert not (tmp_path / "data" / "household" / "users.db").exists()

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -8,13 +8,17 @@ from pathlib import Path
 
 import rex.config as app_config
 import rex.config_manager as config_manager
+import rex.runtime_paths as runtime_paths_module
 from rex.runtime_paths import (
     config_path,
     data_dir,
     env_path,
+    household_data_dir,
     memory_dir,
     profiles_dir,
     runtime_root,
+    user_data_dir,
+    users_data_dir,
 )
 
 
@@ -109,3 +113,47 @@ def test_config_load_from_foreign_cwd_writes_only_to_runtime_root(tmp_path: Path
     assert (runtime / "profiles" / "default.json").is_file()
     assert not (unrelated / "config").exists()
     assert not (unrelated / "profiles").exists()
+
+
+def test_legacy_data_override_remains_exact_household_root(monkeypatch, tmp_path: Path) -> None:
+    root = tmp_path / "legacy-data"
+    monkeypatch.setenv("REX_DATA_DIR", str(root))
+    monkeypatch.delenv("ASKREX_HOUSEHOLD_DATA_DIR", raising=False)
+    monkeypatch.delenv("ASKREX_USERS_DATA_DIR", raising=False)
+
+    assert data_dir() == root.resolve()
+    assert household_data_dir() == root.resolve()
+    assert users_data_dir() == (root / "users").resolve()
+    assert user_data_dir("james") == (root / "users" / "james").resolve()
+
+
+def test_explicit_private_and_household_roots_override_legacy_data(
+    monkeypatch, tmp_path: Path
+) -> None:
+    legacy = tmp_path / "legacy"
+    household = tmp_path / "shared"
+    users = tmp_path / "private"
+    monkeypatch.setenv("REX_DATA_DIR", str(legacy))
+    monkeypatch.setenv("ASKREX_HOUSEHOLD_DATA_DIR", str(household))
+    monkeypatch.setenv("ASKREX_USERS_DATA_DIR", str(users))
+
+    assert household_data_dir() == household.resolve()
+    assert users_data_dir() == users.resolve()
+    assert user_data_dir("cole") == (users / "cole").resolve()
+
+
+def test_windows_os_users_receive_distinct_runtime_roots(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("ASKREX_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(runtime_paths_module, "source_checkout_root", lambda start=None: None)
+    monkeypatch.setattr(runtime_paths_module.sys, "platform", "win32")
+
+    first = tmp_path / "windows-user-one"
+    second = tmp_path / "windows-user-two"
+    monkeypatch.setenv("LOCALAPPDATA", str(first))
+    first_root = runtime_root()
+    monkeypatch.setenv("LOCALAPPDATA", str(second))
+    second_root = runtime_root()
+
+    assert first_root == (first / "AskRex").resolve()
+    assert second_root == (second / "AskRex").resolve()
+    assert first_root != second_root


### PR DESCRIPTION
## Summary
- define canonical Windows/platform runtime roots with explicit household and per-user partitions
- pass runtime, household, and users roots to every Electron-managed Python bridge
- migrate memory, history, auth, permissions, notifications, autonomy, contacts, Home Assistant, and mobile persistence callers
- add dry-run-first, backed-up, idempotent legacy data migration with conflict detection
- keep legacy REX_DATA_DIR behavior compatible
- make the Electron streaming verifier deterministic across setup/status routing

## Validation
- 8,109 CI-selected Python tests passed; 110 skipped; 82.49% coverage
- 36 integration tests passed; 2 skipped
- 26 GUI tests passed; typecheck/build passed; lint 0 errors (3 existing warnings)
- Electron streamed-chat verification passed
- Ruff, Black, mypy (363 files), release security audit, generated-artifact guard, and changed-file detect-secrets passed

## External note
- S1 provider-side revocation of the historically exposed mobile token remains an account-owner action and is not part of this PR.