### PR TITLE
feat(security): enforce mobile device capability grants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,5 +617,11 @@ The first two files are the product sources of truth. Other PRDs are supporting 
 - `rex/mobile_api/pairing.py`, `device_proof.py`, and `grants.py` implement the desktop-owned P-256 pairing authority.
 - Password login never creates a device grant. The mobile HTTP API exposes only proof submission and private-token status polling; challenge creation, approval, denial, listing, and revocation remain local Electron IPC operations through `bridge/rex_pairing_bridge.py`.
 - Challenges expire after 120 seconds and are single-use. Proof binds desktop ID, challenge/nonce, canonical public key, user, scopes, and one-time code.
-- Persisted grants are immutable/versioned, expiring, revocable, and audited. S6 must enforce them on every mobile action. S7 must enforce non-loopback TLS and certificate/public-key pinning before production LAN access.
-- See `docs/mobile/DEVICE_PAIRING.md` and `tests/mobile_api/test_pairing.py`.
+- Persisted grants are immutable/versioned, expiring, revocable, and audited.
+- S6 session enforcement lives in `rex/mobile_api/authorization.py`, `auth.py`, and `sessions.py`. Password login is bootstrap-only with zero scopes. Device activation requires a short-lived P-256 proof challenge and atomically replaces/revokes the bootstrap session family.
+- Never authorize from JWT/client-supplied scopes or device metadata. Every request/refresh must resolve the current device, latest grant version, desktop/user binding, scopes, expiry, and revocation from SQLite. Long-lived SSE/WS output must revalidate while streaming.
+- Mobile authorization is the intersection of the immutable device grant and live Rex user permissions. Home scopes require `ha_control` or `admin`; approval responses require `admin`. Permission metadata or capability tags must never widen authority.
+- Device revocation and grant supersession revoke all bound sessions and refresh families. Existing device keys cannot be reassigned across Rex users.
+- Pairing key possession is not strong authentication. Keep `strong_auth_at` null until S8 records a server-verified, challenge-bound assertion; never stamp it during pairing/session activation.
+- S7 must enforce non-loopback TLS and certificate/public-key pinning before production LAN access.
+- See `docs/mobile/DEVICE_PAIRING.md`, `tests/mobile_api/test_pairing.py`, and `tests/mobile_api/test_grant_enforcement.py`.

--- a/docs/mobile/DEVICE_PAIRING.md
+++ b/docs/mobile/DEVICE_PAIRING.md
@@ -19,6 +19,54 @@ AskRex uses a desktop-owned enrollment flow. A username and password can create 
 7. A local desktop user explicitly approves or denies the request.
 8. Approval creates a versioned, expiring grant. The mobile client polls `POST /mobile/pairing/status` with its private poll token.
 
+## S6 device-bound session activation
+
+Password login creates a bootstrap session only. It can call authentication,
+pairing, status, and logout surfaces, but it has an empty capability scope set
+and cannot call chat, voice, Home Assistant, task, or approval actions.
+
+After desktop approval, the mobile client upgrades the bootstrap session:
+
+1. `POST /mobile/auth/device-challenge` requests a 120-second challenge for the
+   approved `device_id` and `grant_id`.
+2. The desktop validates the current device/grant/user/desktop/version from
+   SQLite. Client-supplied scopes are ignored for authorization.
+3. The phone signs the `AskRex-Device-Session-v1` transcript with its paired
+   P-256 private key. The transcript binds the desktop, bootstrap session,
+   challenge/nonce, device, grant/version, and user.
+4. `POST /mobile/auth/activate-device` verifies the proof and atomically creates
+   a new paired session/refresh family, marks the challenge used, and revokes
+   the bootstrap session and its refresh family.
+5. Every authenticated request and refresh resolves the current device and
+   grant from SQLite. A revoked, expired, superseded, cross-user, cross-desktop,
+   partially bound, or malformed grant invalidates the session.
+
+The session endpoint reports only server-derived binding metadata: `paired`,
+`device_id`, `grant_id`, `grant_version`, `desktop_id`, `scopes`, and
+`strong_auth_at`. Pairing proof establishes device-key possession, not user
+strong authentication, so `strong_auth_at` remains `null` until S8 verifies a
+challenge-bound biometric/passcode assertion for a specific high-risk action.
+
+## Capability enforcement
+
+The centralized server-side route map currently enforces:
+
+- HTTP chat, SSE chat, and WebSocket chat: `chat.send`
+- voice upload and TTS playback: `voice.use`
+- reserved mappings for Home Assistant, tasks, and approval actions use
+  `home.read`, `home.control`, `tasks.read`, `tasks.write`, and
+  `approvals.respond` as those mobile routes are enabled.
+
+Device scopes are an additional restriction, not a replacement for Rex user
+permissions. Home scopes also require the live `ha_control` or `admin` user
+permission, and `approvals.respond` requires `admin`. Permission changes are
+revalidated while long-running actions stream.
+
+SSE and WebSocket sessions revalidate authorization while streaming, before
+emitting each subsequent chunk. Device revocation or grant replacement revokes
+bound sessions and refresh tokens, so access stops without waiting for JWT
+expiry.
+
 ## Security properties
 
 - Challenges expire after 120 seconds and are single-use.
@@ -28,15 +76,24 @@ AskRex uses a desktop-owned enrollment flow. A username and password can create 
 - Challenge creation, approval, denial, device listing, and revocation are not exposed through the mobile HTTP API. They are available only through the local Electron IPC bridge.
 - Renderer-facing failures are fixed messages; bridge stderr, filesystem paths, database details, and exception text are not returned.
 - Grants are immutable and versioned. Scope changes require a new grant version rather than mutation of an existing row.
-- Device revocation revokes its active grants and is audited.
+- Device revocation revokes its active grants, bound sessions, and refresh
+  families atomically and is audited.
+- A new grant version supersedes and revokes sessions bound to older versions.
+- A paired public key/device identity cannot be reassigned to another Rex user.
 
 ## Current boundary
 
-S5 establishes the pairing authority and persists device/grant state. S6 must enforce those grants on every mobile action request. S7 must enforce the supported encrypted LAN transport and certificate/public-key pinning. Until S6 and S7 are complete, pairing is not a claim that non-loopback production mobile access is fully authorized or transport-hardened.
+S5 establishes the pairing authority and S6 enforces device-bound grants on
+mobile sessions and action transports. S7 must still enforce supported encrypted
+LAN transport and certificate/public-key pinning. Until S7 is complete,
+non-loopback production mobile access is not transport-hardened.
 
 ## Mobile endpoints
 
 - `POST /mobile/pairing/submit`
 - `POST /mobile/pairing/status`
+- `POST /mobile/auth/device-challenge` (authenticated bootstrap session)
+- `POST /mobile/auth/activate-device` (authenticated bootstrap session)
 
-There is intentionally no mobile endpoint for creating or approving a challenge.
+There is intentionally no mobile endpoint for creating or approving the initial
+pairing enrollment challenge.

--- a/rex/actions/dispatcher.py
+++ b/rex/actions/dispatcher.py
@@ -170,8 +170,18 @@ class ActionDispatcher:
             )
         effective_user = validate_user_id(effective_user)
 
+        from rex.mobile_api.action_context import (  # noqa: PLC0415
+            mobile_action_context_active,
+            mobile_scope_granted,
+            run_in_executor_with_mobile_context,
+        )
+
         # 1. Skill training: intercept natural-language skill creation before LLM
-        if self._skill_trainer is not None and self._skill_registry is not None:
+        if (
+            self._skill_trainer is not None
+            and self._skill_registry is not None
+            and not mobile_action_context_active()
+        ):
             training_response = self._skill_trainer.handle_if_training_request(
                 transcript, self._skill_registry
             )
@@ -183,7 +193,7 @@ class ActionDispatcher:
                 )
 
         # 2. Skill invocation: check registered skill triggers before the LLM
-        if self._skill_router is not None:
+        if self._skill_router is not None and not mobile_action_context_active():
             matched_skill = self._skill_router.match(transcript)
             if matched_skill is not None:
                 skill_response = str(self._skill_router.execute(matched_skill, transcript))
@@ -194,7 +204,7 @@ class ActionDispatcher:
                 )
 
         # 3. Shopping list voice commands
-        if self._shopping_list_handler is not None:
+        if self._shopping_list_handler is not None and mobile_scope_granted("tasks.write"):
             _sl_response = self._shopping_list_handler.handle(transcript, user_id=effective_user)
             if _sl_response is not None:
                 return ActionResult(
@@ -204,7 +214,7 @@ class ActionDispatcher:
                 )
 
         # 4. Music Assistant voice commands
-        if self._music_handler is not None:
+        if self._music_handler is not None and mobile_scope_granted("home.control"):
             _music_response = self._music_handler.handle(transcript)
             if _music_response is not None:
                 return ActionResult(
@@ -214,7 +224,7 @@ class ActionDispatcher:
                 )
 
         # 5. Device state queries
-        if self._device_state_handler is not None:
+        if self._device_state_handler is not None and mobile_scope_granted("home.read"):
             _ds_response = self._device_state_handler.handle(transcript)
             if _ds_response is not None:
                 return ActionResult(
@@ -228,8 +238,8 @@ class ActionDispatcher:
         if self._tool_dispatcher is not None:
             _selected_tools = self._tool_dispatcher.select_tools(transcript)
             if _selected_tools:
-                _tool_results = await _loop.run_in_executor(
-                    None,
+                _tool_results = await run_in_executor_with_mobile_context(
+                    _loop,
                     functools.partial(
                         self._tool_dispatcher.execute_tools,
                         _selected_tools,
@@ -242,16 +252,20 @@ class ActionDispatcher:
         completion: str | None = None
 
         # 7. HA command routing (including undo and proactive suggestion injection)
-        if self._ha_bridge is not None and self._ha_bridge.enabled:
+        if (
+            self._ha_bridge is not None
+            and self._ha_bridge.enabled
+            and mobile_scope_granted("home.control")
+        ):
             if _UNDO_PATTERN.match(transcript):
-                completion = await _loop.run_in_executor(
-                    None,
+                completion = await run_in_executor_with_mobile_context(
+                    _loop,
                     self._ha_bridge.undo_last,
                 )
             else:
                 _hist_len_before = len(getattr(self._ha_bridge, "_command_history", None) or [])
-                completion = await _loop.run_in_executor(
-                    None,
+                completion = await run_in_executor_with_mobile_context(
+                    _loop,
                     self._ha_bridge.process_transcript,
                     transcript,
                 )
@@ -303,19 +317,19 @@ class ActionDispatcher:
             messages = ctx.messages
             prompt = ctx.prompt
             try:
-                completion = await _loop.run_in_executor(
-                    None,
+                completion = await run_in_executor_with_mobile_context(
+                    _loop,
                     lambda: self._llm.generate(messages=messages),
                 )
             except TypeError:
-                completion = await _loop.run_in_executor(
-                    None,
+                completion = await run_in_executor_with_mobile_context(
+                    _loop,
                     lambda: self._llm.generate(prompt),
                 )
 
             # 9. Post-process LLM output (TOOL_REQUEST resolution, OpenClaw bridge)
             plugin_enrichments: list[str] = []
-            if self._run_plugins_fn is not None:
+            if self._run_plugins_fn is not None and not mobile_action_context_active():
                 plugin_enrichments = await self._run_plugins_fn(transcript)
 
             tool_context_dict: dict = (

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -559,7 +559,13 @@ class Assistant:
     async def _post_process_completion(
         self, transcript: str, completion: str, *, user_id: str | None = None
     ) -> str:
-        plugin_enrichments = await self._run_plugins(transcript)
+        from rex.mobile_api.action_context import (  # noqa: PLC0415
+            mobile_action_context_active,
+        )
+
+        plugin_enrichments = (
+            [] if mobile_action_context_active() else await self._run_plugins(transcript)
+        )
         return await self._result_handler.process(
             transcript,
             completion,
@@ -631,6 +637,10 @@ class Assistant:
     ) -> AsyncIterator[str]:
         loop = asyncio.get_running_loop()
         completion: str | None = None
+        from rex.mobile_api.action_context import (  # noqa: PLC0415
+            mobile_scope_granted,
+            run_in_executor_with_mobile_context,
+        )
 
         # Resolve and validate the request identity before any private state
         # (intent shortcuts, history, cues) is touched (issue #303).
@@ -644,9 +654,9 @@ class Assistant:
             yield _intent.response
             return
 
-        if self._ha_bridge and self._ha_bridge.enabled:
-            completion = await loop.run_in_executor(
-                None,
+        if self._ha_bridge and self._ha_bridge.enabled and mobile_scope_granted("home.control"):
+            completion = await run_in_executor_with_mobile_context(
+                loop,
                 self._ha_bridge.process_transcript,
                 transcript,
             )
@@ -666,8 +676,8 @@ class Assistant:
         try:
             token_iterator = self._stream_model_reply(prompt, messages)
         except NotImplementedError:
-            completion = await loop.run_in_executor(
-                None, self._generate_model_reply, prompt, messages
+            completion = await run_in_executor_with_mobile_context(
+                loop, self._generate_model_reply, prompt, messages
             )
             completion = await self._post_process_completion(
                 transcript, completion, user_id=effective_user_id

--- a/rex/llm_client.py
+++ b/rex/llm_client.py
@@ -715,12 +715,20 @@ class LanguageModel:
         if function_name not in self._tool_functions:
             return f"Error: Unknown function {function_name}"
 
+        from rex.mobile_api.action_context import (  # noqa: PLC0415
+            MobileActionDeniedError,
+            authorize_mobile_tool,
+        )
+
+        authorize_mobile_tool(function_name)
         try:
             result = self._tool_functions[function_name](**function_args)
             return str(result) if result is not None else "No results found"
+        except MobileActionDeniedError:
+            raise
         except Exception as e:
-            logger.error(f"Tool execution failed: {e}")
-            return f"Error executing {function_name}: {str(e)}"
+            logger.error("Tool execution failed: %s", type(e).__name__)
+            return f"Error executing {function_name}"
 
     def _format_messages(self, messages: Sequence[dict[str, str]]) -> str:
         return "\n".join(

--- a/rex/local_tool_executor.py
+++ b/rex/local_tool_executor.py
@@ -264,6 +264,22 @@ def execute_tool(tool_name: str, args: dict[str, Any] | None = None) -> str:
     if tool_name not in EXECUTABLE_TOOLS:
         raise UnknownToolError(tool_name)
 
+    from rex.mobile_api.action_context import authorize_mobile_tool  # noqa: PLC0415
+
+    authorize_mobile_tool(
+        tool_name,
+        operation=(
+            "mutation"
+            if tool_name
+            in {
+                "send_email",
+                "calendar_create_event",
+                "home_assistant_call_service",
+            }
+            else "read"
+        ),
+    )
+
     from rex.tools.execution import ToolExecutionLifecycle
     from rex.tools.registry import Tool
 

--- a/rex/mobile_api/action_context.py
+++ b/rex/mobile_api/action_context.py
@@ -1,0 +1,182 @@
+"""Per-request mobile capability context for action/tool dispatch (S6).
+
+Desktop, CLI, and local voice calls run without this context and retain their
+existing policy model.  Mobile chat/voice requests install a server-derived
+scope set plus a live session revalidation callback.  Every lower action
+layer can then fail closed without trusting prompt text, JWT claims, or tool
+arguments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+
+class MobileActionDeniedError(PermissionError):
+    """A mobile device grant does not authorize an action."""
+
+
+@dataclass(frozen=True)
+class MobileActionContext:
+    scopes: frozenset[str]
+    permissions: frozenset[str]
+    revalidate: Callable[[], None] | None = None
+
+
+_CONTEXT: contextvars.ContextVar[MobileActionContext | None] = contextvars.ContextVar(
+    "askrex_mobile_action_context", default=None
+)
+
+
+@contextmanager
+def mobile_action_context(
+    scopes: frozenset[str] | set[str] | tuple[str, ...] | list[str],
+    *,
+    permissions: frozenset[str] | set[str] | tuple[str, ...] | list[str] = frozenset(),
+    revalidate: Callable[[], None] | None = None,
+) -> Iterator[None]:
+    token = _CONTEXT.set(MobileActionContext(frozenset(scopes), frozenset(permissions), revalidate))
+    try:
+        yield
+    finally:
+        _CONTEXT.reset(token)
+
+
+def current_mobile_action_context() -> MobileActionContext | None:
+    return _CONTEXT.get()
+
+
+def mobile_action_context_active() -> bool:
+    return _CONTEXT.get() is not None
+
+
+def mobile_scope_granted(scope: str) -> bool:
+    """Return whether the current mobile grant has *scope*.
+
+    Non-mobile callers return True.  A live revalidation callback still runs
+    before the answer so revocation cannot be hidden by a stale context.
+    """
+    context = _CONTEXT.get()
+    if context is None:
+        return True
+    if context.revalidate is not None:
+        context.revalidate()
+    from rex.mobile_api.authorization import require_scope  # noqa: PLC0415
+
+    try:
+        require_scope(context.scopes, scope, permissions=context.permissions)
+    except ValueError:
+        return False
+    return True
+
+
+def authorize_mobile_action(required_scope: str | None, action_name: str) -> None:
+    """Authorize one lower-layer action when called from a mobile request.
+
+    ``None`` means the action is intentionally unmapped and therefore denied
+    for mobile callers.  Non-mobile callers have no context and are unchanged.
+    """
+    context = _CONTEXT.get()
+    if context is None:
+        return
+    if context.revalidate is not None:
+        context.revalidate()
+    if required_scope is None:
+        raise MobileActionDeniedError(
+            f"The paired device is not authorized for action {action_name!r}."
+        )
+    from rex.mobile_api.authorization import require_scope  # noqa: PLC0415
+
+    try:
+        require_scope(
+            context.scopes,
+            required_scope,
+            permissions=context.permissions,
+        )
+    except ValueError as exc:
+        raise MobileActionDeniedError(
+            f"The user and paired device are not authorized for action {action_name!r}."
+        ) from exc
+
+
+def required_scope_for_tool(
+    tool_name: str,
+    *,
+    capability_tags: tuple[str, ...] | list[str] | None = None,
+    operation: str | None = None,
+) -> str | None:
+    """Map a known canonical tool to a mobile grant scope.
+
+    Authorization is intentionally name-based and fail-closed.  Capability
+    tags are descriptive metadata, not an authority source: a future plugin
+    cannot gain mobile access merely by choosing a trusted-looking tag or
+    name fragment.  New tools require an explicit entry and tests here.
+    """
+    del capability_tags  # Metadata must never widen authority.
+    name = tool_name.strip().lower()
+    normalized_operation = operation.strip().lower() if isinstance(operation, str) else None
+
+    read_only_chat = {"time_now", "weather_now", "web_search"}
+    if name in read_only_chat:
+        return "chat.send" if normalized_operation in {None, "read", "query"} else None
+
+    home_mutations = {
+        "home_assistant_call_service",
+        "music_play",
+        "music_pause",
+        "music_resume",
+        "music_skip",
+        "music_volume",
+    }
+    if name in home_mutations:
+        return "home.control" if normalized_operation in {None, "mutation", "write"} else None
+
+    # Email, calendar, SMS, shell, filesystem, diagnostics, dynamic OpenClaw
+    # tools, and every future tool are unavailable to mobile until a deliberate
+    # scope mapping and enforcement test are added.
+    return None
+
+
+def authorize_mobile_tool(
+    tool_name: str,
+    *,
+    capability_tags: tuple[str, ...] | list[str] | None = None,
+    operation: str | None = None,
+) -> None:
+    authorize_mobile_action(
+        required_scope_for_tool(
+            tool_name,
+            capability_tags=capability_tags,
+            operation=operation,
+        ),
+        f"tool:{tool_name}",
+    )
+
+
+async def run_in_executor_with_mobile_context(
+    loop: asyncio.AbstractEventLoop,
+    func: Callable[..., Any],
+    *args: Any,
+) -> Any:
+    """Run a blocking call while preserving the current mobile context."""
+    copied = contextvars.copy_context()
+    return await loop.run_in_executor(None, copied.run, func, *args)
+
+
+__all__ = [
+    "MobileActionContext",
+    "MobileActionDeniedError",
+    "authorize_mobile_action",
+    "authorize_mobile_tool",
+    "current_mobile_action_context",
+    "mobile_action_context",
+    "mobile_action_context_active",
+    "mobile_scope_granted",
+    "required_scope_for_tool",
+    "run_in_executor_with_mobile_context",
+]

--- a/rex/mobile_api/auth.py
+++ b/rex/mobile_api/auth.py
@@ -80,6 +80,16 @@ class MobilePrincipal:
     display_name: str
     role: str
     permissions: frozenset[str]
+    paired_device_id: str | None = None
+    grant_id: str | None = None
+    desktop_id: str | None = None
+    grant_version: int | None = None
+    scopes: frozenset[str] = frozenset()
+    strong_auth_at: str | None = None
+
+    @property
+    def paired(self) -> bool:
+        return self.paired_device_id is not None
 
 
 def issue_access_token(
@@ -138,59 +148,26 @@ def _bearer_token_from_request() -> str:
     return parts[1].strip()
 
 
-def authenticate_request(
-    services: MobileApiServices, *, allow_revoked_session: bool = False
+def _load_principal_for_session(
+    services: MobileApiServices,
+    *,
+    user_id: str,
+    session_id: str,
+    allow_revoked_session: bool = False,
+    touch: bool = True,
 ) -> MobilePrincipal:
-    """Authenticate the current Flask request and return its principal.
+    """Resolve identity and current grant state from server-side storage."""
+    from rex.mobile_api.authorization import (  # noqa: PLC0415
+        GrantAuthorizationError,
+        resolve_session_grant,
+    )
 
-    ``allow_revoked_session`` exists solely so ``POST /mobile/auth/logout``
-    can be idempotent: every JWT check (algorithm, signature, issuer,
-    audience, required claims, nbf, exp), the canonical ``sub`` validation,
-    session existence/ownership, and user status still apply — only the
-    already-revoked-session rejection is skipped, and the session is never
-    reactivated or modified. Every other endpoint must use the default.
-
-    Raises:
-        MobileApiError: On any validation failure (fails closed).
-    """
-    token = _bearer_token_from_request()
-    return authenticate_token(services, token, allow_revoked_session=allow_revoked_session)
-
-
-def authenticate_token(
-    services: MobileApiServices, token: str, *, allow_revoked_session: bool = False
-) -> MobilePrincipal:
-    """Validate an access token and return the request principal.
-
-    Shared by the HTTP Bearer path and the WebSocket first-frame ``auth``
-    path so both transports apply identical validation: signature/algorithm,
-    issuer, audience, time claims, required claims, canonical ``sub``
-    (before any private lookup), session existence/ownership/status, and
-    user existence/active status.  Fails closed on any mismatch.
-
-    Raises:
-        MobileApiError: On any validation failure.
-    """
-    claims = decode_access_token(token, services.jwt_secret)
-
-    # Canonical identity validation BEFORE any private lookup.
-    try:
-        user_id = validate_user_id(str(claims["sub"]))
-    except ValueError as exc:
-        raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401) from exc
-
-    session_id = str(claims["sid"])
     store = services.session_store
     session = store.get_session(session_id)
     if session is None:
         raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401)
     if session["user_id"] != user_id:
-        # Token subject does not own this session; audit with safe IDs only.
-        logger.warning(
-            "Mobile session/subject mismatch: session=%s jti=%s",
-            session_id,
-            claims.get("jti"),
-        )
+        logger.warning("Mobile session/subject mismatch: session=%s", session_id)
         raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401)
     session_revoked = session["revoked_at"] is not None
     if session_revoked and not allow_revoked_session:
@@ -199,10 +176,20 @@ def authenticate_token(
         raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session has expired.", 401)
 
     conn = connect(services.db_path)
+    grant = None
+    grant_invalid = False
     try:
         user = musers.get_user(conn, user_id)
+        if not session_revoked:
+            try:
+                grant = resolve_session_grant(conn, session, now=store.now())
+            except GrantAuthorizationError:
+                grant_invalid = True
     finally:
         conn.close()
+    if grant_invalid:
+        store.revoke_session(session_id, "device_grant_invalid")
+        raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session is no longer valid.", 401)
     if user is None or not musers.is_user_active(user):
         raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session is no longer valid.", 401)
 
@@ -213,9 +200,9 @@ def authenticate_token(
     if profile and isinstance(profile.get("name"), str) and profile["name"].strip():
         display_name = profile["name"].strip()
 
-    # Never modify an already-revoked session (logout-only path).
-    if not session_revoked:
+    if touch and not session_revoked:
         store.touch_session(session_id)
+    scopes = frozenset(grant.scopes) if grant is not None else frozenset()
     return MobilePrincipal(
         user_id=user_id,
         session_id=session_id,
@@ -223,15 +210,119 @@ def authenticate_token(
         display_name=display_name,
         role=musers.role_projection(permissions),
         permissions=permissions,
+        paired_device_id=grant.device_id if grant is not None else None,
+        grant_id=grant.grant_id if grant is not None else None,
+        desktop_id=grant.desktop_id if grant is not None else None,
+        grant_version=grant.version if grant is not None else None,
+        scopes=scopes,
+        strong_auth_at=str(session["strong_auth_at"]) if session["strong_auth_at"] else None,
     )
 
 
-def require_mobile_auth(view: Any = None, *, allow_revoked_session: bool = False) -> Any:
-    """Decorator: authenticate the request and attach ``g.mobile_principal``.
+def _require_scope(principal: MobilePrincipal, required_scope: str | None) -> None:
+    if required_scope is None:
+        return
+    from rex.mobile_api.authorization import (  # noqa: PLC0415
+        GrantAuthorizationError,
+        require_scope,
+    )
 
-    ``allow_revoked_session=True`` is reserved for the idempotent logout
-    endpoint only (see :func:`authenticate_request`).
-    """
+    try:
+        require_scope(
+            principal.scopes,
+            required_scope,
+            permissions=principal.permissions,
+        )
+    except GrantAuthorizationError as exc:
+        raise MobileApiError(
+            merr.FORBIDDEN,
+            "This user and paired device are not authorized for the requested capability.",
+            403,
+        ) from exc
+
+
+def authenticate_request(
+    services: MobileApiServices,
+    *,
+    allow_revoked_session: bool = False,
+    required_scope: str | None = None,
+) -> MobilePrincipal:
+    """Authenticate the current Flask request and return its live principal."""
+    token = _bearer_token_from_request()
+    return authenticate_token(
+        services,
+        token,
+        allow_revoked_session=allow_revoked_session,
+        required_scope=required_scope,
+    )
+
+
+def authenticate_token(
+    services: MobileApiServices,
+    token: str,
+    *,
+    allow_revoked_session: bool = False,
+    required_scope: str | None = None,
+) -> MobilePrincipal:
+    """Validate a JWT and resolve current user/session/device/grant state."""
+    claims = decode_access_token(token, services.jwt_secret)
+    try:
+        user_id = validate_user_id(str(claims["sub"]))
+    except ValueError as exc:
+        raise MobileApiError(merr.AUTH_TOKEN_INVALID, "Invalid access token.", 401) from exc
+    principal = _load_principal_for_session(
+        services,
+        user_id=user_id,
+        session_id=str(claims["sid"]),
+        allow_revoked_session=allow_revoked_session,
+    )
+    _require_scope(principal, required_scope)
+    return principal
+
+
+def revalidate_principal(
+    services: MobileApiServices,
+    principal: MobilePrincipal,
+    *,
+    required_scope: str | None = None,
+    touch: bool = False,
+) -> MobilePrincipal:
+    """Revalidate a long-lived SSE/WebSocket principal against current state."""
+    current = _load_principal_for_session(
+        services,
+        user_id=principal.user_id,
+        session_id=principal.session_id,
+        touch=touch,
+    )
+    original_binding = (
+        principal.paired_device_id,
+        principal.grant_id,
+        principal.desktop_id,
+        principal.grant_version,
+    )
+    current_binding = (
+        current.paired_device_id,
+        current.grant_id,
+        current.desktop_id,
+        current.grant_version,
+    )
+    if original_binding != current_binding:
+        services.session_store.revoke_session(principal.session_id, "device_grant_changed")
+        raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session is no longer valid.", 401)
+    if current.permissions != principal.permissions:
+        services.session_store.revoke_session(principal.session_id, "user_permissions_changed")
+        raise MobileApiError(merr.AUTH_SESSION_REVOKED, "Session is no longer valid.", 401)
+    _require_scope(current, required_scope)
+    return current
+
+
+def require_mobile_auth(
+    view: Any = None,
+    *,
+    allow_revoked_session: bool = False,
+    required_scope: str | None = None,
+) -> Any:
+    """Decorator: authenticate and attach ``g.mobile_principal``."""
 
     def decorate(fn: Any) -> Any:
         @wraps(fn)
@@ -240,7 +331,9 @@ def require_mobile_auth(view: Any = None, *, allow_revoked_session: bool = False
 
             services = current_app.extensions["mobile_api_services"]
             g.mobile_principal = authenticate_request(
-                services, allow_revoked_session=allow_revoked_session
+                services,
+                allow_revoked_session=allow_revoked_session,
+                required_scope=required_scope,
             )
             return fn(*args, **kwargs)
 
@@ -263,5 +356,6 @@ __all__ = [
     "decode_access_token",
     "issue_access_token",
     "load_jwt_secret",
+    "revalidate_principal",
     "require_mobile_auth",
 ]

--- a/rex/mobile_api/authorization.py
+++ b/rex/mobile_api/authorization.py
@@ -1,0 +1,200 @@
+"""Server-side mobile device grant authorization (S6).
+
+All capability scopes are loaded from the current SQLite device/grant rows.
+Client metadata and JWT claims never supply authorization.  A partially
+bound, revoked, expired, superseded, or malformed binding fails closed.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from types import MappingProxyType
+
+from rex.mobile_api.grants import ScopeError, canonicalize_scopes
+
+ROUTE_SCOPES = MappingProxyType(
+    {
+        "chat.send": "chat.send",
+        "chat.stream": "chat.send",
+        "chat.websocket": "chat.send",
+        "voice.upload": "voice.use",
+        "tts.playback": "voice.use",
+        "home.read": "home.read",
+        "home.control": "home.control",
+        "tasks.read": "tasks.read",
+        "tasks.write": "tasks.write",
+        "approvals.respond": "approvals.respond",
+    }
+)
+
+# Device scopes are an additional restriction, never a replacement for Rex's
+# live per-user permissions.  Scopes omitted here are user-owned/non-privileged
+# surfaces and require only an active user plus an active device grant.
+SCOPE_USER_PERMISSIONS = MappingProxyType(
+    {
+        "home.read": frozenset({"ha_control", "admin"}),
+        "home.control": frozenset({"ha_control", "admin"}),
+        "approvals.respond": frozenset({"admin"}),
+    }
+)
+
+
+class GrantAuthorizationError(ValueError):
+    """The persisted device/grant binding is not currently authorized."""
+
+
+@dataclass(frozen=True)
+class ActiveGrant:
+    device_id: str
+    grant_id: str
+    desktop_id: str
+    user_id: str
+    version: int
+    scopes: tuple[str, ...]
+    expires_at: str
+    last_strong_auth_at: str | None
+    public_key_b64: str
+
+
+def _parse_utc(value: object) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise GrantAuthorizationError("Grant expiry is invalid.")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise GrantAuthorizationError("Grant expiry is invalid.") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _canonical_stored_scopes(raw: object) -> tuple[str, ...]:
+    if not isinstance(raw, str):
+        raise GrantAuthorizationError("Grant scopes are invalid.")
+    try:
+        value = json.loads(raw)
+        canonical = canonicalize_scopes(value)
+    except (ValueError, TypeError, ScopeError) as exc:
+        raise GrantAuthorizationError("Grant scopes are invalid.") from exc
+    if list(canonical) != value:
+        raise GrantAuthorizationError("Grant scopes are not canonical.")
+    return canonical
+
+
+def load_active_grant(
+    conn: sqlite3.Connection,
+    *,
+    device_id: str,
+    grant_id: str,
+    expected_user_id: str,
+    now: datetime,
+    expected_desktop_id: str | None = None,
+    expected_version: int | None = None,
+) -> ActiveGrant:
+    """Load and validate one approved device/grant using server-side state."""
+    row = conn.execute(
+        """SELECT
+               d.device_id, d.desktop_id AS device_desktop_id,
+               d.user_id AS device_user_id, d.public_key_b64,
+               d.revoked_at AS device_revoked_at,
+               g.grant_id, g.desktop_id AS grant_desktop_id,
+               g.user_id AS grant_user_id, g.version, g.scopes_json,
+               g.expires_at, g.last_strong_auth_at,
+               g.revoked_at AS grant_revoked_at
+           FROM mobile_paired_devices d
+           JOIN mobile_device_grants g ON g.device_id = d.device_id
+           WHERE d.device_id = ? AND g.grant_id = ?""",
+        (device_id, grant_id),
+    ).fetchone()
+    if row is None:
+        raise GrantAuthorizationError("Device grant is invalid.")
+    if row["device_revoked_at"] is not None or row["grant_revoked_at"] is not None:
+        raise GrantAuthorizationError("Device grant has been revoked.")
+    if row["device_user_id"] != expected_user_id or row["grant_user_id"] != expected_user_id:
+        raise GrantAuthorizationError("Device grant user binding is invalid.")
+    desktop_id = str(row["device_desktop_id"])
+    if row["grant_desktop_id"] != desktop_id:
+        raise GrantAuthorizationError("Device grant desktop binding is invalid.")
+    if expected_desktop_id is not None and desktop_id != expected_desktop_id:
+        raise GrantAuthorizationError("Device grant desktop binding is invalid.")
+    version = int(row["version"])
+    if expected_version is not None and version != expected_version:
+        raise GrantAuthorizationError("Device grant version is invalid.")
+    latest = conn.execute(
+        "SELECT COALESCE(MAX(version), 0) AS version FROM mobile_device_grants WHERE device_id = ?",
+        (device_id,),
+    ).fetchone()
+    if latest is None or int(latest["version"]) != version:
+        raise GrantAuthorizationError("Device grant has been superseded.")
+    if now >= _parse_utc(row["expires_at"]):
+        raise GrantAuthorizationError("Device grant has expired.")
+    scopes = _canonical_stored_scopes(row["scopes_json"])
+    public_key = row["public_key_b64"]
+    if not isinstance(public_key, str) or not public_key:
+        raise GrantAuthorizationError("Device public key is invalid.")
+    return ActiveGrant(
+        device_id=str(row["device_id"]),
+        grant_id=str(row["grant_id"]),
+        desktop_id=desktop_id,
+        user_id=expected_user_id,
+        version=version,
+        scopes=scopes,
+        expires_at=str(row["expires_at"]),
+        last_strong_auth_at=(
+            str(row["last_strong_auth_at"]) if row["last_strong_auth_at"] else None
+        ),
+        public_key_b64=public_key,
+    )
+
+
+def resolve_session_grant(
+    conn: sqlite3.Connection, session: sqlite3.Row, *, now: datetime
+) -> ActiveGrant | None:
+    """Return the active grant for a fully bound session, or None for bootstrap."""
+    fields = (
+        session["paired_device_id"],
+        session["grant_id"],
+        session["grant_version"],
+        session["desktop_id"],
+    )
+    if all(value is None for value in fields):
+        return None
+    if any(value is None for value in fields):
+        raise GrantAuthorizationError("Session grant binding is incomplete.")
+    grant = load_active_grant(
+        conn,
+        device_id=str(session["paired_device_id"]),
+        grant_id=str(session["grant_id"]),
+        expected_user_id=str(session["user_id"]),
+        expected_desktop_id=str(session["desktop_id"]),
+        expected_version=int(session["grant_version"]),
+        now=now,
+    )
+    return grant
+
+
+def require_scope(
+    scopes: frozenset[str] | set[str],
+    required_scope: str,
+    *,
+    permissions: frozenset[str] | set[str] = frozenset(),
+) -> None:
+    if required_scope not in scopes:
+        raise GrantAuthorizationError("Required device capability is not granted.")
+    required_permissions = SCOPE_USER_PERMISSIONS.get(required_scope, frozenset())
+    if required_permissions and not required_permissions.intersection(permissions):
+        raise GrantAuthorizationError("Required user permission is not granted.")
+
+
+__all__ = [
+    "ActiveGrant",
+    "GrantAuthorizationError",
+    "ROUTE_SCOPES",
+    "SCOPE_USER_PERMISSIONS",
+    "load_active_grant",
+    "require_scope",
+    "resolve_session_grant",
+]

--- a/rex/mobile_api/chat.py
+++ b/rex/mobile_api/chat.py
@@ -120,22 +120,59 @@ class MobileChatService:
                     raise _backend_unavailable(exc) from exc
         return self._assistant
 
-    def generate(self, message: str, *, user_id: str, voice_mode: bool = False) -> str:
-        """Return one complete reply for ``user_id`` via the canonical Assistant."""
+    def generate(
+        self,
+        message: str,
+        *,
+        user_id: str,
+        voice_mode: bool = False,
+        capability_scopes: frozenset[str] | None = None,
+        capability_permissions: frozenset[str] | None = None,
+        authorization_check: Callable[[], None] | None = None,
+    ) -> str:
+        """Return one complete reply under the server-derived mobile grant."""
+        from rex.mobile_api.action_context import (  # noqa: PLC0415
+            MobileActionDeniedError,
+            mobile_action_context,
+        )
+
         assistant = self._get_assistant()
         try:
-            return str(
-                asyncio.run(
-                    assistant.generate_reply(message, voice_mode=voice_mode, active_user_id=user_id)
+            with mobile_action_context(
+                capability_scopes or frozenset(),
+                permissions=capability_permissions or frozenset(),
+                revalidate=authorization_check,
+            ):
+                return str(
+                    asyncio.run(
+                        assistant.generate_reply(
+                            message,
+                            voice_mode=voice_mode,
+                            active_user_id=user_id,
+                        )
+                    )
                 )
-            )
         except MobileApiError:
             raise
+        except MobileActionDeniedError as exc:
+            raise MobileApiError(
+                "FORBIDDEN",
+                "This paired device is not authorized for the requested action.",
+                403,
+            ) from exc
         except Exception as exc:
-            logger.error("Mobile chat generate_reply failed: %s", exc)
+            logger.error("Mobile chat generate_reply failed: %s", type(exc).__name__)
             raise _backend_unavailable(exc) from exc
 
-    def stream(self, message: str, *, user_id: str) -> Iterator[str]:
+    def stream(
+        self,
+        message: str,
+        *,
+        user_id: str,
+        capability_scopes: frozenset[str] | None = None,
+        capability_permissions: frozenset[str] | None = None,
+        authorization_check: Callable[[], None] | None = None,
+    ) -> Iterator[str]:
         """Yield reply chunks for ``user_id`` via ``Assistant.stream_reply()``.
 
         Bridges the async generator onto a private event loop owned by the
@@ -143,29 +180,48 @@ class MobileChatService:
         structured ``BACKEND_UNAVAILABLE`` error for the transport to emit
         as a terminal error event.
         """
+        from rex.mobile_api.action_context import (  # noqa: PLC0415
+            MobileActionDeniedError,
+            mobile_action_context,
+        )
+
         assistant = self._get_assistant()
         loop = asyncio.new_event_loop()
         agen = None
         try:
-            agen = assistant.stream_reply(message, active_user_id=user_id)
-            while True:
-                try:
-                    chunk = loop.run_until_complete(agen.__anext__())
-                except StopAsyncIteration:
-                    break
-                except MobileApiError:
-                    raise
-                except Exception as exc:
-                    logger.error("Mobile chat stream_reply failed: %s", exc)
-                    raise _backend_unavailable(exc) from exc
-                if chunk:
-                    yield str(chunk)
+            with mobile_action_context(
+                capability_scopes or frozenset(),
+                permissions=capability_permissions or frozenset(),
+                revalidate=authorization_check,
+            ):
+                agen = assistant.stream_reply(message, active_user_id=user_id)
+                while True:
+                    try:
+                        chunk = loop.run_until_complete(agen.__anext__())
+                    except StopAsyncIteration:
+                        break
+                    except MobileApiError:
+                        raise
+                    except MobileActionDeniedError as exc:
+                        raise MobileApiError(
+                            "FORBIDDEN",
+                            "This paired device is not authorized for the requested action.",
+                            403,
+                        ) from exc
+                    except Exception as exc:
+                        logger.error(
+                            "Mobile chat stream_reply failed: %s",
+                            type(exc).__name__,
+                        )
+                        raise _backend_unavailable(exc) from exc
+                    if chunk:
+                        yield str(chunk)
         finally:
             if agen is not None:
                 try:
                     loop.run_until_complete(agen.aclose())
                 except Exception:  # pragma: no cover - close-time cleanup
-                    logger.debug("Mobile chat stream close failed", exc_info=True)
+                    logger.debug("Mobile chat stream close failed")
             loop.close()
 
 

--- a/rex/mobile_api/db.py
+++ b/rex/mobile_api/db.py
@@ -88,6 +88,11 @@ def migrate_users_db(db_path: Path | str) -> None:
                 device_name TEXT NOT NULL DEFAULT '',
                 platform TEXT NOT NULL DEFAULT '',
                 app_version TEXT NOT NULL DEFAULT '',
+                paired_device_id TEXT NULL,
+                grant_id TEXT NULL,
+                grant_version INTEGER NULL,
+                desktop_id TEXT NULL,
+                strong_auth_at TEXT NULL,
                 created_at TEXT NOT NULL,
                 last_seen_at TEXT NOT NULL,
                 expires_at TEXT NOT NULL,
@@ -96,9 +101,25 @@ def migrate_users_db(db_path: Path | str) -> None:
                 FOREIGN KEY (user_id) REFERENCES users(id)
             )
             """)
+        session_columns = _table_columns(conn, "mobile_sessions")
+        session_migrations = {
+            "paired_device_id": "TEXT NULL",
+            "grant_id": "TEXT NULL",
+            "grant_version": "INTEGER NULL",
+            "desktop_id": "TEXT NULL",
+            "strong_auth_at": "TEXT NULL",
+        }
+        for column, definition in session_migrations.items():
+            if column not in session_columns:
+                conn.execute(f"ALTER TABLE mobile_sessions ADD COLUMN {column} {definition}")
+                logger.info("users.db migration: added mobile_sessions.%s", column)
         conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_mobile_sessions_user
             ON mobile_sessions(user_id, revoked_at)
+            """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_mobile_sessions_grant
+            ON mobile_sessions(paired_device_id, grant_id, revoked_at)
             """)
         conn.execute("""
             CREATE TABLE IF NOT EXISTS mobile_refresh_tokens (
@@ -212,12 +233,43 @@ def migrate_users_db(db_path: Path | str) -> None:
                 scopes_json TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 expires_at TEXT NOT NULL,
+                last_strong_auth_at TEXT NULL,
                 revoked_at TEXT NULL,
                 revoke_reason TEXT NULL,
                 UNIQUE (device_id, version),
                 FOREIGN KEY (device_id) REFERENCES mobile_paired_devices(device_id),
                 FOREIGN KEY (user_id) REFERENCES users(id)
             )
+            """)
+        grant_columns = _table_columns(conn, "mobile_device_grants")
+        if "last_strong_auth_at" not in grant_columns:
+            conn.execute(
+                "ALTER TABLE mobile_device_grants ADD COLUMN last_strong_auth_at TEXT NULL"
+            )
+            logger.info("users.db migration: added mobile_device_grants.last_strong_auth_at")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS mobile_device_session_challenges (
+                challenge_id TEXT PRIMARY KEY,
+                bootstrap_session_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                device_id TEXT NOT NULL,
+                grant_id TEXT NOT NULL,
+                grant_version INTEGER NOT NULL,
+                desktop_id TEXT NOT NULL,
+                nonce_b64 TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                used_at TEXT NULL,
+                replacement_session_id TEXT NULL,
+                FOREIGN KEY (bootstrap_session_id) REFERENCES mobile_sessions(session_id),
+                FOREIGN KEY (user_id) REFERENCES users(id),
+                FOREIGN KEY (device_id) REFERENCES mobile_paired_devices(device_id),
+                FOREIGN KEY (grant_id) REFERENCES mobile_device_grants(grant_id)
+            )
+            """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_mobile_device_session_challenges_expiry
+            ON mobile_device_session_challenges(expires_at, used_at)
             """)
         conn.execute("""
             CREATE TABLE IF NOT EXISTS mobile_pairing_audit (

--- a/rex/mobile_api/device_proof.py
+++ b/rex/mobile_api/device_proof.py
@@ -33,6 +33,9 @@ from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 PROOF_DOMAIN = b"AskRex-Pairing-Proof-v1"
 TRANSCRIPT_TYPE = "askrex-pairing-proof"
 TRANSCRIPT_VERSION = 1
+SESSION_PROOF_DOMAIN = b"AskRex-Device-Session-v1"
+SESSION_TRANSCRIPT_TYPE = "askrex-device-session-proof"
+SESSION_TRANSCRIPT_VERSION = 1
 
 # Bounded input sizes for untrusted encodings (defense against oversized
 # payloads before any crypto work).  A P-256 SPKI DER is ~120 bytes (~160 b64
@@ -170,6 +173,44 @@ def decode_nonce(nonce_b64: str) -> bytes:
     return _strict_b64decode(nonce_b64, max_length=_MAX_NONCE_B64, label="Nonce")
 
 
+def canonical_session_transcript(
+    *,
+    desktop_id: str,
+    bootstrap_session_id: str,
+    challenge_id: str,
+    nonce_b64: str,
+    device_id: str,
+    grant_id: str,
+    grant_version: int,
+    user_id: str,
+) -> bytes:
+    """Return the signed transcript for upgrading a bootstrap session.
+
+    The server challenge, approved device/grant identity, desktop, user, and
+    bootstrap session are all bound into one domain-separated canonical JSON
+    document.  A proof cannot be replayed for another session or grant.
+    """
+    payload = {
+        "typ": SESSION_TRANSCRIPT_TYPE,
+        "v": SESSION_TRANSCRIPT_VERSION,
+        "desktop_id": desktop_id,
+        "bootstrap_session_id": bootstrap_session_id,
+        "challenge_id": challenge_id,
+        "nonce": nonce_b64,
+        "device_id": device_id,
+        "grant_id": grant_id,
+        "grant_version": grant_version,
+        "user_id": user_id,
+    }
+    body = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return SESSION_PROOF_DOMAIN + b"\n" + body
+
+
 # ---------------------------------------------------------------------------
 # Deterministic signing helpers (used by tests and contract-vector generation).
 # These operate only on caller-supplied private keys; production server code
@@ -214,10 +255,14 @@ def sign_transcript(private_key: ec.EllipticCurvePrivateKey, transcript: bytes) 
 
 __all__ = [
     "PROOF_DOMAIN",
+    "SESSION_PROOF_DOMAIN",
+    "SESSION_TRANSCRIPT_TYPE",
+    "SESSION_TRANSCRIPT_VERSION",
     "TRANSCRIPT_TYPE",
     "TRANSCRIPT_VERSION",
     "ProofError",
     "canonical_public_key_spki_b64",
+    "canonical_session_transcript",
     "canonical_transcript",
     "decode_nonce",
     "generate_p256_private_key",

--- a/rex/mobile_api/pairing.py
+++ b/rex/mobile_api/pairing.py
@@ -339,9 +339,16 @@ class PairingAuthority:
             if row is None or row["status"] != PAIRING_PENDING:
                 raise PairingError("Pairing request is not pending approval.")
             existing = conn.execute(
-                "SELECT device_id FROM mobile_paired_devices WHERE desktop_id = ? AND key_thumbprint = ?",
+                """SELECT device_id, user_id, public_key_b64, revoked_at
+                   FROM mobile_paired_devices
+                   WHERE desktop_id = ? AND key_thumbprint = ?""",
                 (row["desktop_id"], row["key_thumbprint"]),
             ).fetchone()
+            if existing is not None and (
+                existing["user_id"] != row["user_id"]
+                or existing["public_key_b64"] != row["public_key_b64"]
+            ):
+                raise PairingError("Paired device identity cannot be reassigned.")
             device_id = str(existing["device_id"]) if existing else self._id()
             if existing is None:
                 conn.execute(
@@ -360,12 +367,7 @@ class PairingAuthority:
                         now.isoformat(),
                     ),
                 )
-            elif (
-                conn.execute(
-                    "SELECT revoked_at FROM mobile_paired_devices WHERE device_id = ?", (device_id,)
-                ).fetchone()["revoked_at"]
-                is not None
-            ):
+            elif existing["revoked_at"] is not None:
                 raise PairingError("Paired device has been revoked.")
             version_row = conn.execute(
                 "SELECT COALESCE(MAX(version), 0) AS v FROM mobile_device_grants WHERE device_id = ?",
@@ -390,6 +392,20 @@ class PairingAuthority:
                     now.isoformat(),
                     expires.isoformat(),
                 ),
+            )
+            conn.execute(
+                """UPDATE mobile_refresh_tokens SET revoked_at = ?
+                   WHERE revoked_at IS NULL AND session_id IN (
+                       SELECT session_id FROM mobile_sessions
+                       WHERE paired_device_id = ? AND grant_version < ? AND revoked_at IS NULL
+                   )""",
+                (now.isoformat(), device_id, version),
+            )
+            conn.execute(
+                """UPDATE mobile_sessions
+                   SET revoked_at = ?, revoke_reason = ?
+                   WHERE paired_device_id = ? AND grant_version < ? AND revoked_at IS NULL""",
+                (now.isoformat(), "device_grant_superseded", device_id, version),
             )
             conn.execute(
                 """UPDATE mobile_pairing_requests SET status = ?, decision_at = ?,
@@ -504,7 +520,7 @@ class PairingAuthority:
         conn = connect(self._db_path)
         try:
             rows = conn.execute("""SELECT d.*, g.grant_id, g.version, g.scopes_json, g.expires_at,
-                   g.revoked_at AS grant_revoked_at
+                   g.last_strong_auth_at, g.revoked_at AS grant_revoked_at
                    FROM mobile_paired_devices d
                    LEFT JOIN mobile_device_grants g ON g.grant_id = (
                      SELECT grant_id FROM mobile_device_grants x
@@ -524,6 +540,7 @@ class PairingAuthority:
                     "grant_version": row["version"],
                     "scopes": json.loads(row["scopes_json"]) if row["scopes_json"] else [],
                     "grant_expires_at": row["expires_at"],
+                    "last_strong_auth_at": row["last_strong_auth_at"],
                     "grant_revoked_at": row["grant_revoked_at"],
                 }
                 for row in rows
@@ -544,6 +561,19 @@ class PairingAuthority:
             )
             conn.execute(
                 "UPDATE mobile_device_grants SET revoked_at = ?, revoke_reason = ? WHERE device_id = ? AND revoked_at IS NULL",
+                (now, reason[:128], device_id),
+            )
+            conn.execute(
+                """UPDATE mobile_refresh_tokens SET revoked_at = ?
+                   WHERE revoked_at IS NULL AND session_id IN (
+                       SELECT session_id FROM mobile_sessions
+                       WHERE paired_device_id = ? AND revoked_at IS NULL
+                   )""",
+                (now, device_id),
+            )
+            conn.execute(
+                """UPDATE mobile_sessions SET revoked_at = ?, revoke_reason = ?
+                   WHERE paired_device_id = ? AND revoked_at IS NULL""",
                 (now, reason[:128], device_id),
             )
             if cursor.rowcount:

--- a/rex/mobile_api/routes/auth.py
+++ b/rex/mobile_api/routes/auth.py
@@ -27,6 +27,7 @@ from rex.mobile_api.auth import issue_access_token, require_mobile_auth
 from rex.mobile_api.db import connect
 from rex.mobile_api.errors import MobileApiError
 from rex.mobile_api.services import MobileApiServices
+from rex.mobile_api.sessions import DeviceSessionError
 from rex.mobile_api.validation import (
     parse_device_info,
     parse_json_body,
@@ -114,6 +115,66 @@ def build_auth_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint
             created.refresh_expires_at,
         )
 
+    @bp.post("/device-challenge")
+    @limiter.limit(cfg.rate_limit_refresh)
+    @require_mobile_auth
+    def device_challenge() -> Any:
+        principal = g.mobile_principal
+        payload = parse_json_body()
+        if set(payload) != {"device_id", "grant_id"}:
+            raise MobileApiError(merr.BAD_REQUEST, "Device challenge fields are invalid.", 400)
+        device_id = require_string_field(payload, "device_id", max_length=128)
+        grant_id = require_string_field(payload, "grant_id", max_length=128)
+        try:
+            challenge = services.session_store.create_device_session_challenge(
+                bootstrap_session_id=principal.session_id,
+                user_id=principal.user_id,
+                device_id=device_id,
+                grant_id=grant_id,
+            )
+        except DeviceSessionError as exc:
+            raise MobileApiError(merr.PAIRING_INVALID, str(exc), 403) from exc
+        return jsonify(
+            {
+                "challenge_id": challenge.challenge_id,
+                "bootstrap_session_id": challenge.bootstrap_session_id,
+                "user_id": challenge.user_id,
+                "device_id": challenge.device_id,
+                "grant_id": challenge.grant_id,
+                "grant_version": challenge.grant_version,
+                "desktop_id": challenge.desktop_id,
+                "nonce": challenge.nonce_b64,
+                "expires_at": challenge.expires_at.isoformat(),
+            }
+        )
+
+    @bp.post("/activate-device")
+    @limiter.limit(cfg.rate_limit_refresh)
+    @require_mobile_auth
+    def activate_device() -> Any:
+        principal = g.mobile_principal
+        payload = parse_json_body()
+        if set(payload) != {"challenge_id", "signature"}:
+            raise MobileApiError(merr.BAD_REQUEST, "Device activation fields are invalid.", 400)
+        challenge_id = require_string_field(payload, "challenge_id", max_length=128)
+        signature = require_string_field(payload, "signature", max_length=256)
+        try:
+            created = services.session_store.activate_device_session(
+                bootstrap_session_id=principal.session_id,
+                user_id=principal.user_id,
+                challenge_id=challenge_id,
+                signature_b64=signature,
+            )
+        except DeviceSessionError as exc:
+            raise MobileApiError(merr.PAIRING_INVALID, str(exc), 403) from exc
+        return _token_pair_response(
+            created.session_id,
+            created.user_id,
+            principal.username,
+            created.refresh_token,
+            created.refresh_expires_at,
+        )
+
     @bp.post("/refresh")
     @limiter.limit(cfg.rate_limit_refresh)
     def refresh() -> Any:
@@ -180,6 +241,13 @@ def build_auth_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint
         return jsonify(
             {
                 "session_id": principal.session_id,
+                "paired": principal.paired,
+                "device_id": principal.paired_device_id,
+                "grant_id": principal.grant_id,
+                "grant_version": principal.grant_version,
+                "desktop_id": principal.desktop_id,
+                "scopes": sorted(principal.scopes),
+                "strong_auth_at": principal.strong_auth_at,
                 "user": musers.build_user_projection(
                     services.db_path, principal.user_id, principal.username
                 ),

--- a/rex/mobile_api/routes/chat.py
+++ b/rex/mobile_api/routes/chat.py
@@ -32,7 +32,8 @@ from flask import Blueprint, Response, g, jsonify, request
 from rex.mobile_api import errors as merr
 from rex.mobile_api import events as mev
 from rex.mobile_api import idempotency as idem
-from rex.mobile_api.auth import require_mobile_auth
+from rex.mobile_api.auth import require_mobile_auth, revalidate_principal
+from rex.mobile_api.authorization import ROUTE_SCOPES
 from rex.mobile_api.chat import STATUS_COMPLETED
 from rex.mobile_api.errors import MobileApiError
 from rex.mobile_api.services import MobileApiServices
@@ -105,7 +106,7 @@ def build_chat_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint
 
     @bp.post("/chat")
     @limiter.limit(cfg.rate_limit_chat)
-    @require_mobile_auth
+    @require_mobile_auth(required_scope=ROUTE_SCOPES["chat.send"])
     def chat() -> Any:
         principal = g.mobile_principal
         chat_request = _validated_chat_request()
@@ -122,9 +123,25 @@ def build_chat_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint
             stored = json.loads(reservation.response_json or "{}")
             return jsonify(stored), 200
 
+        def authorization_check() -> None:
+            revalidate_principal(
+                services,
+                principal,
+                required_scope=ROUTE_SCOPES["chat.send"],
+            )
+
         try:
             completion = services.chat_service.generate(
-                chat_request.message, user_id=principal.user_id
+                chat_request.message,
+                user_id=principal.user_id,
+                capability_scopes=principal.scopes,
+                capability_permissions=principal.permissions,
+                authorization_check=authorization_check,
+            )
+            revalidate_principal(
+                services,
+                principal,
+                required_scope=ROUTE_SCOPES["chat.send"],
             )
         except MobileApiError as exc:
             services.message_store.fail(principal.user_id, chat_request.message_id, exc.code)
@@ -154,7 +171,7 @@ def build_chat_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint
 
     @bp.post("/chat/stream")
     @limiter.limit(cfg.rate_limit_chat)
-    @require_mobile_auth
+    @require_mobile_auth(required_scope=ROUTE_SCOPES["chat.stream"])
     def chat_stream() -> Any:
         principal = g.mobile_principal
         chat_request = _validated_chat_request()
@@ -184,6 +201,13 @@ def build_chat_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint
         store = services.message_store
         chat_service = services.chat_service
 
+        def authorization_check() -> None:
+            revalidate_principal(
+                services,
+                principal,
+                required_scope=ROUTE_SCOPES["chat.stream"],
+            )
+
         def generate():
             # No Flask request-context access inside the generator: every
             # needed value was captured above.
@@ -191,7 +215,30 @@ def build_chat_blueprint(services: MobileApiServices, limiter: Any) -> Blueprint
             finished = False
             try:
                 try:
-                    for chunk in chat_service.stream(message, user_id=user_id):
+                    iterator = iter(
+                        chat_service.stream(
+                            message,
+                            user_id=user_id,
+                            capability_scopes=principal.scopes,
+                            capability_permissions=principal.permissions,
+                            authorization_check=authorization_check,
+                        )
+                    )
+                    while True:
+                        revalidate_principal(
+                            services,
+                            principal,
+                            required_scope=ROUTE_SCOPES["chat.stream"],
+                        )
+                        try:
+                            chunk = next(iterator)
+                        except StopIteration:
+                            break
+                        revalidate_principal(
+                            services,
+                            principal,
+                            required_scope=ROUTE_SCOPES["chat.stream"],
+                        )
                         collected.append(chunk)
                         yield mev.format_sse(mev.token_event(message_id, chunk))
                 except MobileApiError as exc:

--- a/rex/mobile_api/routes/voice.py
+++ b/rex/mobile_api/routes/voice.py
@@ -32,7 +32,8 @@ from typing import Any
 from flask import Blueprint, g, jsonify, request
 
 from rex.mobile_api import errors as merr
-from rex.mobile_api.auth import require_mobile_auth
+from rex.mobile_api.auth import require_mobile_auth, revalidate_principal
+from rex.mobile_api.authorization import ROUTE_SCOPES
 from rex.mobile_api.chat import STATUS_COMPLETED
 from rex.mobile_api.errors import MobileApiError
 from rex.mobile_api.services import MobileApiServices
@@ -131,6 +132,11 @@ def _handle_voice_upload(services: MobileApiServices) -> Any:
         cfg.max_audio_bytes + 128 * 1024
     ):
         raise MobileApiError(merr.PAYLOAD_TOO_LARGE, "The upload is too large.", 413)
+    revalidate_principal(
+        services,
+        g.mobile_principal,
+        required_scope=ROUTE_SCOPES["voice.upload"],
+    )
     services.stt.require_available()
     data = _validate_upload_form()
     if not data:
@@ -140,8 +146,31 @@ def _handle_voice_upload(services: MobileApiServices) -> Any:
     transcript = _decode_upload(services, data)
     if not transcript:
         raise MobileApiError(merr.INVALID_MEDIA, "No speech was recognized in the audio.", 415)
+    revalidate_principal(
+        services,
+        g.mobile_principal,
+        required_scope=ROUTE_SCOPES["voice.upload"],
+    )
+
+    def authorization_check() -> None:
+        revalidate_principal(
+            services,
+            g.mobile_principal,
+            required_scope=ROUTE_SCOPES["voice.upload"],
+        )
+
     response_text = services.chat_service.generate(
-        transcript, user_id=g.mobile_principal.user_id, voice_mode=True
+        transcript,
+        user_id=g.mobile_principal.user_id,
+        voice_mode=True,
+        capability_scopes=g.mobile_principal.scopes,
+        capability_permissions=g.mobile_principal.permissions,
+        authorization_check=authorization_check,
+    )
+    revalidate_principal(
+        services,
+        g.mobile_principal,
+        required_scope=ROUTE_SCOPES["voice.upload"],
     )
     body: dict[str, Any] = {
         "request_id": getattr(g, "request_id", None),
@@ -171,9 +200,19 @@ def _handle_tts_playback(services: MobileApiServices) -> Any:
     voice = payload.get("voice")
     if voice is not None and not isinstance(voice, str):
         raise MobileApiError(merr.BAD_REQUEST, "Field 'voice' must be a string.", 400)
+    revalidate_principal(
+        services,
+        g.mobile_principal,
+        required_scope=ROUTE_SCOPES["tts.playback"],
+    )
     services.tts.require_available()
     voice_id = services.tts.resolve_voice(voice)
     audio_bytes = services.tts.synthesize(text, voice_id)
+    revalidate_principal(
+        services,
+        g.mobile_principal,
+        required_scope=ROUTE_SCOPES["tts.playback"],
+    )
     return (
         jsonify(
             {
@@ -193,13 +232,13 @@ def build_voice_blueprint(services: MobileApiServices, limiter: Any) -> Blueprin
 
     @bp.post("/voice/upload")
     @limiter.limit(services.config.rate_limit_voice)
-    @require_mobile_auth
+    @require_mobile_auth(required_scope=ROUTE_SCOPES["voice.upload"])
     def voice_upload() -> Any:
         return _handle_voice_upload(services)
 
     @bp.post("/tts/playback")
     @limiter.limit(services.config.rate_limit_voice)
-    @require_mobile_auth
+    @require_mobile_auth(required_scope=ROUTE_SCOPES["tts.playback"])
     def tts_playback() -> Any:
         return _handle_tts_playback(services)
 

--- a/rex/mobile_api/sessions.py
+++ b/rex/mobile_api/sessions.py
@@ -42,6 +42,7 @@ SESSION_REVOKED = "session_revoked"
 USER_INACTIVE = "user_inactive"
 
 _MAX_DEVICE_FIELD_LENGTH = 128
+DEVICE_SESSION_CHALLENGE_TTL_SECONDS = 120
 
 
 def hash_refresh_token(raw_token: str) -> str:
@@ -92,6 +93,25 @@ class RotationResult:
     user_id: str | None = None
     refresh_token: str | None = None
     refresh_expires_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class DeviceSessionChallenge:
+    """Short-lived proof challenge for replacing a bootstrap session."""
+
+    challenge_id: str
+    bootstrap_session_id: str
+    user_id: str
+    device_id: str
+    grant_id: str
+    grant_version: int
+    desktop_id: str
+    nonce_b64: str
+    expires_at: datetime
+
+
+class DeviceSessionError(ValueError):
+    """Stable, secret-free device-session activation failure."""
 
 
 class MobileSessionStore:
@@ -255,6 +275,260 @@ class MobileSessionStore:
             user_id=user_id,
             refresh_token=raw_token,
             refresh_expires_at=expires_at,
+            family_id=family_id,
+        )
+
+    def create_device_session_challenge(
+        self,
+        *,
+        bootstrap_session_id: str,
+        user_id: str,
+        device_id: str,
+        grant_id: str,
+    ) -> DeviceSessionChallenge:
+        """Create a single-use challenge bound to one bootstrap session/grant."""
+        from rex.mobile_api.authorization import (  # noqa: PLC0415
+            GrantAuthorizationError,
+            load_active_grant,
+        )
+
+        user_id = validate_user_id(user_id)
+        if not bootstrap_session_id or len(bootstrap_session_id) > 128:
+            raise DeviceSessionError("Bootstrap session is invalid.")
+        if not device_id or len(device_id) > 128 or not grant_id or len(grant_id) > 128:
+            raise DeviceSessionError("Device grant is invalid.")
+        now = self.now()
+        expires_at = now + timedelta(seconds=DEVICE_SESSION_CHALLENGE_TTL_SECONDS)
+        challenge_id = self._id_generator()
+        nonce_b64 = secrets.token_urlsafe(32)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            session = conn.execute(
+                "SELECT * FROM mobile_sessions WHERE session_id = ?",
+                (bootstrap_session_id,),
+            ).fetchone()
+            if (
+                session is None
+                or session["user_id"] != user_id
+                or not self.session_is_active(session, now)
+                or any(
+                    session[name] is not None
+                    for name in ("paired_device_id", "grant_id", "grant_version", "desktop_id")
+                )
+            ):
+                raise DeviceSessionError("Bootstrap session is not eligible for activation.")
+            try:
+                grant = load_active_grant(
+                    conn,
+                    device_id=device_id,
+                    grant_id=grant_id,
+                    expected_user_id=user_id,
+                    now=now,
+                )
+            except GrantAuthorizationError as exc:
+                raise DeviceSessionError("Device grant is not active.") from exc
+            conn.execute(
+                """INSERT INTO mobile_device_session_challenges(
+                       challenge_id, bootstrap_session_id, user_id, device_id,
+                       grant_id, grant_version, desktop_id, nonce_b64,
+                       created_at, expires_at
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    challenge_id,
+                    bootstrap_session_id,
+                    user_id,
+                    grant.device_id,
+                    grant.grant_id,
+                    grant.version,
+                    grant.desktop_id,
+                    nonce_b64,
+                    now.isoformat(),
+                    expires_at.isoformat(),
+                ),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+        finally:
+            conn.close()
+        return DeviceSessionChallenge(
+            challenge_id=challenge_id,
+            bootstrap_session_id=bootstrap_session_id,
+            user_id=user_id,
+            device_id=grant.device_id,
+            grant_id=grant.grant_id,
+            grant_version=grant.version,
+            desktop_id=grant.desktop_id,
+            nonce_b64=nonce_b64,
+            expires_at=expires_at,
+        )
+
+    def activate_device_session(
+        self,
+        *,
+        bootstrap_session_id: str,
+        user_id: str,
+        challenge_id: str,
+        signature_b64: str,
+    ) -> CreatedSession:
+        """Verify device proof and atomically replace the bootstrap session."""
+        from rex.mobile_api.authorization import (  # noqa: PLC0415
+            GrantAuthorizationError,
+            load_active_grant,
+        )
+        from rex.mobile_api.device_proof import (  # noqa: PLC0415
+            ProofError,
+            canonical_session_transcript,
+            verify_proof,
+        )
+
+        user_id = validate_user_id(user_id)
+        if not challenge_id or len(challenge_id) > 128:
+            raise DeviceSessionError("Device session challenge is invalid or expired.")
+        if not isinstance(signature_b64, str) or not signature_b64:
+            raise DeviceSessionError("Device proof could not be verified.")
+        now = self.now()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            challenge = conn.execute(
+                "SELECT * FROM mobile_device_session_challenges WHERE challenge_id = ?",
+                (challenge_id,),
+            ).fetchone()
+            expires_at = self._parse_ts(challenge["expires_at"]) if challenge is not None else None
+            if (
+                challenge is None
+                or challenge["bootstrap_session_id"] != bootstrap_session_id
+                or challenge["user_id"] != user_id
+                or challenge["used_at"] is not None
+                or expires_at is None
+                or now >= expires_at
+            ):
+                raise DeviceSessionError("Device session challenge is invalid or expired.")
+            bootstrap = conn.execute(
+                "SELECT * FROM mobile_sessions WHERE session_id = ?",
+                (bootstrap_session_id,),
+            ).fetchone()
+            if (
+                bootstrap is None
+                or bootstrap["user_id"] != user_id
+                or not self.session_is_active(bootstrap, now)
+                or any(
+                    bootstrap[name] is not None
+                    for name in ("paired_device_id", "grant_id", "grant_version", "desktop_id")
+                )
+            ):
+                raise DeviceSessionError("Bootstrap session is not eligible for activation.")
+            try:
+                grant = load_active_grant(
+                    conn,
+                    device_id=str(challenge["device_id"]),
+                    grant_id=str(challenge["grant_id"]),
+                    expected_user_id=user_id,
+                    expected_desktop_id=str(challenge["desktop_id"]),
+                    expected_version=int(challenge["grant_version"]),
+                    now=now,
+                )
+                transcript = canonical_session_transcript(
+                    desktop_id=grant.desktop_id,
+                    bootstrap_session_id=bootstrap_session_id,
+                    challenge_id=challenge_id,
+                    nonce_b64=str(challenge["nonce_b64"]),
+                    device_id=grant.device_id,
+                    grant_id=grant.grant_id,
+                    grant_version=grant.version,
+                    user_id=user_id,
+                )
+                verify_proof(
+                    public_key_b64=grant.public_key_b64,
+                    signature_b64=signature_b64,
+                    transcript=transcript,
+                )
+            except (GrantAuthorizationError, ProofError) as exc:
+                raise DeviceSessionError("Device proof could not be verified.") from exc
+
+            new_session_id = self._id_generator()
+            family_id = self._id_generator()
+            raw_token = self._token_generator()
+            refresh_expires_at = now + timedelta(seconds=self._refresh_ttl_seconds)
+            conn.execute(
+                """INSERT INTO mobile_sessions(
+                       session_id, user_id, device_id, device_name, platform,
+                       app_version, paired_device_id, grant_id, grant_version,
+                       desktop_id, strong_auth_at, created_at, last_seen_at, expires_at
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    new_session_id,
+                    user_id,
+                    bootstrap["device_id"],
+                    bootstrap["device_name"],
+                    bootstrap["platform"],
+                    bootstrap["app_version"],
+                    grant.device_id,
+                    grant.grant_id,
+                    grant.version,
+                    grant.desktop_id,
+                    None,
+                    now.isoformat(),
+                    now.isoformat(),
+                    refresh_expires_at.isoformat(),
+                ),
+            )
+            conn.execute(
+                """INSERT INTO mobile_refresh_tokens(
+                       token_hash, family_id, session_id, user_id, created_at, expires_at
+                   ) VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    hash_refresh_token(raw_token),
+                    family_id,
+                    new_session_id,
+                    user_id,
+                    now.isoformat(),
+                    refresh_expires_at.isoformat(),
+                ),
+            )
+            conn.execute(
+                """UPDATE mobile_device_session_challenges
+                   SET used_at = ?, replacement_session_id = ?
+                   WHERE challenge_id = ? AND used_at IS NULL""",
+                (now.isoformat(), new_session_id, challenge_id),
+            )
+            conn.execute(
+                """UPDATE mobile_sessions SET revoked_at = ?, revoke_reason = ?
+                   WHERE session_id = ? AND revoked_at IS NULL""",
+                (now.isoformat(), "device_session_activated", bootstrap_session_id),
+            )
+            conn.execute(
+                """UPDATE mobile_refresh_tokens SET revoked_at = ?
+                   WHERE session_id = ? AND revoked_at IS NULL""",
+                (now.isoformat(), bootstrap_session_id),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+        finally:
+            conn.close()
+        logger.info(
+            "Mobile paired session activated: session=%s user=%s device=%s grant=%s",
+            new_session_id,
+            user_id,
+            grant.device_id,
+            grant.grant_id,
+        )
+        return CreatedSession(
+            session_id=new_session_id,
+            user_id=user_id,
+            refresh_token=raw_token,
+            refresh_expires_at=refresh_expires_at,
             family_id=family_id,
         )
 
@@ -423,11 +697,34 @@ class MobileSessionStore:
             if not self.session_is_active(session, now):
                 conn.execute("COMMIT")
                 return RotationResult(status=SESSION_REVOKED)
+            try:
+                from rex.mobile_api.authorization import (  # noqa: PLC0415
+                    GrantAuthorizationError,
+                    resolve_session_grant,
+                )
+
+                resolve_session_grant(conn, session, now=now)
+            except GrantAuthorizationError:
+                self._revoke_family_locked(
+                    conn,
+                    row["family_id"],
+                    row["session_id"],
+                    now,
+                    "device_grant_invalid",
+                )
+                conn.execute("COMMIT")
+                return RotationResult(status=SESSION_REVOKED)
 
             user = conn.execute("SELECT * FROM users WHERE id = ?", (row["user_id"],)).fetchone()
             user_disabled = user is None or user["disabled_at"] is not None
             if user_disabled:
-                self._revoke_family_locked(conn, row["family_id"], row["session_id"], now)
+                self._revoke_family_locked(
+                    conn,
+                    row["family_id"],
+                    row["session_id"],
+                    now,
+                    "user_inactive",
+                )
                 conn.execute("COMMIT")
                 logger.info(
                     "Mobile refresh rejected for inactive user: session=%s",
@@ -519,7 +816,11 @@ class MobileSessionStore:
 
     @staticmethod
     def _revoke_family_locked(
-        conn: sqlite3.Connection, family_id: str, session_id: str, now: datetime
+        conn: sqlite3.Connection,
+        family_id: str,
+        session_id: str,
+        now: datetime,
+        reason: str = "refresh_token_reuse",
     ) -> None:
         """Revoke a token family and its session inside the caller's transaction."""
         now_iso = now.isoformat()
@@ -537,7 +838,7 @@ class MobileSessionStore:
             SET revoked_at = ?, revoke_reason = ?
             WHERE session_id = ? AND revoked_at IS NULL
             """,
-            (now_iso, "refresh_token_reuse", session_id),
+            (now_iso, reason[:128], session_id),
         )
 
 
@@ -549,6 +850,9 @@ __all__ = [
     "SESSION_REVOKED",
     "USER_INACTIVE",
     "CreatedSession",
+    "DEVICE_SESSION_CHALLENGE_TTL_SECONDS",
+    "DeviceSessionChallenge",
+    "DeviceSessionError",
     "DeviceInfo",
     "MobileSessionStore",
     "RotationResult",

--- a/rex/mobile_api/websocket.py
+++ b/rex/mobile_api/websocket.py
@@ -41,7 +41,8 @@ from typing import Any
 from rex.mobile_api import errors as merr
 from rex.mobile_api import events as mev
 from rex.mobile_api import idempotency as idem
-from rex.mobile_api.auth import MobilePrincipal, authenticate_token
+from rex.mobile_api.auth import MobilePrincipal, authenticate_token, revalidate_principal
+from rex.mobile_api.authorization import ROUTE_SCOPES
 from rex.mobile_api.chat import STATUS_COMPLETED
 from rex.mobile_api.errors import MobileApiError
 from rex.mobile_api.services import MobileApiServices
@@ -61,7 +62,7 @@ CLOSE_RATE_LIMITED = 4429
 
 AUTH_TIMEOUT_SECONDS = 10.0
 IDLE_POLL_SECONDS = 5.0
-SESSION_RECHECK_SECONDS = 30.0
+SESSION_RECHECK_SECONDS = 5.0
 MAX_FRAME_BYTES = 64 * 1024
 CONNECTIONS_PER_MINUTE = 30
 
@@ -186,6 +187,16 @@ class MobileWebSocketServer:
             self._send(ws, mev.auth_error_event(exc.code, exc.message))
             self._close(ws, CLOSE_UNAUTHENTICATED, "Not authenticated")
             return None
+        if ROUTE_SCOPES["chat.websocket"] not in principal.scopes:
+            self._send(
+                ws,
+                mev.auth_error_event(
+                    merr.FORBIDDEN,
+                    "This paired device is not authorized for chat.",
+                ),
+            )
+            self._close(ws, CLOSE_FORBIDDEN, "Capability not granted")
+            return None
 
         from rex.mobile_api import users as musers  # noqa: PLC0415
 
@@ -196,11 +207,15 @@ class MobileWebSocketServer:
         return principal
 
     def _session_active(self, principal: MobilePrincipal) -> bool:
-        store = self._services.session_store
-        session = store.get_session(principal.session_id)
-        if session is None or session["revoked_at"] is not None:
+        try:
+            revalidate_principal(
+                self._services,
+                principal,
+                required_scope=ROUTE_SCOPES["chat.websocket"],
+            )
+            return True
+        except MobileApiError:
             return False
-        return store.session_is_active(session, store.now())
 
     # ── Connection loop ─────────────────────────────────────────────────
 
@@ -270,6 +285,8 @@ class MobileWebSocketServer:
         message_limiter: SlidingWindowLimiter,
     ) -> tuple[bool, bool]:
         frame_type = frame["type"]
+        if not self._require_active_session(ws, principal):
+            return False, False
         if frame_type == "ping":
             self._send(ws, mev.pong_event(self._now_iso()))
             return True, False
@@ -281,8 +298,6 @@ class MobileWebSocketServer:
             return True, False
         if not message_limiter.allow(principal.session_id):
             self._close(ws, CLOSE_RATE_LIMITED, "Message rate limited")
-            return False, False
-        if not self._require_active_session(ws, principal):
             return False, False
         return self._handle_chat_frame(ws, principal, frame), True
 
@@ -364,9 +379,42 @@ class MobileWebSocketServer:
         store = services.message_store
         collected: list[str] = []
         try:
-            for chunk in services.chat_service.stream(
-                chat_request.message, user_id=principal.user_id
-            ):
+
+            def authorization_check() -> None:
+                revalidate_principal(
+                    services,
+                    principal,
+                    required_scope=ROUTE_SCOPES["chat.websocket"],
+                )
+
+            iterator = iter(
+                services.chat_service.stream(
+                    chat_request.message,
+                    user_id=principal.user_id,
+                    capability_scopes=principal.scopes,
+                    capability_permissions=principal.permissions,
+                    authorization_check=authorization_check,
+                )
+            )
+            while True:
+                if not self._require_active_session(ws, principal):
+                    store.fail(
+                        principal.user_id,
+                        chat_request.message_id,
+                        merr.AUTH_SESSION_REVOKED,
+                    )
+                    return False
+                try:
+                    chunk = next(iterator)
+                except StopIteration:
+                    break
+                if not self._require_active_session(ws, principal):
+                    store.fail(
+                        principal.user_id,
+                        chat_request.message_id,
+                        merr.AUTH_SESSION_REVOKED,
+                    )
+                    return False
                 collected.append(chunk)
                 self._send(ws, mev.token_event(chat_request.message_id, chunk))
         except MobileApiError as exc:

--- a/rex/openclaw/tool_executor.py
+++ b/rex/openclaw/tool_executor.py
@@ -192,6 +192,10 @@ def execute_tool(
     if not isinstance(args, dict):
         return _error_result("Invalid tool arguments", tool=tool, args={})
 
+    from rex.mobile_api.action_context import authorize_mobile_action  # noqa: PLC0415
+
+    authorize_mobile_action(None, f"openclaw:{tool}")
+
     if skip_policy_check:
         skip_credential_check = True
 

--- a/rex/tools/dispatcher.py
+++ b/rex/tools/dispatcher.py
@@ -248,6 +248,13 @@ class ToolDispatcher:
         if tool is None:
             return ToolResult(success=False, error=f"Unknown tool: {name!r}")
 
+        from rex.mobile_api.action_context import authorize_mobile_tool  # noqa: PLC0415
+
+        authorize_mobile_tool(
+            tool.name,
+            capability_tags=tool.capability_tags,
+            operation=getattr(tool, "operation", None),
+        )
         available = self._config is None or tool in self._registry.available_tools(self._config)
         return ToolExecutionLifecycle().execute(
             tool,

--- a/rex/tools/result_handler.py
+++ b/rex/tools/result_handler.py
@@ -119,9 +119,13 @@ class ToolResultHandler:
             Cleaned, safe user-facing completion string.
         """
         loop = asyncio.get_running_loop()
+        from rex.mobile_api.action_context import (  # noqa: PLC0415
+            mobile_scope_granted,
+            run_in_executor_with_mobile_context,
+        )
 
-        completion = await loop.run_in_executor(
-            None,
+        completion = await run_in_executor_with_mobile_context(
+            loop,
             self._tool_router_fn,
             completion,
             tool_context,
@@ -131,16 +135,20 @@ class ToolResultHandler:
         if plugin_enrichments:
             completion = f"{completion}\n\nAdditional info:\n" + "\n".join(plugin_enrichments)
 
-        if self._ha_bridge is not None and self._ha_bridge.enabled:
-            completion = await loop.run_in_executor(
-                None,
+        if (
+            self._ha_bridge is not None
+            and self._ha_bridge.enabled
+            and mobile_scope_granted("home.control")
+        ):
+            completion = await run_in_executor_with_mobile_context(
+                loop,
                 self._ha_bridge.post_process_response,
                 completion,
             )
 
         if self._contains_internal_tool_syntax(completion):
-            completion = await loop.run_in_executor(
-                None,
+            completion = await run_in_executor_with_mobile_context(
+                loop,
                 self._sanitize_internal_tool_output,
                 transcript,
                 completion,

--- a/tests/mobile_api/conftest.py
+++ b/tests/mobile_api/conftest.py
@@ -108,13 +108,34 @@ class FakeChatService:
     def _reply(self, message: str, user_id: str) -> str:
         return f"echo[{user_id}]: {message}"
 
-    def generate(self, message: str, *, user_id: str, voice_mode: bool = False) -> str:
+    def generate(
+        self,
+        message: str,
+        *,
+        user_id: str,
+        voice_mode: bool = False,
+        capability_scopes=None,
+        capability_permissions=None,
+        authorization_check=None,
+    ) -> str:
+        if authorization_check is not None:
+            authorization_check()
         if self.fail_with is not None:
             raise self.fail_with
         self.calls.append((message, user_id))
         return self._reply(message, user_id)
 
-    def stream(self, message: str, *, user_id: str):
+    def stream(
+        self,
+        message: str,
+        *,
+        user_id: str,
+        capability_scopes=None,
+        capability_permissions=None,
+        authorization_check=None,
+    ):
+        if authorization_check is not None:
+            authorization_check()
         if self.fail_with is not None:
             raise self.fail_with
         self.calls.append((message, user_id))
@@ -316,6 +337,104 @@ def login(client, username: str, password: str, device: dict | None = None):
 
 def auth_header(access_token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {access_token}"}
+
+
+def paired_login_tokens(
+    client,
+    username: str,
+    password: str,
+    *,
+    scopes: list[str] | None = None,
+) -> dict:
+    """Create a real S5 grant and upgrade a password bootstrap session.
+
+    Tests use the same P-256 pairing and S6 activation transcripts as the
+    production protocol.  The private key remains local to this helper.
+    """
+    from rex.mobile_api.db import connect
+    from rex.mobile_api.device_proof import (
+        canonical_session_transcript,
+        canonical_transcript,
+        generate_p256_private_key,
+        public_key_spki_b64,
+        sign_transcript,
+    )
+
+    services = client.application.extensions["mobile_api_services"]
+    bootstrap = login_tokens(client, username, password)
+    conn = connect(services.db_path)
+    try:
+        user = conn.execute("SELECT id FROM users WHERE username = ?", (username,)).fetchone()
+    finally:
+        conn.close()
+    assert user is not None
+    user_id = str(user["id"])
+    requested_scopes = scopes or ["chat.send", "chat.history.read", "voice.use"]
+    private_key = generate_p256_private_key()
+    public_key = public_key_spki_b64(private_key)
+    challenge = services.pairing_authority.create_challenge(
+        user_id=user_id,
+        scopes=requested_scopes,
+    )
+    transcript = canonical_transcript(
+        desktop_id=challenge.desktop_id,
+        challenge_id=challenge.challenge_id,
+        nonce_b64=challenge.nonce_b64,
+        mobile_public_key_b64=public_key,
+        user_id=challenge.user_id,
+        scopes=challenge.scopes,
+        code=challenge.code,
+    )
+    submitted = services.pairing_authority.submit_proof(
+        {
+            "desktop_id": challenge.desktop_id,
+            "challenge_id": challenge.challenge_id,
+            "nonce": challenge.nonce_b64,
+            "code": challenge.code,
+            "user_id": challenge.user_id,
+            "scopes": list(challenge.scopes),
+            "public_key": public_key,
+            "signature": sign_transcript(private_key, transcript),
+            "device_name": "Test iPhone",
+            "platform": "ios",
+        }
+    )
+    grant = services.pairing_authority.approve(
+        submitted.request_id,
+        approved_by="TEST\\DesktopOwner",
+    )
+    challenge_response = client.post(
+        "/mobile/auth/device-challenge",
+        json={"device_id": grant.device_id, "grant_id": grant.grant_id},
+        headers=auth_header(bootstrap["access_token"]),
+    )
+    assert challenge_response.status_code == 200, challenge_response.get_json()
+    activation = challenge_response.get_json()
+    activation_transcript = canonical_session_transcript(
+        desktop_id=activation["desktop_id"],
+        bootstrap_session_id=activation["bootstrap_session_id"],
+        challenge_id=activation["challenge_id"],
+        nonce_b64=activation["nonce"],
+        device_id=activation["device_id"],
+        grant_id=activation["grant_id"],
+        grant_version=activation["grant_version"],
+        user_id=activation["user_id"],
+    )
+    response = client.post(
+        "/mobile/auth/activate-device",
+        json={
+            "challenge_id": activation["challenge_id"],
+            "signature": sign_transcript(private_key, activation_transcript),
+        },
+        headers=auth_header(bootstrap["access_token"]),
+    )
+    assert response.status_code == 200, response.get_json()
+    tokens = response.get_json()
+    tokens["_paired_device_id"] = grant.device_id
+    tokens["_grant_id"] = grant.grant_id
+    tokens["_private_key"] = private_key
+    tokens["_bootstrap"] = bootstrap
+    return tokens
 
 
 def login_tokens(client, username: str, password: str) -> dict:

--- a/tests/mobile_api/contract_vectors.json
+++ b/tests/mobile_api/contract_vectors.json
@@ -1,9 +1,15 @@
 {
-  "contract_version": "2026-07-15.323.2",
+  "contract_version": "2026-08-01.323.3",
   "api_version": "1.0",
   "statuses": {
     "normal_chat": "completed",
-    "action_statuses": ["attempted", "completed", "verified", "failed", "needs_confirmation"]
+    "action_statuses": [
+      "attempted",
+      "completed",
+      "verified",
+      "failed",
+      "needs_confirmation"
+    ]
   },
   "http": {
     "login_request": {
@@ -27,7 +33,9 @@
         "id": "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         "name": "James",
         "role": "owner",
-        "permissions": ["admin"],
+        "permissions": [
+          "admin"
+        ],
         "color": "#2D7FF9"
       }
     },
@@ -45,17 +53,28 @@
         "id": "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         "name": "James",
         "role": "owner",
-        "permissions": ["admin"],
+        "permissions": [
+          "admin"
+        ],
         "color": "#2D7FF9"
       }
     },
     "session_response": {
       "session_id": "0d9c3a52-6f4e-4e91-8b7c-2f81f3f0a222",
+      "paired": false,
+      "device_id": null,
+      "grant_id": null,
+      "grant_version": null,
+      "desktop_id": null,
+      "scopes": [],
+      "strong_auth_at": null,
       "user": {
         "id": "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         "name": "James",
         "role": "owner",
-        "permissions": ["admin"],
+        "permissions": [
+          "admin"
+        ],
         "color": "#2D7FF9"
       }
     },
@@ -90,7 +109,10 @@
     "sse": {
       "content_type": "text/event-stream",
       "data_prefix": "data: ",
-      "terminal_events": ["message_done", "error"],
+      "terminal_events": [
+        "message_done",
+        "error"
+      ],
       "idempotency_header": "Idempotency-Key"
     },
     "voice_response": {
@@ -149,7 +171,9 @@
         "id": "3d6f2c1e-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         "name": "James",
         "role": "owner",
-        "permissions": ["admin"],
+        "permissions": [
+          "admin"
+        ],
         "color": "#2D7FF9"
       }
     },

--- a/tests/mobile_api/test_action_scope_enforcement.py
+++ b/tests/mobile_api/test_action_scope_enforcement.py
@@ -1,0 +1,234 @@
+"""Lower-layer mobile capability enforcement tests (S6)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from rex.mobile_api.action_context import (
+    MobileActionDeniedError,
+    mobile_action_context,
+)
+from rex.tools.dispatcher import ToolDispatcher
+from rex.tools.registry import Tool, ToolRegistry
+from tests.test_us016_action_dispatcher import (
+    _make_context,
+    _make_dispatcher,
+    _unhandled_intent,
+)
+
+
+def _tool(name: str, tags: list[str], operation: str = "read") -> tuple[Tool, MagicMock]:
+    handler = MagicMock(return_value={"ok": True})
+    return (
+        Tool(
+            name=name,
+            description=name,
+            capability_tags=tags,
+            requires_config=[],
+            handler=handler,
+            operation=operation,
+        ),
+        handler,
+    )
+
+
+def test_tool_dispatcher_allows_safe_chat_tool_with_chat_scope() -> None:
+    tool, handler = _tool("weather_now", ["weather"], "read")
+    registry = ToolRegistry()
+    registry.register(tool)
+    with mobile_action_context(frozenset({"chat.send"})):
+        result = ToolDispatcher(registry).dispatch("weather_now", {}, {})
+    assert result.success is True
+    handler.assert_called_once()
+
+
+def test_tool_dispatcher_denies_home_mutation_without_home_scope() -> None:
+    tool, handler = _tool("home_assistant_call_service", ["smart_home"], "mutation")
+    registry = ToolRegistry()
+    registry.register(tool)
+    with mobile_action_context(frozenset({"chat.send"})):
+        with pytest.raises(MobileActionDeniedError):
+            ToolDispatcher(registry).dispatch("home_assistant_call_service", {}, {})
+    handler.assert_not_called()
+
+
+def test_action_dispatcher_propagates_mobile_context_into_executor_thread() -> None:
+    tool, handler = _tool("home_assistant_call_service", ["smart_home"], "mutation")
+    registry = ToolRegistry()
+    registry.register(tool)
+    dispatcher = _make_dispatcher(tool_dispatcher=ToolDispatcher(registry))
+    with mobile_action_context(frozenset({"chat.send"})):
+        with pytest.raises(MobileActionDeniedError):
+            asyncio.run(
+                dispatcher.dispatch(
+                    _unhandled_intent(),
+                    _make_context(),
+                    "turn on the lights",
+                    user_id="default",
+                )
+            )
+    handler.assert_not_called()
+
+
+def test_direct_ha_bridge_runs_only_with_home_control() -> None:
+    ha = MagicMock()
+    ha.enabled = True
+    ha.process_transcript.return_value = "Lights changed."
+    ha._command_history = None
+    dispatcher = _make_dispatcher(ha_bridge=ha)
+
+    with mobile_action_context(frozenset({"chat.send"})):
+        denied_result = asyncio.run(
+            dispatcher.dispatch(
+                _unhandled_intent(),
+                _make_context(),
+                "turn on the lights",
+                user_id="default",
+            )
+        )
+    assert denied_result.response == "LLM reply"
+    ha.process_transcript.assert_not_called()
+
+    with mobile_action_context(
+        frozenset({"chat.send", "home.control"}),
+        permissions=frozenset({"ha_control"}),
+    ):
+        allowed_result = asyncio.run(
+            dispatcher.dispatch(
+                _unhandled_intent(),
+                _make_context(),
+                "turn on the lights",
+                user_id="default",
+            )
+        )
+    assert allowed_result.response == "Lights changed."
+    ha.process_transcript.assert_called_once_with("turn on the lights")
+
+
+def test_live_revalidation_runs_before_lower_action() -> None:
+    calls: list[str] = []
+    tool, handler = _tool("weather_now", ["weather"], "read")
+    registry = ToolRegistry()
+    registry.register(tool)
+
+    def revoked() -> None:
+        calls.append("checked")
+        raise RuntimeError("revoked")
+
+    with mobile_action_context(frozenset({"chat.send"}), revalidate=revoked):
+        with pytest.raises(RuntimeError, match="revoked"):
+            ToolDispatcher(registry).dispatch("weather_now", {}, {})
+    assert calls == ["checked"]
+    handler.assert_not_called()
+
+
+def test_unmapped_local_tool_is_denied_for_mobile() -> None:
+    from rex.local_tool_executor import execute_tool
+
+    with mobile_action_context(frozenset({"chat.send"})):
+        with pytest.raises(MobileActionDeniedError):
+            execute_tool(
+                "send_email",
+                {"to": "nobody@example.test", "body": "test", "_user_id": "default"},
+            )
+
+
+def test_ha_response_post_processing_requires_home_control_scope() -> None:
+    from rex.tools.result_handler import ToolResultHandler
+
+    ha = MagicMock()
+    ha.enabled = True
+    ha.post_process_response.return_value = "Lights changed."
+    handler = ToolResultHandler(tool_router_fn=lambda completion, *_args: completion, ha_bridge=ha)
+
+    with mobile_action_context(frozenset({"chat.send"})):
+        denied = asyncio.run(
+            handler.process(
+                "turn on the lights",
+                "[[ha:light.turn_on entity_id=light.office]]",
+                tool_context={},
+                model_call_fn=None,
+                plugin_enrichments=[],
+            )
+        )
+    assert denied == "[[ha:light.turn_on entity_id=light.office]]"
+    ha.post_process_response.assert_not_called()
+
+    with mobile_action_context(
+        frozenset({"chat.send", "home.control"}),
+        permissions=frozenset({"ha_control"}),
+    ):
+        allowed = asyncio.run(
+            handler.process(
+                "turn on the lights",
+                "[[ha:light.turn_on entity_id=light.office]]",
+                tool_context={},
+                model_call_fn=None,
+                plugin_enrichments=[],
+            )
+        )
+    assert allowed == "Lights changed."
+    ha.post_process_response.assert_called_once()
+
+
+def test_tool_name_fragment_cannot_invent_task_scope() -> None:
+    tool, handler = _tool("task_exfiltrate", ["untrusted"], "mutation")
+    registry = ToolRegistry()
+    registry.register(tool)
+    with mobile_action_context(frozenset({"tasks.write"})):
+        with pytest.raises(MobileActionDeniedError):
+            ToolDispatcher(registry).dispatch("task_exfiltrate", {}, {})
+    handler.assert_not_called()
+
+
+def test_dynamic_openclaw_tool_is_denied_for_mobile_even_with_chat_scope() -> None:
+    from rex.openclaw.tool_executor import execute_tool
+
+    with mobile_action_context(frozenset({"chat.send"})):
+        with pytest.raises(MobileActionDeniedError):
+            execute_tool(
+                {"tool": "weather_now", "args": {}},
+                {},
+                skip_policy_check=True,
+                skip_audit_log=True,
+            )
+
+
+def test_skill_training_remains_desktop_only_even_with_tasks_write() -> None:
+    trainer = MagicMock()
+    trainer.handle_if_training_request.return_value = "Skill created."
+    registry = MagicMock()
+    dispatcher = _make_dispatcher(skill_trainer=trainer, skill_registry=registry)
+
+    with mobile_action_context(frozenset({"chat.send", "tasks.write"})):
+        result = asyncio.run(
+            dispatcher.dispatch(
+                _unhandled_intent(),
+                _make_context(),
+                "teach Rex a new skill",
+                user_id="default",
+            )
+        )
+    assert result.response == "LLM reply"
+    trainer.handle_if_training_request.assert_not_called()
+
+
+def test_home_scope_alone_cannot_bypass_live_user_permission() -> None:
+    tool, handler = _tool("home_assistant_call_service", ["smart_home"], "mutation")
+    registry = ToolRegistry()
+    registry.register(tool)
+
+    with mobile_action_context(frozenset({"home.control"})):
+        with pytest.raises(MobileActionDeniedError):
+            ToolDispatcher(registry).dispatch("home_assistant_call_service", {}, {})
+    handler.assert_not_called()
+
+    with mobile_action_context(frozenset({"home.control"}), permissions=frozenset({"admin"})):
+        result = ToolDispatcher(registry).dispatch(
+            "home_assistant_call_service", {}, {"user_id": "default"}
+        )
+    assert result.status == "attempted_unverified"
+    handler.assert_called_once()

--- a/tests/mobile_api/test_chat_http.py
+++ b/tests/mobile_api/test_chat_http.py
@@ -13,13 +13,13 @@ from tests.mobile_api.conftest import (
     auth_header,
     chat_payload,
     create_user,
-    login_tokens,
+    paired_login_tokens,
 )
 
 
 def _authed(client, username: str = "james", password: str = "pw-123456") -> tuple[str, dict]:
     user_id = create_user(username, password)
-    tokens = login_tokens(client, username, password)
+    tokens = paired_login_tokens(client, username, password)
     return user_id, auth_header(tokens["access_token"])
 
 

--- a/tests/mobile_api/test_chat_stream.py
+++ b/tests/mobile_api/test_chat_stream.py
@@ -9,14 +9,14 @@ from tests.mobile_api.conftest import (
     auth_header,
     chat_payload,
     create_user,
-    login_tokens,
+    paired_login_tokens,
     parse_sse_events,
 )
 
 
 def _authed(client, username: str = "james", password: str = "pw-123456") -> tuple[str, dict]:
     user_id = create_user(username, password)
-    tokens = login_tokens(client, username, password)
+    tokens = paired_login_tokens(client, username, password)
     return user_id, auth_header(tokens["access_token"])
 
 

--- a/tests/mobile_api/test_chat_websocket.py
+++ b/tests/mobile_api/test_chat_websocket.py
@@ -22,7 +22,7 @@ from rex.mobile_api.websocket import (
     MobileWebSocketServer,
     SlidingWindowLimiter,
 )
-from tests.mobile_api.conftest import chat_payload, create_user, login_tokens
+from tests.mobile_api.conftest import chat_payload, create_user, paired_login_tokens
 
 TIMEOUT = object()
 
@@ -68,7 +68,7 @@ def _chat_frame(message: str = "Hello Rex", **overrides) -> str:
 
 def _login(client, username: str = "james", password: str = "pw-123456") -> tuple[str, str]:
     user_id = create_user(username, password)
-    tokens = login_tokens(client, username, password)
+    tokens = paired_login_tokens(client, username, password)
     return user_id, tokens["access_token"]
 
 
@@ -315,7 +315,7 @@ class TestWsIdempotency:
         ws = _run(services, [_auth_frame(token), json.dumps({"type": "chat", **payload})])
         done = [e for e in ws.sent if e["type"] == "message_done"][0]
 
-        tokens = login_tokens(client, "james", "pw-123456")
+        tokens = paired_login_tokens(client, "james", "pw-123456")
         from tests.mobile_api.conftest import auth_header
 
         response = client.post(

--- a/tests/mobile_api/test_chat_websocket_live.py
+++ b/tests/mobile_api/test_chat_websocket_live.py
@@ -1,4 +1,4 @@
-"""Live loopback WebSocket integration through Flask-Sock/simple-websocket."""
+﻿"""Live loopback WebSocket integration through Flask-Sock/simple-websocket."""
 
 from __future__ import annotations
 
@@ -11,6 +11,13 @@ import requests
 from simple_websocket import Client, ConnectionClosed
 from werkzeug.serving import make_server
 
+from rex.mobile_api.device_proof import (
+    canonical_session_transcript,
+    canonical_transcript,
+    generate_p256_private_key,
+    public_key_spki_b64,
+    sign_transcript,
+)
 from tests.mobile_api.conftest import chat_payload, create_user
 
 
@@ -34,7 +41,7 @@ def live_server(app):
         thread.join(timeout=5)
 
 
-def _login(base_url: str) -> str:
+def _paired_login(base_url: str, services, user_id: str) -> str:
     response = requests.post(
         f"{base_url}/mobile/auth/login",
         json={
@@ -50,7 +57,70 @@ def _login(base_url: str) -> str:
         timeout=5,
     )
     response.raise_for_status()
-    return str(response.json()["access_token"])
+    bootstrap = response.json()
+    private_key = generate_p256_private_key()
+    public_key = public_key_spki_b64(private_key)
+    challenge = services.pairing_authority.create_challenge(
+        user_id=user_id,
+        scopes=["chat.send", "chat.history.read", "voice.use"],
+    )
+    transcript = canonical_transcript(
+        desktop_id=challenge.desktop_id,
+        challenge_id=challenge.challenge_id,
+        nonce_b64=challenge.nonce_b64,
+        mobile_public_key_b64=public_key,
+        user_id=challenge.user_id,
+        scopes=challenge.scopes,
+        code=challenge.code,
+    )
+    submitted = services.pairing_authority.submit_proof(
+        {
+            "desktop_id": challenge.desktop_id,
+            "challenge_id": challenge.challenge_id,
+            "nonce": challenge.nonce_b64,
+            "code": challenge.code,
+            "user_id": challenge.user_id,
+            "scopes": list(challenge.scopes),
+            "public_key": public_key,
+            "signature": sign_transcript(private_key, transcript),
+            "device_name": "Loopback iPhone",
+            "platform": "ios",
+        }
+    )
+    grant = services.pairing_authority.approve(
+        submitted.request_id,
+        approved_by=r"TEST\DesktopOwner",
+    )
+    headers = {"Authorization": f"Bearer {bootstrap['access_token']}"}
+    challenge_response = requests.post(
+        f"{base_url}/mobile/auth/device-challenge",
+        json={"device_id": grant.device_id, "grant_id": grant.grant_id},
+        headers=headers,
+        timeout=5,
+    )
+    challenge_response.raise_for_status()
+    activation = challenge_response.json()
+    activation_transcript = canonical_session_transcript(
+        desktop_id=activation["desktop_id"],
+        bootstrap_session_id=activation["bootstrap_session_id"],
+        challenge_id=activation["challenge_id"],
+        nonce_b64=activation["nonce"],
+        device_id=activation["device_id"],
+        grant_id=activation["grant_id"],
+        grant_version=activation["grant_version"],
+        user_id=activation["user_id"],
+    )
+    activated = requests.post(
+        f"{base_url}/mobile/auth/activate-device",
+        json={
+            "challenge_id": activation["challenge_id"],
+            "signature": sign_transcript(private_key, activation_transcript),
+        },
+        headers=headers,
+        timeout=5,
+    )
+    activated.raise_for_status()
+    return str(activated.json()["access_token"])
 
 
 def _ws_url(base_url: str) -> str:
@@ -62,11 +132,11 @@ def _receive_json(ws: Client, timeout: float = 3) -> dict:
 
 
 def test_live_upgrade_auth_chat_dedupe_close_codes_and_revocation(
-    live_server, fake_chat_service, monkeypatch
+    live_server, services, fake_chat_service, monkeypatch
 ) -> None:
     """Actual upgrade/auth/chat plus HTTP dedupe and security close paths."""
-    create_user("james", "pw-123456")
-    token = _login(live_server)
+    user_id = create_user("james", "pw-123456")
+    token = _paired_login(live_server, services, user_id)
     url = _ws_url(live_server)
     assert "token" not in url.lower()
 
@@ -114,7 +184,7 @@ def test_live_upgrade_auth_chat_dedupe_close_codes_and_revocation(
         timed_out.receive(timeout=3)
     assert int(timeout_close.value.reason) == 4408
 
-    live_token = _login(live_server)
+    live_token = _paired_login(live_server, services, user_id)
     revoked = Client.connect(url)
     revoked.send(json.dumps(_auth_frame(live_token)))
     assert _receive_json(revoked)["type"] == "auth_ok"

--- a/tests/mobile_api/test_contract_vectors.py
+++ b/tests/mobile_api/test_contract_vectors.py
@@ -16,7 +16,13 @@ from pathlib import Path
 
 import pytest
 
-from tests.mobile_api.conftest import auth_header, create_user, login_tokens, parse_sse_events
+from tests.mobile_api.conftest import (
+    auth_header,
+    create_user,
+    login_tokens,
+    paired_login_tokens,
+    parse_sse_events,
+)
 
 VECTORS_PATH = Path(__file__).parent / "contract_vectors.json"
 _SNAKE_CASE = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -156,7 +162,7 @@ class TestLiveResponseConformance:
 
     def test_chat_request_vector_is_accepted_and_response_conforms(self, client, vectors) -> None:
         create_user("james", "pw-123456")
-        tokens = login_tokens(client, "james", "pw-123456")
+        tokens = paired_login_tokens(client, "james", "pw-123456")
         response = client.post(
             "/mobile/chat",
             json=vectors["http"]["chat_request"],
@@ -167,7 +173,7 @@ class TestLiveResponseConformance:
 
     def test_sse_grammar_conforms(self, client, vectors) -> None:
         create_user("james", "pw-123456")
-        tokens = login_tokens(client, "james", "pw-123456")
+        tokens = paired_login_tokens(client, "james", "pw-123456")
         chat_request = dict(vectors["http"]["chat_request"])
         chat_request["message_id"] = "5f8f1f2a-9999-4999-8999-999999999999"
         response = client.post(
@@ -186,7 +192,7 @@ class TestLiveResponseConformance:
         from tests.mobile_api.test_chat_websocket import FakeWs
 
         create_user("james", "pw-123456")
-        tokens = login_tokens(client, "james", "pw-123456")
+        tokens = paired_login_tokens(client, "james", "pw-123456")
         auth_frame = dict(vectors["websocket"]["auth_frame"])
         auth_frame["access_token"] = tokens["access_token"]
         ws = FakeWs([json.dumps(auth_frame), json.dumps(vectors["websocket"]["chat_frame"])])
@@ -200,7 +206,7 @@ class TestLiveResponseConformance:
 
     def test_tts_response_conforms(self, client, vectors) -> None:
         create_user("james", "pw-123456")
-        tokens = login_tokens(client, "james", "pw-123456")
+        tokens = paired_login_tokens(client, "james", "pw-123456")
         response = client.post(
             "/mobile/tts/playback",
             json={"text": vectors["http"]["tts_request"]["text"]},
@@ -215,7 +221,7 @@ class TestLiveResponseConformance:
         import wave
 
         create_user("james", "pw-123456")
-        tokens = login_tokens(client, "james", "pw-123456")
+        tokens = paired_login_tokens(client, "james", "pw-123456")
         buffer = io.BytesIO()
         with wave.open(buffer, "wb") as wav_file:
             wav_file.setnchannels(1)

--- a/tests/mobile_api/test_grant_enforcement.py
+++ b/tests/mobile_api/test_grant_enforcement.py
@@ -1,0 +1,415 @@
+"""Adversarial device-session grant enforcement tests (S6)."""
+
+from __future__ import annotations
+
+import json
+
+from rex.mobile_api.device_proof import (
+    canonical_session_transcript,
+    canonical_transcript,
+    generate_p256_private_key,
+    public_key_spki_b64,
+    sign_transcript,
+)
+from rex.mobile_api.pairing import PairingError
+from rex.mobile_api.websocket import CLOSE_UNAUTHENTICATED, MobileWebSocketServer
+from tests.mobile_api.conftest import (
+    auth_header,
+    chat_payload,
+    create_user,
+    login_tokens,
+    paired_login_tokens,
+    parse_sse_events,
+)
+
+SCOPES = ["chat.send", "chat.history.read", "voice.use"]
+
+
+def _approved_device(services, user_id: str, *, private_key=None, scopes=None):
+    private_key = private_key or generate_p256_private_key()
+    scopes = scopes or SCOPES
+    public_key = public_key_spki_b64(private_key)
+    challenge = services.pairing_authority.create_challenge(user_id=user_id, scopes=scopes)
+    transcript = canonical_transcript(
+        desktop_id=challenge.desktop_id,
+        challenge_id=challenge.challenge_id,
+        nonce_b64=challenge.nonce_b64,
+        mobile_public_key_b64=public_key,
+        user_id=challenge.user_id,
+        scopes=challenge.scopes,
+        code=challenge.code,
+    )
+    submitted = services.pairing_authority.submit_proof(
+        {
+            "desktop_id": challenge.desktop_id,
+            "challenge_id": challenge.challenge_id,
+            "nonce": challenge.nonce_b64,
+            "code": challenge.code,
+            "user_id": challenge.user_id,
+            "scopes": list(challenge.scopes),
+            "public_key": public_key,
+            "signature": sign_transcript(private_key, transcript),
+            "device_name": "Test iPhone",
+            "platform": "ios",
+        }
+    )
+    grant = services.pairing_authority.approve(
+        submitted.request_id, approved_by="TEST\\DesktopOwner"
+    )
+    return private_key, grant
+
+
+def _activation_challenge(client, bootstrap: dict, grant) -> dict:
+    response = client.post(
+        "/mobile/auth/device-challenge",
+        json={"device_id": grant.device_id, "grant_id": grant.grant_id},
+        headers=auth_header(bootstrap["access_token"]),
+    )
+    assert response.status_code == 200, response.get_json()
+    return response.get_json()
+
+
+def _activation_signature(private_key, challenge: dict) -> str:
+    transcript = canonical_session_transcript(
+        desktop_id=challenge["desktop_id"],
+        bootstrap_session_id=challenge["bootstrap_session_id"],
+        challenge_id=challenge["challenge_id"],
+        nonce_b64=challenge["nonce"],
+        device_id=challenge["device_id"],
+        grant_id=challenge["grant_id"],
+        grant_version=challenge["grant_version"],
+        user_id=challenge["user_id"],
+    )
+    return sign_transcript(private_key, transcript)
+
+
+def test_password_session_is_bootstrap_only_and_client_scopes_are_ignored(client, services):
+    create_user("bootstrap-only", "pw-123456")
+    response = client.post(
+        "/mobile/auth/login",
+        json={
+            "username": "bootstrap-only",
+            "password": "pw-123456",  # pragma: allowlist secret
+            "scopes": ["chat.send", "home.control"],
+            "device": {"device_id": "client-claimed-device"},
+        },
+    )
+    assert response.status_code == 200
+    tokens = response.get_json()
+    session = client.get("/mobile/auth/session", headers=auth_header(tokens["access_token"]))
+    assert session.status_code == 200
+    assert session.get_json()["paired"] is False
+    assert session.get_json()["scopes"] == []
+    denied = client.post(
+        "/mobile/chat",
+        json=chat_payload(),
+        headers=auth_header(tokens["access_token"]),
+    )
+    assert denied.status_code == 403
+    assert denied.get_json()["error"]["code"] == "FORBIDDEN"
+
+
+def test_activation_binds_server_grant_and_revokes_bootstrap_family(client, services):
+    user_id = create_user("activate", "pw-123456")
+    bootstrap = login_tokens(client, "activate", "pw-123456")
+    private_key, grant = _approved_device(services, user_id)
+    challenge = _activation_challenge(client, bootstrap, grant)
+    activated = client.post(
+        "/mobile/auth/activate-device",
+        json={
+            "challenge_id": challenge["challenge_id"],
+            "signature": _activation_signature(private_key, challenge),
+        },
+        headers=auth_header(bootstrap["access_token"]),
+    )
+    assert activated.status_code == 200
+    body = activated.get_json()
+    assert body["session_id"] != bootstrap["session_id"]
+    old_access = client.get("/mobile/auth/session", headers=auth_header(bootstrap["access_token"]))
+    assert old_access.status_code == 401
+    old_refresh = client.post(
+        "/mobile/auth/refresh", json={"refresh_token": bootstrap["refresh_token"]}
+    )
+    assert old_refresh.status_code == 401
+    current = client.get(
+        "/mobile/auth/session", headers=auth_header(body["access_token"])
+    ).get_json()
+    assert current["paired"] is True
+    assert current["device_id"] == grant.device_id
+    assert current["grant_id"] == grant.grant_id
+    assert current["grant_version"] == 1
+    assert current["scopes"] == sorted(SCOPES)
+    assert current["strong_auth_at"] is None
+
+
+def test_activation_wrong_key_expiry_and_replay_fail_closed(client, services, clock):
+    user_id = create_user("activation-guards", "pw-123456")
+    bootstrap = login_tokens(client, "activation-guards", "pw-123456")
+    private_key, grant = _approved_device(services, user_id)
+    challenge = _activation_challenge(client, bootstrap, grant)
+    wrong = client.post(
+        "/mobile/auth/activate-device",
+        json={
+            "challenge_id": challenge["challenge_id"],
+            "signature": _activation_signature(generate_p256_private_key(), challenge),
+        },
+        headers=auth_header(bootstrap["access_token"]),
+    )
+    assert wrong.status_code == 403
+    good = client.post(
+        "/mobile/auth/activate-device",
+        json={
+            "challenge_id": challenge["challenge_id"],
+            "signature": _activation_signature(private_key, challenge),
+        },
+        headers=auth_header(bootstrap["access_token"]),
+    )
+    assert good.status_code == 200
+    replay = client.post(
+        "/mobile/auth/activate-device",
+        json={
+            "challenge_id": challenge["challenge_id"],
+            "signature": _activation_signature(private_key, challenge),
+        },
+        headers=auth_header(good.get_json()["access_token"]),
+    )
+    assert replay.status_code == 403
+
+    create_user("activation-expired", "pw-123456")
+    expired_bootstrap = login_tokens(client, "activation-expired", "pw-123456")
+    from rex.mobile_api.db import connect
+
+    conn = connect(services.db_path)
+    try:
+        expired_user = conn.execute(
+            "SELECT id FROM users WHERE username = ?", ("activation-expired",)
+        ).fetchone()["id"]
+    finally:
+        conn.close()
+    expired_key, expired_grant = _approved_device(services, str(expired_user))
+    expired_challenge = _activation_challenge(client, expired_bootstrap, expired_grant)
+    clock.advance(seconds=121)
+    expired = client.post(
+        "/mobile/auth/activate-device",
+        json={
+            "challenge_id": expired_challenge["challenge_id"],
+            "signature": _activation_signature(expired_key, expired_challenge),
+        },
+        headers=auth_header(expired_bootstrap["access_token"]),
+    )
+    assert expired.status_code == 403
+
+
+def test_cross_user_device_grant_cannot_be_claimed(client, services):
+    alice_id = create_user("grant-alice", "pw-123456")
+    create_user("grant-bob", "pw-123456")
+    bob_bootstrap = login_tokens(client, "grant-bob", "pw-123456")
+    _key, alice_grant = _approved_device(services, alice_id)
+    response = client.post(
+        "/mobile/auth/device-challenge",
+        json={"device_id": alice_grant.device_id, "grant_id": alice_grant.grant_id},
+        headers=auth_header(bob_bootstrap["access_token"]),
+    )
+    assert response.status_code == 403
+
+
+def test_device_revoke_immediately_denies_http_and_refresh(client, services):
+    create_user("revoke-live", "pw-123456")
+    tokens = paired_login_tokens(client, "revoke-live", "pw-123456")
+    assert services.pairing_authority.revoke_device(
+        tokens["_paired_device_id"],
+        revoked_by="TEST\\DesktopOwner",
+        reason="owner_revoked",
+    )
+    denied = client.post(
+        "/mobile/chat",
+        json=chat_payload(),
+        headers=auth_header(tokens["access_token"]),
+    )
+    assert denied.status_code == 401
+    refreshed = client.post("/mobile/auth/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert refreshed.status_code == 401
+
+
+def test_existing_device_key_cannot_be_reassigned_to_another_user(client, services):
+    alice_id = create_user("device-owner-alice", "pw-123456")
+    bob_id = create_user("device-owner-bob", "pw-123456")
+    private_key, _grant = _approved_device(services, alice_id)
+    import pytest
+
+    with pytest.raises(PairingError, match="cannot be reassigned"):
+        _approved_device(services, bob_id, private_key=private_key)
+
+
+def test_new_grant_version_revokes_sessions_bound_to_old_version(client, services):
+    create_user("grant-version", "pw-123456")
+    tokens = paired_login_tokens(client, "grant-version", "pw-123456")
+    from rex.mobile_api.db import connect
+
+    conn = connect(services.db_path)
+    try:
+        user_id = str(
+            conn.execute("SELECT id FROM users WHERE username = ?", ("grant-version",)).fetchone()[
+                "id"
+            ]
+        )
+    finally:
+        conn.close()
+    _same_key, replacement = _approved_device(
+        services,
+        user_id,
+        private_key=tokens["_private_key"],
+        scopes=["chat.history.read"],
+    )
+    assert replacement.device_id == tokens["_paired_device_id"]
+    assert replacement.version == 2
+    denied = client.post(
+        "/mobile/chat",
+        json=chat_payload(),
+        headers=auth_header(tokens["access_token"]),
+    )
+    assert denied.status_code == 401
+
+
+def test_sse_stops_before_emitting_chunk_produced_after_revoke(client, services, fake_chat_service):
+    create_user("sse-revoke", "pw-123456")
+    tokens = paired_login_tokens(client, "sse-revoke", "pw-123456")
+
+    def revoking_stream(
+        message: str,
+        *,
+        user_id: str,
+        capability_scopes: frozenset[str],
+        capability_permissions: frozenset[str],
+        authorization_check,
+    ):
+        assert "chat.send" in capability_scopes
+        assert capability_permissions == frozenset()
+        authorization_check()
+        yield "first"
+        services.pairing_authority.revoke_device(
+            tokens["_paired_device_id"],
+            revoked_by="TEST\\DesktopOwner",
+            reason="test_midstream_revoke",
+        )
+        yield "must-not-emit"
+
+    fake_chat_service.stream = revoking_stream
+    response = client.post(
+        "/mobile/chat/stream",
+        json=chat_payload("revoke during stream"),
+        headers=auth_header(tokens["access_token"]),
+    )
+    events = parse_sse_events(response.data)
+    contents = [event.get("content") for event in events if event["type"] == "token"]
+    assert contents == ["first"]
+    assert all("must-not-emit" not in json.dumps(event) for event in events)
+    assert events[-1]["type"] == "error"
+
+
+class _FakeWs:
+    def __init__(self, frames: list[str]) -> None:
+        self.incoming = list(frames)
+        self.sent: list[dict] = []
+        self.closed: tuple[int, str] | None = None
+
+    def receive(self, timeout: float | None = None):
+        if self.closed is not None or not self.incoming:
+            raise RuntimeError("closed")
+        return self.incoming.pop(0)
+
+    def send(self, data: str) -> None:
+        if self.closed is not None:
+            raise RuntimeError("closed")
+        self.sent.append(json.loads(data))
+
+    def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed = (code, reason)
+
+
+def _ws_auth(token: str) -> str:
+    return json.dumps(
+        {
+            "type": "auth",
+            "access_token": token,
+            "client": {"platform": "ios", "app_version": "0.1.0", "device_id": "dev-1"},
+        }
+    )
+
+
+def test_websocket_stops_output_and_closes_after_midstream_revoke(
+    client, services, fake_chat_service
+):
+    create_user("ws-revoke", "pw-123456")
+    tokens = paired_login_tokens(client, "ws-revoke", "pw-123456")
+
+    def revoking_stream(
+        message: str,
+        *,
+        user_id: str,
+        capability_scopes: frozenset[str],
+        capability_permissions: frozenset[str],
+        authorization_check,
+    ):
+        assert "chat.send" in capability_scopes
+        assert capability_permissions == frozenset()
+        authorization_check()
+        yield "first"
+        services.pairing_authority.revoke_device(
+            tokens["_paired_device_id"],
+            revoked_by="TEST\\DesktopOwner",
+            reason="test_ws_revoke",
+        )
+        yield "must-not-emit"
+
+    fake_chat_service.stream = revoking_stream
+    frame = json.dumps({"type": "chat", **chat_payload("ws revoke")})
+    ws = _FakeWs([_ws_auth(tokens["access_token"]), frame])
+    MobileWebSocketServer(services).handle(ws, "10.0.0.1")
+    contents = [event.get("content") for event in ws.sent if event["type"] == "token"]
+    assert contents == ["first"]
+    assert all("must-not-emit" not in json.dumps(event) for event in ws.sent)
+    assert ws.closed is not None
+    assert ws.closed[0] == CLOSE_UNAUTHENTICATED
+
+
+def test_device_scope_is_intersected_with_live_user_permission(client, services):
+    import pytest
+
+    from rex.mobile_api.auth import authenticate_token, revalidate_principal
+    from rex.mobile_api.errors import MobileApiError
+    from rex.permissions import grant_permission, revoke_permission
+
+    user_id = create_user("home-permission", "pw-123456")
+    tokens = paired_login_tokens(
+        client,
+        "home-permission",
+        "pw-123456",
+        scopes=["home.control"],
+    )
+
+    with pytest.raises(MobileApiError) as denied:
+        authenticate_token(
+            services,
+            tokens["access_token"],
+            required_scope="home.control",
+        )
+    assert denied.value.http_status == 403
+
+    grant_permission(user_id, "ha_control")
+    principal = authenticate_token(
+        services,
+        tokens["access_token"],
+        required_scope="home.control",
+    )
+    assert "ha_control" in principal.permissions
+
+    revoke_permission(user_id, "ha_control")
+    with pytest.raises(MobileApiError) as revoked:
+        revalidate_principal(
+            services,
+            principal,
+            required_scope="home.control",
+        )
+    assert revoked.value.http_status == 401
+    assert revoked.value.code == "AUTH_SESSION_REVOKED"

--- a/tests/mobile_api/test_migrations.py
+++ b/tests/mobile_api/test_migrations.py
@@ -26,13 +26,17 @@ def _table_names(db_path: Path) -> set[str]:
     return {row[0] for row in rows}
 
 
-def _user_columns(db_path: Path) -> set[str]:
+def _table_columns(db_path: Path, table: str) -> set[str]:
     conn = sqlite3.connect(str(db_path))
     try:
-        rows = conn.execute("PRAGMA table_info(users)").fetchall()
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
     finally:
         conn.close()
     return {row[1] for row in rows}
+
+
+def _user_columns(db_path: Path) -> set[str]:
+    return _table_columns(db_path, "users")
 
 
 def _make_legacy_db(db_path: Path, username: str, password: str) -> str:
@@ -73,8 +77,13 @@ class TestFreshMigration:
             "user_permissions",
             "mobile_sessions",
             "mobile_refresh_tokens",
+            "mobile_paired_devices",
+            "mobile_device_grants",
+            "mobile_device_session_challenges",
         } <= tables
         assert "disabled_at" in _user_columns(db_path)
+        assert "last_strong_auth_at" in _table_columns(db_path, "mobile_device_grants")
+        assert "last_strong_auth_at" in _table_columns(db_path, "mobile_device_grants")
 
 
 class TestLegacyMigration:

--- a/tests/mobile_api/test_tts.py
+++ b/tests/mobile_api/test_tts.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 import base64
 
-from tests.mobile_api.conftest import auth_header, create_user, login_tokens
+from tests.mobile_api.conftest import auth_header, create_user, paired_login_tokens
 
 
 def _authed(client, username: str = "james", password: str = "pw-123456") -> dict:
     create_user(username, password)
-    tokens = login_tokens(client, username, password)
+    tokens = paired_login_tokens(client, username, password)
     return auth_header(tokens["access_token"])
 
 

--- a/tests/mobile_api/test_voice_upload.py
+++ b/tests/mobile_api/test_voice_upload.py
@@ -11,7 +11,7 @@ import struct
 import wave
 
 from rex.mobile_api.voice import sniff_audio_container
-from tests.mobile_api.conftest import auth_header, create_user, login_tokens
+from tests.mobile_api.conftest import auth_header, create_user, paired_login_tokens
 
 
 def _wav_bytes(seconds: float = 1.0, sample_rate: int = 16_000) -> bytes:
@@ -27,7 +27,7 @@ def _wav_bytes(seconds: float = 1.0, sample_rate: int = 16_000) -> bytes:
 
 def _authed(client, username: str = "james", password: str = "pw-123456") -> tuple[str, dict]:
     user_id = create_user(username, password)
-    tokens = login_tokens(client, username, password)
+    tokens = paired_login_tokens(client, username, password)
     return user_id, auth_header(tokens["access_token"])
 
 


### PR DESCRIPTION
## Summary
- bind mobile sessions to immutable desktop-approved device grants and grant versions
- enforce server-derived scopes across HTTP, SSE, WebSocket, voice, assistant dispatch, tools, inline Home Assistant actions, and thread/executor boundaries
- intersect sensitive device scopes with live Rex user permissions and revoke sessions when grants, devices, or permissions change
- add migration-safe grant/session challenge schema, P-256 device activation, revocation/supersession handling, and audit coverage
- keep pairing proof distinct from S8 strong authentication; `strong_auth_at` remains null
- fail closed for unknown/dynamic/OpenClaw tools and keep skill management desktop-only

## Security properties
- password login is bootstrap-only with zero action scopes
- JWT/client-supplied scope and device metadata are never authorization sources
- Home scopes also require live `ha_control` or `admin`; approval responses require `admin`
- revocation and grant supersession terminate sessions and refresh families
- SSE/WS revalidate while streaming and stop before post-revocation output
- explicit canonical tool mappings only; capability tags and name fragments cannot widen authority

## Validation
- `283 passed` — complete `tests/mobile_api` suite
- `175 passed` — pairing/session/action transport compatibility gate
- `21 passed` — final adversarial grant/action permission gate
- `ruff`, `black --check`, `compileall` — passed across all changed Python files
- CI-equivalent `mypy rex --ignore-missing-imports` — no issues in 371 source files
- `pre-commit run --all-files --show-diff-on-failure` — passed
- `python scripts/security_audit.py --release-gate` — passed; no secrets, merge markers, or actionable incomplete code
- broad repository run: 8,272 passed / 94 skipped; only local failure was the known ignored `coverage.txt` precondition, which the CI coverage job generates