### PR TITLE
fix(security): isolate concurrent strong-auth executions

### DIFF
--- a/rex/mobile_api/action_context.py
+++ b/rex/mobile_api/action_context.py
@@ -38,13 +38,6 @@ class MobileStrongAuthRequiredError(MobileActionDeniedError):
         self.action = action
 
 
-@dataclass
-class MobileAuthorizationState:
-    """Per-request stack preventing duplicate consumption in nested layers."""
-
-    active_actions: list[tuple[str, str]]
-
-
 @dataclass(frozen=True)
 class MobileActionContext:
     scopes: frozenset[str]
@@ -53,11 +46,13 @@ class MobileActionContext:
     strong_auth_authority: Any | None = None
     strong_auth_principal: Any | None = None
     strong_auth_approval_id: str | None = None
-    authorization_state: MobileAuthorizationState | None = None
 
 
 _CONTEXT: contextvars.ContextVar[MobileActionContext | None] = contextvars.ContextVar(
     "askrex_mobile_action_context", default=None
+)
+_AUTHORIZED_ACTIONS: contextvars.ContextVar[tuple[tuple[str, str], ...]] = contextvars.ContextVar(
+    "askrex_mobile_authorized_actions", default=()
 )
 
 
@@ -79,7 +74,6 @@ def mobile_action_context(
             strong_auth_authority=strong_auth_authority,
             strong_auth_principal=strong_auth_principal,
             strong_auth_approval_id=strong_auth_approval_id,
-            authorization_state=MobileAuthorizationState(active_actions=[]),
         )
     )
     try:
@@ -265,8 +259,8 @@ def authorized_mobile_tool(
 
     _, _, action_hash = canonical_action(normalized_name, action_arguments)
     binding = (normalized_name, action_hash)
-    state = context.authorization_state
-    if state is not None and state.active_actions and state.active_actions[-1] == binding:
+    authorized_actions = _AUTHORIZED_ACTIONS.get()
+    if authorized_actions and authorized_actions[-1] == binding:
         yield
         return
 
@@ -296,15 +290,11 @@ def authorized_mobile_tool(
             message="The strong-authentication approval is invalid, expired, or already used.",
         ) from exc
 
-    if state is not None:
-        state.active_actions.append(binding)
+    token = _AUTHORIZED_ACTIONS.set((*authorized_actions, binding))
     try:
         yield
     finally:
-        if state is not None:
-            popped = state.active_actions.pop()
-            if popped != binding:
-                raise RuntimeError("Mobile authorization stack integrity failure.")
+        _AUTHORIZED_ACTIONS.reset(token)
 
 
 def authorize_mobile_tool(

--- a/tests/mobile_api/test_action_scope_enforcement.py
+++ b/tests/mobile_api/test_action_scope_enforcement.py
@@ -295,6 +295,51 @@ def test_one_approval_cannot_execute_same_privileged_action_twice() -> None:
     handler.assert_called_once()
 
 
+def test_concurrent_same_action_cannot_share_one_approval() -> None:
+    authority = MagicMock()
+    authority.consume_approval.side_effect = [
+        None,
+        StrongAuthError("approval_replayed", "used"),
+    ]
+    principal = object()
+    args = {"domain": "light", "service": "turn_off", "entity_id": "light.office"}
+
+    async def scenario() -> None:
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def first_execution() -> None:
+            with authorized_mobile_tool(
+                "home_assistant_call_service",
+                operation="mutation",
+                arguments=args,
+            ):
+                first_entered.set()
+                await release_first.wait()
+
+        with mobile_action_context(
+            frozenset({"home.control"}),
+            permissions=frozenset({"admin"}),
+            strong_auth_authority=authority,
+            strong_auth_principal=principal,
+            strong_auth_approval_id="approval-123",
+        ):
+            first_task = asyncio.create_task(first_execution())
+            await first_entered.wait()
+            with pytest.raises(MobileStrongAuthRequiredError):
+                with authorized_mobile_tool(
+                    "home_assistant_call_service",
+                    operation="mutation",
+                    arguments=args,
+                ):
+                    pass
+            release_first.set()
+            await first_task
+
+    asyncio.run(scenario())
+    assert authority.consume_approval.call_count == 2
+
+
 def test_nested_authorization_layers_consume_one_approval_for_one_execution() -> None:
     tool, handler = _tool("home_assistant_call_service", ["smart_home"], "mutation")
     registry = ToolRegistry()


### PR DESCRIPTION
## Summary
- make the nested strong-auth execution marker task-local instead of sharing a mutable authorization stack across copied async contexts
- ensure two concurrent identical privileged actions independently hit the atomic single-use approval check
- preserve one-time approval consumption across legitimate nested dispatch layers within the same execution
- add a deterministic concurrent same-action regression test

## Security impact
Before this correction, two concurrent identical privileged tool calls in the same copied mobile request context could observe the same shared nested-authorization marker. The second call could therefore mistake the first call's in-progress authorization for its own nested execution. The marker is now held in an immutable task-local `ContextVar` stack, so only genuine nested dispatch inside the same task bypasses duplicate consumption.

## Validation
- `py -3.11 -m pytest tests/mobile_api -q` — 343 passed
- `tests/mobile_api/test_action_scope_enforcement.py` — 16 passed, including the new concurrency regression
- full Ruff — passed
- full Black check — passed
- full repository mypy — passed, 375 source files
- release security audit — passed; zero actionable findings and zero exposed secrets
- pre-commit — passed
- `git diff --check` — passed

## Context
The main S8 implementation landed in PR #339. This PR contains only the independent post-merge concurrency hardening found during the final shipping review.