### PR TITLE
feat(mobile): expose authorized Home Assistant inventory

### DIFF
--- a/rex/mobile_api/routes/home.py
+++ b/rex/mobile_api/routes/home.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import re
 from typing import Any
 
 from flask import Blueprint, g, jsonify
@@ -14,6 +16,22 @@ from rex.mobile_api.services import MobileApiServices
 from rex.mobile_api.strong_auth import StrongAuthError
 from rex.mobile_api.validation import parse_json_body, require_string_field
 from rex.openclaw.tools.ha_tool import ha_call_service
+
+_SUPPORTED_DOMAINS = {
+    "light": "light",
+    "switch": "switch",
+    "input_boolean": "switch",
+    "fan": "switch",
+    "climate": "thermostat",
+    "lock": "lock",
+    "cover": "switch",
+    "scene": "scene",
+    "media_player": "speaker",
+}
+_ACTIVE_STATES = {"on", "open", "opening", "unlocked", "heating", "cooling", "playing"}
+_INACTIVE_STATES = {"off", "closed", "closing", "locked", "idle", "paused", "standby"}
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+logger = logging.getLogger(__name__)
 
 _ACTION_NAME = "home_assistant_call_service"
 _REQUIRED_FIELDS = {"domain", "service", "entity_id", "strong_auth_approval_id"}
@@ -110,8 +128,131 @@ def _http_status_for_result(result: dict[str, Any]) -> int:
     return 500
 
 
+def _load_home_entities() -> tuple[bool, list[dict[str, Any]]]:
+    """Load the household HA entity inventory without exposing credentials."""
+    from rex.config import load_config
+    from rex.ha.discovery import discover_devices, load_ignored_devices
+
+    config = load_config(reload=True)
+    configured = bool(config.ha_base_url and config.ha_token)
+    if not configured:
+        return False, []
+    ignored = set(load_ignored_devices())
+    entities = discover_devices(
+        config.ha_base_url,
+        config.ha_token,
+        verify_ssl=config.ha_verify_ssl,
+        timeout=config.ha_timeout,
+    )
+    return True, [entry for entry in entities if entry.get("entity_id") not in ignored]
+
+
+def _device_type(domain: str, entity_id: str, name: str) -> str | None:
+    mapped = _SUPPORTED_DOMAINS.get(domain)
+    if mapped is None:
+        return None
+    if domain == "cover":
+        if "garage" in f"{entity_id} {name}".lower():
+            return "garage"
+        return None
+    return mapped
+
+
+def _device_state(raw_state: object) -> str:
+    state = str(raw_state or "unknown").strip().lower()
+    if state in _ACTIVE_STATES:
+        return "on"
+    if state in _INACTIVE_STATES:
+        return "off"
+    return "unknown"
+
+
+def _risk_level(device_type: str, entity_id: str, name: str) -> str:
+    if device_type in {"lock", "garage"}:
+        return "high"
+    if device_type == "thermostat" or "camera" in f"{entity_id} {name}".lower():
+        return "medium"
+    return "low"
+
+
+def _room_id(value: object) -> str:
+    raw = str(value or "home").strip().lower()
+    slug = _SLUG_RE.sub("-", raw).strip("-")
+    return slug[:64] or "home"
+
+
+def _project_home_entities(entities: list[dict[str, Any]]) -> dict[str, Any]:
+    devices: list[dict[str, Any]] = []
+    room_counts: dict[str, dict[str, Any]] = {}
+    for entity in entities:
+        entity_id = str(entity.get("entity_id") or "").strip()
+        domain = str(entity.get("domain") or "").strip().lower()
+        name = str(entity.get("friendly_name") or entity_id).strip() or entity_id
+        if not entity_id or not domain or not entity_id.startswith(f"{domain}."):
+            continue
+        device_type = _device_type(domain, entity_id, name)
+        if device_type is None:
+            continue
+        room_name = str(entity.get("area_name") or "Home").strip() or "Home"
+        room = _room_id(room_name)
+        state = _device_state(entity.get("state"))
+        device = {
+            "id": entity_id,
+            "name": name[:160],
+            "type": device_type,
+            "room": room,
+            "state": state,
+            "riskLevel": _risk_level(device_type, entity_id, name),
+        }
+        alias = entity.get("alias")
+        if isinstance(alias, str) and alias.strip():
+            device["alias"] = alias.strip()[:160]
+        devices.append(device)
+        aggregate = room_counts.setdefault(
+            room,
+            {"id": room, "name": room_name[:80], "deviceCount": 0, "activeCount": 0},
+        )
+        aggregate["deviceCount"] += 1
+        if state == "on":
+            aggregate["activeCount"] += 1
+    devices.sort(key=lambda item: (item["room"], item["name"].casefold(), item["id"]))
+    rooms = sorted(room_counts.values(), key=lambda item: (item["name"].casefold(), item["id"]))
+    rooms.insert(
+        0,
+        {
+            "id": "all",
+            "name": "All",
+            "deviceCount": len(devices),
+            "activeCount": sum(1 for item in devices if item["state"] == "on"),
+        },
+    )
+    return {"rooms": rooms, "devices": devices}
+
+
 def build_home_blueprint(services: MobileApiServices) -> Blueprint:
     bp = Blueprint("mobile_home", __name__)
+
+    @bp.get("/mobile/home/entities")
+    @require_mobile_auth(required_scope=ROUTE_SCOPES["home.read"])
+    def entities():
+        principal = g.mobile_principal
+        revalidate_principal(services, principal, required_scope=ROUTE_SCOPES["home.read"])
+        try:
+            configured, raw_entities = _load_home_entities()
+        except Exception as exc:
+            logger.warning(
+                "Mobile Home Assistant inventory fetch failed (%s)",
+                type(exc).__name__,
+            )
+            raise MobileApiError(
+                merr.BACKEND_UNAVAILABLE,
+                "Home Assistant is unavailable.",
+                503,
+                retryable=True,
+            ) from exc
+        revalidate_principal(services, principal, required_scope=ROUTE_SCOPES["home.read"])
+        projection = _project_home_entities(raw_entities)
+        return jsonify({"configured": configured, **projection}), 200
 
     @bp.post("/mobile/home/command")
     @require_mobile_auth(required_scope=ROUTE_SCOPES["home.control"])

--- a/rex/mobile_api/routes/scaffolds.py
+++ b/rex/mobile_api/routes/scaffolds.py
@@ -21,7 +21,6 @@ from rex.mobile_api.services import MobileApiServices
 # streaming, voice, and TTS graduated to real routes in Session 2 and are
 # registered by their own blueprints.
 _SCAFFOLD_ROUTES: tuple[tuple[str, tuple[str, ...], str], ...] = (
-    ("home_entities", ("GET",), "/mobile/home/entities"),
     ("notifications", ("GET",), "/mobile/notifications"),
     ("approvals", ("GET",), "/mobile/approvals"),
     ("tasks", ("GET",), "/mobile/tasks"),

--- a/tests/mobile_api/test_home_entities.py
+++ b/tests/mobile_api/test_home_entities.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tests.mobile_api.conftest import auth_header, create_user, paired_login_tokens
+
+
+def _headers(client, *, admin: bool = True, scopes: list[str] | None = None):
+    create_user("james", "correct-horse", admin=admin)
+    tokens = paired_login_tokens(
+        client,
+        "james",
+        "correct-horse",
+        scopes=scopes or ["home.read"],
+    )
+    return auth_header(tokens["access_token"])
+
+
+def test_home_entities_projects_only_supported_devices(client):
+    headers = _headers(client)
+    raw = [
+        {
+            "entity_id": "light.kitchen",
+            "friendly_name": "Kitchen Lights",
+            "domain": "light",
+            "state": "on",
+            "area_name": "Kitchen",
+        },
+        {
+            "entity_id": "cover.garage_door",
+            "friendly_name": "Garage Door",
+            "domain": "cover",
+            "state": "closed",
+            "area_name": "Garage",
+        },
+        {
+            "entity_id": "climate.downstairs",
+            "friendly_name": "Downstairs Thermostat",
+            "domain": "climate",
+            "state": "heat",
+        },
+        {
+            "entity_id": "cover.living_room_shade",
+            "friendly_name": "Living Room Shade",
+            "domain": "cover",
+            "state": "open",
+        },
+        {
+            "entity_id": "sensor.private_temperature",
+            "friendly_name": "Private Temperature",
+            "domain": "sensor",
+            "state": "72",
+        },
+        {
+            "entity_id": "light.mismatch",
+            "friendly_name": "Invalid",
+            "domain": "switch",
+            "state": "on",
+        },
+    ]
+    with patch("rex.mobile_api.routes.home._load_home_entities", return_value=(True, raw)):
+        response = client.get("/mobile/home/entities", headers=headers)
+    assert response.status_code == 200, response.get_json()
+    body = response.get_json()
+    assert body["configured"] is True
+    assert [device["id"] for device in body["devices"]] == [
+        "cover.garage_door",
+        "climate.downstairs",
+        "light.kitchen",
+    ]
+    by_id = {device["id"]: device for device in body["devices"]}
+    assert by_id["light.kitchen"] == {
+        "id": "light.kitchen",
+        "name": "Kitchen Lights",
+        "type": "light",
+        "room": "kitchen",
+        "state": "on",
+        "riskLevel": "low",
+    }
+    assert by_id["cover.garage_door"]["type"] == "garage"
+    assert by_id["cover.garage_door"]["riskLevel"] == "high"
+    assert by_id["climate.downstairs"]["riskLevel"] == "medium"
+    assert body["rooms"][0] == {
+        "id": "all",
+        "name": "All",
+        "deviceCount": 3,
+        "activeCount": 1,
+    }
+
+
+def test_home_entities_not_configured_is_truthful_and_empty(client):
+    headers = _headers(client)
+    with patch("rex.mobile_api.routes.home._load_home_entities", return_value=(False, [])):
+        response = client.get("/mobile/home/entities", headers=headers)
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "configured": False,
+        "devices": [],
+        "rooms": [
+            {
+                "id": "all",
+                "name": "All",
+                "deviceCount": 0,
+                "activeCount": 0,
+            }
+        ],
+    }
+
+
+def test_home_entities_requires_device_home_read_scope(client):
+    headers = _headers(client, scopes=["chat.send"])
+    response = client.get("/mobile/home/entities", headers=headers)
+    assert response.status_code == 403
+    assert response.get_json()["error"]["code"] == "FORBIDDEN"
+
+
+def test_home_entities_requires_live_user_ha_permission(client):
+    headers = _headers(client, admin=False)
+    response = client.get("/mobile/home/entities", headers=headers)
+    assert response.status_code == 403
+    assert response.get_json()["error"]["code"] == "FORBIDDEN"
+
+
+def test_home_entities_backend_failure_is_retryable_and_secret_free(client):
+    headers = _headers(client)
+    with patch(
+        "rex.mobile_api.routes.home._load_home_entities",
+        side_effect=RuntimeError("Bearer secret-token"),
+    ):
+        response = client.get("/mobile/home/entities", headers=headers)
+    assert response.status_code == 503
+    error = response.get_json()["error"]
+    assert error["code"] == "BACKEND_UNAVAILABLE"
+    assert error["retryable"] is True
+    assert "secret-token" not in error["message"]

--- a/tests/mobile_api/test_scaffolds.py
+++ b/tests/mobile_api/test_scaffolds.py
@@ -12,7 +12,6 @@ from tests.mobile_api.conftest import auth_header, create_user, login_tokens
 # Chat, streaming, voice, TTS, and Home Assistant command execution became
 # real authenticated routes and are covered by their own test modules.
 _SCAFFOLDS = [
-    ("get", "/mobile/home/entities"),
     ("get", "/mobile/notifications"),
     ("get", "/mobile/approvals"),
     ("get", "/mobile/tasks"),


### PR DESCRIPTION
## Summary
- replace the `/mobile/home/entities` 501 scaffold with a real authenticated Home Assistant inventory route
- require the paired device's `home.read` scope plus the user's live `ha_control` or `admin` permission
- revalidate the device grant and user authority before and after the Home Assistant network read
- project only the safe mobile device fields required by the app: ID, name, supported type, room, normalized state, risk level, and optional alias
- remove ignored and unsupported entities rather than exposing raw Home Assistant state payloads
- distinguish truthful not-configured, configured-empty, and temporarily unavailable states

## Security and correctness
- Home Assistant URL, token, attributes, and raw provider errors never reach the mobile response
- backend failures return a generic retryable `BACKEND_UNAVAILABLE` error
- unsupported domains are omitted
- non-garage covers are omitted because the current mobile action contract cannot safely control them; garage covers map to the exact `open_cover`/`close_cover` path
- malformed entity/domain combinations are rejected from the projection
- this is read-only and does not bypass the S8 strong-authentication requirement for mutations

## Validation
- complete `tests/mobile_api` suite: 346 passed
- focused Home/scaffold suites after rebase onto current `master`: 22 passed
- full Ruff: passed
- full Black check: passed, 469 files unchanged
- full repository mypy: clean, 375 source files
- release security audit: passed with zero actionable findings and zero exposed secrets
- `git diff --check`: passed

## Remaining external validation
A live Home Assistant instance is still required to confirm the household's actual entity naming and room metadata. The endpoint fails safely without those credentials and does not claim that external integration test as completed.