### PR TITLE
feat(llm): add secure OpenRouter provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@
 # OpenAI API key — REQUIRED when using the OpenAI provider
 OPENAI_API_KEY=
 
+# OpenRouter API key - REQUIRED when using the OpenRouter provider
+OPENROUTER_API_KEY=
+
 # Anthropic API key — REQUIRED when using the Anthropic/Claude provider
 ANTHROPIC_API_KEY=
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -276,7 +276,7 @@
         "filename": "rex/llm_client.py",
         "hashed_secret": "939bb46a04c3640c8c427e92b1b557e882e2d2a0",
         "is_verified": false,
-        "line_number": 664
+        "line_number": 681
       }
     ],
     "rex/woocommerce/config.py": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ LLM providers:
 
 - local Transformers
 - OpenAI API
+- OpenRouter (OpenAI-compatible API with a separate credential and model slug)
 - Ollama
 
 Search providers:

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -211,7 +211,7 @@ Legacy environment variables are ignored for wake word configuration. Always upd
 ```json
 {
   "models": {
-    "llm_provider": "transformers",    // LLM: transformers, openai, ollama
+    "llm_provider": "transformers",    // LLM: transformers, openai, openrouter, ollama
     "llm_backend": null,               // Alias for llm_provider
     "llm_model": "sshleifer/tiny-gpt2",
     "llm_max_tokens": 120,
@@ -260,7 +260,7 @@ New code should always read settings via the nested path.
 #### `config.llm` — `LLMConfig`
 | Field | Description | Default |
 |-------|-------------|---------|
-| `llm_provider` | LLM backend (`transformers`, `openai`, `ollama`) | `"transformers"` |
+| `llm_provider` | LLM backend (`transformers`, `openai`, `openrouter`, `ollama`) | `"transformers"` |
 | `model_name` | Model name or path | `"sshleifer/tiny-gpt2"` |
 | `openai_api_key_env` | Env var holding OpenAI API key | `"OPENAI_API_KEY"` |
 | `ollama_url` | Ollama server URL | `"http://localhost:11434"` |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -310,7 +310,7 @@ Common fixes:
 
 - Missing FFmpeg: install FFmpeg and reopen the terminal so `PATH` updates.
 - Missing ML dependencies: install `requirements-cpu.txt` or the matching GPU requirements file.
-- OpenAI/Ollama/model failures: check `config/rex_config.json` model settings and `.env` secrets.
+- OpenAI/OpenRouter/Ollama/model failures: check `config/rex_config.json` model settings and the credential-vault status shown in Settings.
 - TTS API startup failure: set `REX_SPEAK_API_KEY`.
 - Tool server 401s: set `REX_TOOL_API_KEY`.
 

--- a/INTEGRATIONS_STATUS.md
+++ b/INTEGRATIONS_STATUS.md
@@ -13,7 +13,7 @@ Credentials alone mean `configured`. They never mean connected, authenticated, w
 | Calendar | Partial / read-only by backend | ICS reads exist. Credentials are configured-only until authenticated. Provider writes and Outlook Graph OAuth are unavailable. |
 | SMS / Phone | Experimental | Twilio paths require complete credentials. Status checks do not claim delivery or calling success; live delivery is externally verified. |
 | Web search | Partial | Provider selection exists. Configuration does not prove current network reachability. |
-| OpenAI / Ollama | Supported provider options | A key or URL is configuration evidence only. Provider availability depends on a live request. |
+| OpenAI / OpenRouter / Ollama | Supported provider options | A key or URL is configuration evidence only. Provider availability depends on a live request. |
 | MQTT / Telegram / Push | Experimental | Visible and configurable, but live broker/provider authentication and delivery are externally verified. |
 | OpenClaw gateway | Experimental and optional | Feature-flagged HTTP client/tool adapters exist. A URL is configured-only evidence; the external gateway is not required by the packaged app. |
 | Browser automation / Windows control | Experimental | Environment-sensitive and permission-gated. Not part of the release-critical end-user path. |

--- a/bridge/rex_setup_bridge.py
+++ b/bridge/rex_setup_bridge.py
@@ -69,6 +69,9 @@ def _handle_complete(payload: dict[str, Any]) -> None:
     if not username or not password:
         sys.stdout.write(json.dumps({"ok": False, "error": "username and password are required"}))
         return
+    if llm_provider not in {"local", "openai", "openrouter", "anthropic", "ollama"}:
+        sys.stdout.write(json.dumps({"ok": False, "error": "unsupported LLM provider"}))
+        return
 
     from rex.auth import _open_db, create_user  # noqa: PLC2701
     from rex.credential_persistence import persist_household_secrets
@@ -81,6 +84,7 @@ def _handle_complete(payload: dict[str, Any]) -> None:
         if llm_api_key:
             logical_name = {
                 "openai": "OPENAI_API_KEY",
+                "openrouter": "OPENROUTER_API_KEY",
                 "anthropic": "ANTHROPIC_API_KEY",
                 "ollama": "OLLAMA_API_KEY",
             }.get(llm_provider)
@@ -93,9 +97,16 @@ def _handle_complete(payload: dict[str, Any]) -> None:
         bootstrap_admin_if_first_user(user_id)
 
         def update_config(config: dict[str, Any]) -> None:
-            config.setdefault("llm", {})["provider"] = llm_provider
-            if llm_provider == "ollama" and payload.get("ollama_base_url"):
-                config.setdefault("llm", {})["ollama_base_url"] = payload["ollama_base_url"]
+            runtime_provider = "transformers" if llm_provider == "local" else llm_provider
+            config.setdefault("models", {})["llm_provider"] = runtime_provider
+            if llm_provider == "openai":
+                config.setdefault("openai", {}).setdefault("model", "gpt-4o")
+            elif llm_provider == "openrouter":
+                openrouter = config.setdefault("openrouter", {})
+                openrouter.setdefault("model", "openai/gpt-4o")
+                openrouter.setdefault("base_url", "https://openrouter.ai/api/v1")
+            elif llm_provider == "ollama" and payload.get("ollama_base_url"):
+                config.setdefault("ollama", {})["base_url"] = payload["ollama_base_url"]
             config["tts_provider"] = tts_provider
             if ha_base_url:
                 config.setdefault("home_assistant", {})["base_url"] = ha_base_url

--- a/config/rex_config.example.json
+++ b/config/rex_config.example.json
@@ -67,10 +67,6 @@
     "model": null,
     "base_url": null
   },
-  "openrouter": {
-    "model": "openai/gpt-4o",
-    "base_url": "https://openrouter.ai/api/v1"
-  },
   "api": {
     "rate_limit": "30/minute",
     "allowed_origins": [
@@ -235,5 +231,10 @@
         "enabled": false
       }
     ]
+  },
+  "openrouter": {
+    "model": "openai/gpt-4o",
+    "base_url": "https://openrouter.ai/api/v1"
   }
+
 }

--- a/config/rex_config.example.json
+++ b/config/rex_config.example.json
@@ -67,6 +67,10 @@
     "model": null,
     "base_url": null
   },
+  "openrouter": {
+    "model": "openai/gpt-4o",
+    "base_url": "https://openrouter.ai/api/v1"
+  },
   "api": {
     "rate_limit": "30/minute",
     "allowed_origins": [

--- a/config/rex_config.schema.json
+++ b/config/rex_config.schema.json
@@ -105,7 +105,7 @@
       "properties": {
         "llm_provider": {
           "type": "string",
-          "description": "LLM provider (transformers, openai, ollama)",
+          "description": "LLM provider (transformers, openai, openrouter, anthropic, ollama)",
           "default": "transformers"
         },
         "llm_backend": {
@@ -346,6 +346,22 @@
         "base_url": {
           "type": ["string", "null"],
           "description": "OpenAI API base URL (for compatible APIs)"
+        }
+      }
+    },
+    "openrouter": {
+      "type": "object",
+      "description": "OpenRouter configuration using its OpenAI-compatible API",
+      "properties": {
+        "model": {
+          "type": ["string", "null"],
+          "description": "OpenRouter model slug, for example openai/gpt-4o"
+        },
+        "base_url": {
+          "type": "string",
+          "description": "Official OpenRouter API base URL",
+          "const": "https://openrouter.ai/api/v1",
+          "default": "https://openrouter.ai/api/v1"
         }
       }
     },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,7 +111,7 @@ profile overrides live in `profiles/<name>.json`.
 |   |-- cli.py               # CLI command tree
 |   |-- assistant.py         # Assistant orchestration
 |   |-- config.py            # AppConfig loader and rex-config CLI
-|   |-- llm_client.py        # Transformers/OpenAI/Anthropic/Ollama clients
+|   |-- llm_client.py        # Transformers/OpenAI/OpenRouter/Anthropic/Ollama clients
 |   |-- voice_loop.py        # Package voice-loop exports
 |   |-- voice_loop_optimized.py
 |   |-- gui_app.py           # Flask local API plus experimental browser dashboard

--- a/docs/INSTRUCTION_MANUAL.md
+++ b/docs/INSTRUCTION_MANUAL.md
@@ -10,7 +10,7 @@ AskRex Assistant is a local-first AI assistant with:
 - CLI text chat
 - wake-word voice interaction
 - Whisper-based speech-to-text
-- LLM backends for local Transformers, OpenAI, Anthropic, and Ollama
+- LLM backends for local Transformers, OpenAI, OpenRouter, Anthropic, and Ollama
 - text-to-speech backends such as XTTS, Edge TTS, Piper, and pyttsx3 paths
 - memory, knowledge base, scheduler, reminders, notifications, workflows, and tools
 - integrations for Home Assistant, email, calendar, SMS, GitHub, browser/OS automation, WordPress, WooCommerce, and remote computer control

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,9 +50,25 @@ receives secret values back — only set/unset status.
 |----------|---------|----------|-------------|
 | `OPENAI_API_KEY` | (none) | Yes (OpenAI) | OpenAI API key |
 | `OPENAI_BASE_URL` | SDK default | No | Override for the OpenAI-compatible API base URL |
+| `OPENROUTER_API_KEY` | (none) | Yes (OpenRouter) | OpenRouter API key; stored separately from the OpenAI key |
 | `ANTHROPIC_API_KEY` | (none) | Yes (Anthropic) | Anthropic / Claude API key |
 | `OLLAMA_API_KEY` | (none) | No | Auth token for cloud-hosted Ollama endpoints |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | No | Ollama API base URL |
+
+---
+
+## OpenRouter
+
+Set `models.llm_provider` to `openrouter` and configure a complete model slug
+under `openrouter.model` (for example, `openai/gpt-4o`). AskRex locks
+`openrouter.base_url` to the official `https://openrouter.ai/api/v1` endpoint so
+an OpenRouter credential cannot be redirected to another host. The desktop
+Settings page stores
+`OPENROUTER_API_KEY` in the Windows credential vault; the key is never written
+to `rex_config.json` and is not reused as the OpenAI credential.
+
+OpenRouter usage can incur charges billed by OpenRouter or the selected model
+provider. AskRex does not purchase credits or enable paid usage automatically.
 
 ---
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -55,8 +55,8 @@ values never return to the renderer. The renderer receives only blank secret
 inputs plus `hasCredential` and opaque-reference metadata. Blank input means
 unchanged. Deletion is a separate confirmed operation.
 
-Supported desktop settings cover Home Assistant, OpenAI, Anthropic, Ollama,
-Brave, SerpAPI, Google, OpenWeather, Telegram, Twilio/SMS/phone,
+Supported desktop settings cover Home Assistant, OpenAI, OpenRouter, Anthropic,
+Ollama, Brave, SerpAPI, Google, OpenWeather, Telegram, Twilio/SMS/phone,
 ElevenLabs/TTS, OpenClaw gateway, email/calendar client secrets, and per-account
 email passwords/client secrets. Stored/configured status is distinct from
 connected, authenticated, or verified status.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -22,7 +22,7 @@ rex-config migrate-legacy-env
 | `REX_WAKEWORD` | `hey rex` | Wake word keyword override |
 | `REX_INPUT_DEVICE` | auto | Audio input device index or name |
 | `REX_SAMPLE_RATE` | `16000` | Audio sample rate in Hz |
-| `REX_LLM_PROVIDER` | `openai` | LLM backend provider (`openai`, `ollama`, `local`) |
+| `REX_LLM_PROVIDER` | `openai` | LLM backend provider (`openai`, `openrouter`, `ollama`, `local`) |
 | `REX_TTS_PROVIDER` | `xtts` | TTS backend provider (`xtts`, `edge-tts`, `pyttsx3`) |
 
 ## Core Secrets

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -3007,9 +3007,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4350,9 +4350,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -7324,9 +7324,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -53,7 +53,7 @@
   "overrides": {
     "tmp": "^0.2.6",
     "esbuild": "0.28.1",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   },
   "build": {
     "appId": "com.askrex.app",

--- a/gui/src/main/aiSettings.ts
+++ b/gui/src/main/aiSettings.ts
@@ -1,6 +1,10 @@
 import type { AiSettings, Settings } from '../types/ipc'
 import { readRexConfig } from './configStore'
 
+export const OPENROUTER_DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1'
+export const OPENAI_DEFAULT_MODEL = 'gpt-4o'
+export const OPENROUTER_DEFAULT_MODEL = 'openai/gpt-4o'
+
 export function normalizeAiModelRouting(raw: unknown): AiSettings['modelRouting'] {
   const source = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
   return {
@@ -14,7 +18,7 @@ export function normalizeAiModelRouting(raw: unknown): AiSettings['modelRouting'
 }
 
 export function normalizeGuiAiProvider(raw: unknown): AiSettings['provider'] {
-  if (raw === 'openai' || raw === 'ollama' || raw === 'local') {
+  if (raw === 'openai' || raw === 'openrouter' || raw === 'ollama' || raw === 'local') {
     return raw
   }
   if (raw === 'transformers') {
@@ -27,22 +31,20 @@ export function toRuntimeAiProvider(provider: AiSettings['provider']): string {
   return provider === 'local' ? 'transformers' : provider
 }
 
+function objectSection(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+function nonEmptyString(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : ''
+}
+
 export function buildAiSettings(raw: Settings = {}): AiSettings {
   const rexConfig = readRexConfig()
-  const models = rexConfig.models && typeof rexConfig.models === 'object'
-    ? (rexConfig.models as Record<string, unknown>)
-    : {}
-  const ollama = rexConfig.ollama && typeof rexConfig.ollama === 'object'
-    ? (rexConfig.ollama as Record<string, unknown>)
-    : {}
-  const rawModel = typeof raw.model === 'string' ? raw.model : null
-  const model = rawModel === 'gpt-4o' || rawModel === 'gpt-4-turbo' || rawModel === 'claude-opus-4' || rawModel === 'claude-sonnet-4' || rawModel === 'gemini-1.5-pro'
-    ? rawModel
-    : 'claude-sonnet-4'
-  const routingSource =
-    raw.modelRouting && typeof raw.modelRouting === 'object'
-      ? raw.modelRouting
-      : rexConfig.model_routing
+  const models = objectSection(rexConfig.models)
+  const openai = objectSection(rexConfig.openai)
+  const openrouter = objectSection(rexConfig.openrouter)
+  const ollama = objectSection(rexConfig.ollama)
   const rawProvider =
     typeof models.llm_provider === 'string'
       ? models.llm_provider
@@ -50,16 +52,32 @@ export function buildAiSettings(raw: Settings = {}): AiSettings {
         ? raw.provider
         : null
   const provider = normalizeGuiAiProvider(rawProvider)
-  const rawCustomModelId = typeof raw.customModelId === 'string' ? raw.customModelId : ''
-  const runtimeModelId = typeof models.llm_model === 'string' ? models.llm_model : ''
+  const runtimeModelId = nonEmptyString(models.llm_model)
+  const model =
+    nonEmptyString(raw.model)
+    || nonEmptyString(openai.model)
+    || (provider === 'openai' ? runtimeModelId : '')
+    || OPENAI_DEFAULT_MODEL
+  const openrouterModel =
+    nonEmptyString(raw.openrouterModel)
+    || nonEmptyString(openrouter.model)
+    || (provider === 'openrouter' ? runtimeModelId : '')
+    || OPENROUTER_DEFAULT_MODEL
   const customModelId =
-    rawCustomModelId || (provider !== 'openai' ? runtimeModelId : '')
+    nonEmptyString(raw.customModelId)
+    || (provider === 'ollama' || provider === 'local' ? runtimeModelId : '')
   const ollamaBaseUrl =
-    typeof raw.ollamaBaseUrl === 'string' && raw.ollamaBaseUrl
-      ? raw.ollamaBaseUrl
-      : typeof ollama.base_url === 'string'
-        ? ollama.base_url
-        : 'http://localhost:11434'
+    nonEmptyString(raw.ollamaBaseUrl)
+    || nonEmptyString(ollama.base_url)
+    || 'http://localhost:11434'
+  const openrouterBaseUrl =
+    nonEmptyString(raw.openrouterBaseUrl)
+    || nonEmptyString(openrouter.base_url)
+    || OPENROUTER_DEFAULT_BASE_URL
+  const routingSource =
+    raw.modelRouting && typeof raw.modelRouting === 'object'
+      ? raw.modelRouting
+      : rexConfig.model_routing
 
   const VALID_PERSONALITIES = ['Friendly', 'Professional', 'Minimal']
   const rawPersonality = typeof raw.personality === 'string' ? raw.personality : null
@@ -74,6 +92,8 @@ export function buildAiSettings(raw: Settings = {}): AiSettings {
     provider,
     customModelId,
     ollamaBaseUrl,
+    openrouterModel,
+    openrouterBaseUrl,
     temperature:
       typeof raw.temperature === 'number'
         ? raw.temperature

--- a/gui/src/main/handlers/settings.ts
+++ b/gui/src/main/handlers/settings.ts
@@ -21,6 +21,7 @@ import { safeIpcErrorMessage, SafeValidationError } from '../ipcErrors'
 
 const ALLOWED_API_KEYS = [
   'OPENAI_API_KEY',
+  'OPENROUTER_API_KEY',
   'ANTHROPIC_API_KEY',
   'OLLAMA_API_KEY',
   'ELEVENLABS_API_KEY',
@@ -416,24 +417,32 @@ export function registerSettingsHandlers(session: ElectronSessionIdentity): void
     }
   )
 
-  ipcMain.handle('rex:getApiKeys', async (): Promise<{ openai_key_set: boolean; error?: string }> => {
-    try {
-      const config = readRexConfigStrict()
-      const context = apiKeyContext('OPENAI_API_KEY')
-      const record = getVaultReference(config, 'OPENAI_API_KEY', context, session.userId)
-      return {
-        openai_key_set: record
-          ? await vaultHasSecret(session, record.ref, context)
-          : false
+  ipcMain.handle(
+    'rex:getApiKeys',
+    async (): Promise<{ openai_key_set: boolean; openrouter_key_set: boolean; error?: string }> => {
+      try {
+        const config = readRexConfigStrict()
+        const hasKey = async (name: 'OPENAI_API_KEY' | 'OPENROUTER_API_KEY'): Promise<boolean> => {
+          const context = apiKeyContext(name)
+          const record = getVaultReference(config, name, context, session.userId)
+          return record ? await vaultHasSecret(session, record.ref, context) : false
+        }
+        const [openaiKeySet, openrouterKeySet] = await Promise.all([
+          hasKey('OPENAI_API_KEY'),
+          hasKey('OPENROUTER_API_KEY')
+        ])
+        return { openai_key_set: openaiKeySet, openrouter_key_set: openrouterKeySet }
+      } catch {
+        // Vault unavailable: fail closed and report "not configured" rather
+        // than reading any legacy plaintext credential location (S4).
+        return {
+          openai_key_set: false,
+          openrouter_key_set: false,
+          error: 'Stored API-key state could not be verified'
+        }
       }
-    } catch {
-      // Vault unavailable: fail closed and report "not configured" rather
-      // than reading the legacy plaintext .env location (S4) - a vault
-      // outage must never silently reveal whether a plaintext secret is
-      // sitting on disk.
-      return { openai_key_set: false, error: 'Stored API-key state could not be verified' }
     }
-  })
+  )
 
   ipcMain.handle(
     'rex:setApiKey',

--- a/gui/src/main/settingsDefaults.ts
+++ b/gui/src/main/settingsDefaults.ts
@@ -39,10 +39,12 @@ export const defaultSettingsMap: Record<string, Settings> = {
     wakeWordEmbeddingPath: ''
   } satisfies VoiceSettings,
   ai: {
-    model: 'claude-sonnet-4',
+    model: 'gpt-4o',
     provider: 'openai',
     customModelId: '',
     ollamaBaseUrl: 'http://localhost:11434',
+    openrouterModel: 'openai/gpt-4o',
+    openrouterBaseUrl: 'https://openrouter.ai/api/v1',
     temperature: 0.7,
     maxTokens: 2048,
     systemPrompt: '',

--- a/gui/src/main/settingsMirror.ts
+++ b/gui/src/main/settingsMirror.ts
@@ -23,18 +23,44 @@ export function mirrorToRexConfig(section: string, values: Settings): MirrorResu
       const models = ((rexConfig.models ?? {}) as Record<string, unknown>)
       if (typeof values.temperature === 'number') models.llm_temperature = String(values.temperature)
       if (typeof values.maxTokens === 'number') models.llm_max_tokens = values.maxTokens
-      const provider = normalizeGuiAiProvider(values.provider)
-      models.llm_provider = toRuntimeAiProvider(provider)
-      const llm = ((rexConfig.llm ?? {}) as Record<string, unknown>)
-      llm.provider = provider
-      rexConfig.llm = llm
-      if (typeof values.customModelId === 'string' && values.customModelId.trim()) {
+      const providerWasSupplied = typeof values.provider === 'string'
+      const provider = normalizeGuiAiProvider(
+        providerWasSupplied ? values.provider : models.llm_provider
+      )
+      if (providerWasSupplied) {
+        models.llm_provider = toRuntimeAiProvider(provider)
+        const llm = ((rexConfig.llm ?? {}) as Record<string, unknown>)
+        delete llm.provider
+        rexConfig.llm = llm
+      }
+      if (
+        (provider === 'ollama' || provider === 'local')
+        && (providerWasSupplied || typeof values.customModelId === 'string')
+      ) {
+        if (typeof values.customModelId !== 'string' || !values.customModelId.trim()) {
+          return { ok: false, error: 'Model identifier is required' }
+        }
         models.llm_model = values.customModelId.trim()
       }
-      if (provider === 'openai' && typeof values.model === 'string') {
+      if (provider === 'openai' && (providerWasSupplied || typeof values.model === 'string')) {
+        if (typeof values.model !== 'string' || !values.model.trim()) {
+          return { ok: false, error: 'OpenAI model is required' }
+        }
         const openai = ((rexConfig.openai ?? {}) as Record<string, unknown>)
-        openai.model = values.model
+        openai.model = values.model.trim()
         rexConfig.openai = openai
+      }
+      if (
+        provider === 'openrouter'
+        && (providerWasSupplied || typeof values.openrouterModel === 'string')
+      ) {
+        if (typeof values.openrouterModel !== 'string' || !values.openrouterModel.trim()) {
+          return { ok: false, error: 'OpenRouter model is required' }
+        }
+        const openrouter = ((rexConfig.openrouter ?? {}) as Record<string, unknown>)
+        openrouter.model = values.openrouterModel.trim()
+        openrouter.base_url = 'https://openrouter.ai/api/v1'
+        rexConfig.openrouter = openrouter
       }
       if (typeof values.ollamaBaseUrl === 'string' && values.ollamaBaseUrl.trim()) {
         const ollama = ((rexConfig.ollama ?? {}) as Record<string, unknown>)

--- a/gui/src/pages/SettingsPage.tsx
+++ b/gui/src/pages/SettingsPage.tsx
@@ -2068,7 +2068,7 @@ function AiPanel(): React.ReactElement {
   const [openrouterKeySet, setOpenrouterKeySet] = useState(false)
   const [openaiKeyValue, setOpenaiKeyValue] = useState('')
   const [openrouterKeyValue, setOpenrouterKeyValue] = useState('')
-  const [apiKeySaving, setApiKeySaving] = useState<'openai' | 'openrouter' | null>(null)
+  const [credentialSaving, setCredentialSaving] = useState<'openai' | 'openrouter' | null>(null)
 
   function loadSuggestions(): void {
     window.rex
@@ -2227,7 +2227,7 @@ function AiPanel(): React.ReactElement {
   function handleSaveApiKey(provider: 'openai' | 'openrouter'): void {
     const value = provider === 'openai' ? openaiKeyValue.trim() : openrouterKeyValue.trim()
     if (!value) return
-    setApiKeySaving(provider)
+    setCredentialSaving(provider)
     const logicalName = provider === 'openai' ? 'OPENAI_API_KEY' : 'OPENROUTER_API_KEY'
     window.rex
       .setApiKey(logicalName, value)
@@ -2248,7 +2248,7 @@ function AiPanel(): React.ReactElement {
       .catch(() => {
         addToast('Failed to save API key', 'error')
       })
-      .finally(() => setApiKeySaving(null))
+      .finally(() => setCredentialSaving(null))
   }
 
   const activeSuggestion = suggestions.find((s) => !dismissedFields.has(s.field)) ?? null
@@ -2357,10 +2357,10 @@ function AiPanel(): React.ReactElement {
               <button
                 type="button"
                 onClick={() => handleSaveApiKey('openai')}
-                disabled={apiKeySaving !== null || !openaiKeyValue.trim()}
+                disabled={credentialSaving !== null || !openaiKeyValue.trim()}
                 className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50 shrink-0"
               >
-                {apiKeySaving === 'openai' ? 'Saving...' : 'Save'}
+                {credentialSaving === 'openai' ? 'Saving...' : 'Save'}
               </button>
             </div>
             <p className="mt-1 text-xs text-text-secondary">
@@ -2431,10 +2431,10 @@ function AiPanel(): React.ReactElement {
               <button
                 type="button"
                 onClick={() => handleSaveApiKey('openrouter')}
-                disabled={apiKeySaving !== null || !openrouterKeyValue.trim()}
+                disabled={credentialSaving !== null || !openrouterKeyValue.trim()}
                 className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50 shrink-0"
               >
-                {apiKeySaving === 'openrouter' ? 'Saving...' : 'Save'}
+                {credentialSaving === 'openrouter' ? 'Saving...' : 'Save'}
               </button>
             </div>
             <p className="mt-1 text-xs text-text-secondary">

--- a/gui/src/pages/SettingsPage.tsx
+++ b/gui/src/pages/SettingsPage.tsx
@@ -1999,14 +1999,6 @@ function VoicePanel(): React.ReactElement {
   )
 }
 
-const AI_MODELS: Array<{ value: AiSettings['model']; label: string }> = [
-  { value: 'gpt-4o', label: 'GPT-4o' },
-  { value: 'gpt-4-turbo', label: 'GPT-4 Turbo' },
-  { value: 'claude-opus-4', label: 'Claude Opus 4' },
-  { value: 'claude-sonnet-4', label: 'Claude Sonnet 4' },
-  { value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' }
-]
-
 const MODEL_ROUTING_FIELDS: Array<{
   key: keyof AiSettings['modelRouting']
   label: string
@@ -2043,10 +2035,12 @@ const PERSONALITIES = [
 function AiPanel(): React.ReactElement {
   const addToast = useToast()
   const [form, setForm] = useState<AiSettings>({
-    model: 'claude-sonnet-4',
+    model: 'gpt-4o',
     provider: 'openai',
     customModelId: '',
     ollamaBaseUrl: 'http://localhost:11434',
+    openrouterModel: 'openai/gpt-4o',
+    openrouterBaseUrl: 'https://openrouter.ai/api/v1',
     temperature: 0.7,
     maxTokens: 2048,
     systemPrompt: '',
@@ -2070,9 +2064,11 @@ function AiPanel(): React.ReactElement {
   const [dismissedFields, setDismissedFields] = useState<Set<string>>(new Set())
   const [routingDirty, setRoutingDirty] = useState(false)
   const [savingRouting, setSavingRouting] = useState(false)
-  const [apiKeySet, setApiKeySet] = useState(false)
-  const [apiKeyValue, setApiKeyValue] = useState('')
-  const [apiKeySaving, setApiKeySaving] = useState(false)
+  const [openaiKeySet, setOpenaiKeySet] = useState(false)
+  const [openrouterKeySet, setOpenrouterKeySet] = useState(false)
+  const [openaiKeyValue, setOpenaiKeyValue] = useState('')
+  const [openrouterKeyValue, setOpenrouterKeyValue] = useState('')
+  const [apiKeySaving, setApiKeySaving] = useState<'openai' | 'openrouter' | null>(null)
 
   function loadSuggestions(): void {
     window.rex
@@ -2093,16 +2089,22 @@ function AiPanel(): React.ReactElement {
             : {}
         const rawProvider = settings.provider
         const provider: AiSettings['provider'] =
-          rawProvider === 'openai' || rawProvider === 'ollama' || rawProvider === 'local'
+          rawProvider === 'openai' || rawProvider === 'openrouter' || rawProvider === 'ollama' || rawProvider === 'local'
             ? rawProvider
             : 'openai'
         setForm({
-          model: (AI_MODELS.some((m) => m.value === settings.model)
-            ? settings.model
-            : 'claude-sonnet-4') as AiSettings['model'],
+          model: typeof settings.model === 'string' && settings.model.trim() ? settings.model : 'gpt-4o',
           provider,
           customModelId: typeof settings.customModelId === 'string' ? settings.customModelId : '',
           ollamaBaseUrl: typeof settings.ollamaBaseUrl === 'string' ? settings.ollamaBaseUrl : 'http://localhost:11434',
+          openrouterModel:
+            typeof settings.openrouterModel === 'string' && settings.openrouterModel.trim()
+              ? settings.openrouterModel
+              : 'openai/gpt-4o',
+          openrouterBaseUrl:
+            typeof settings.openrouterBaseUrl === 'string' && settings.openrouterBaseUrl.trim()
+              ? settings.openrouterBaseUrl
+              : 'https://openrouter.ai/api/v1',
           temperature: typeof settings.temperature === 'number' ? settings.temperature : 0.7,
           maxTokens: typeof settings.maxTokens === 'number' ? settings.maxTokens : 2048,
           systemPrompt: typeof settings.systemPrompt === 'string' ? settings.systemPrompt : '',
@@ -2134,7 +2136,8 @@ function AiPanel(): React.ReactElement {
     window.rex
       .getApiKeys()
       .then((keys) => {
-        setApiKeySet(keys.openai_key_set)
+        setOpenaiKeySet(keys.openai_key_set)
+        setOpenrouterKeySet(keys.openrouter_key_set)
         if (keys.error) addToast(keys.error, 'error')
       })
       .catch(() => {
@@ -2221,16 +2224,23 @@ function AiPanel(): React.ReactElement {
     setDismissedFields((prev) => new Set(prev).add(field))
   }
 
-  function handleSaveApiKey(): void {
-    if (!apiKeyValue.trim()) return
-    setApiKeySaving(true)
+  function handleSaveApiKey(provider: 'openai' | 'openrouter'): void {
+    const value = provider === 'openai' ? openaiKeyValue.trim() : openrouterKeyValue.trim()
+    if (!value) return
+    setApiKeySaving(provider)
+    const logicalName = provider === 'openai' ? 'OPENAI_API_KEY' : 'OPENROUTER_API_KEY'
     window.rex
-      .setApiKey('OPENAI_API_KEY', apiKeyValue.trim())
+      .setApiKey(logicalName, value)
       .then((result) => {
         if (result.ok) {
-          setApiKeySet(true)
-          setApiKeyValue('')
-          addToast('API key saved', 'success')
+          if (provider === 'openai') {
+            setOpenaiKeySet(true)
+            setOpenaiKeyValue('')
+          } else {
+            setOpenrouterKeySet(true)
+            setOpenrouterKeyValue('')
+          }
+          addToast(`${provider === 'openai' ? 'OpenAI' : 'OpenRouter'} API key saved`, 'success')
         } else {
           addToast(result.error ?? 'Failed to save API key', 'error')
         }
@@ -2238,7 +2248,7 @@ function AiPanel(): React.ReactElement {
       .catch(() => {
         addToast('Failed to save API key', 'error')
       })
-      .finally(() => setApiKeySaving(false))
+      .finally(() => setApiKeySaving(null))
   }
 
   const activeSuggestion = suggestions.find((s) => !dismissedFields.has(s.field)) ?? null
@@ -2301,74 +2311,134 @@ function AiPanel(): React.ReactElement {
           className="w-full bg-surface-raised border border-border rounded-lg px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
         >
           <option value="openai">OpenAI</option>
+          <option value="openrouter">OpenRouter</option>
           <option value="ollama">Ollama (local)</option>
           <option value="local">Local Transformers</option>
         </select>
       </div>
 
-      {/* OpenAI: model dropdown + API key */}
+      {/* OpenAI: model ID + API key */}
       {form.provider === 'openai' && (
         <>
           <div className="mb-5">
             <div className="flex items-center justify-between mb-1.5">
               <label htmlFor="aiModel" className="text-sm font-medium text-text-primary">
-                AI Model
+                OpenAI Model ID
               </label>
               <SavedIndicator visible={savedField === 'model'} />
             </div>
-            <select
+            <input
               id="aiModel"
+              type="text"
               value={form.model}
-              onChange={(e) => handleFieldChange('model', e.target.value as AiSettings['model'])}
-              className="w-full bg-surface-raised border border-border rounded-lg px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
-            >
-              {AI_MODELS.map((m) => (
-                <option key={m.value} value={m.value}>
-                  {m.label}
-                </option>
-              ))}
-            </select>
+              placeholder="gpt-4o"
+              onChange={(e) => setForm((current) => ({ ...current, model: e.target.value }))}
+              onBlur={(e) => handleFieldChange('model', e.target.value.trim() || 'gpt-4o')}
+              className="w-full bg-surface-raised border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
+            />
           </div>
 
-          {/* OpenAI API Key */}
           <div className="mb-5">
             <div className="flex items-center justify-between mb-1.5">
-              <div className="flex items-center gap-1.5">
-                <label htmlFor="openaiApiKey" className="text-sm font-medium text-text-primary">
-                  OpenAI API Key
-                </label>
-                <span
-                  title="Get your API key from platform.openai.com → API keys. Keys start with sk-."
-                  className="flex-shrink-0 w-4 h-4 rounded-full bg-surface-raised text-text-muted flex items-center justify-center text-[10px] font-bold cursor-help select-none"
-                  aria-label="API key help"
-                >
-                  ?
-                </span>
-              </div>
-              {apiKeySet && (
-                <span className="text-xs text-success font-medium">Key set</span>
-              )}
+              <label htmlFor="openaiApiKey" className="text-sm font-medium text-text-primary">
+                OpenAI API Key
+              </label>
+              {openaiKeySet && <span className="text-xs text-success font-medium">Key set</span>}
             </div>
             <div className="flex gap-2">
               <div className="flex-1">
                 <PasswordInput
                   id="openaiApiKey"
-                  value={apiKeyValue}
-                  placeholder={apiKeySet ? '••••••••••••••••' : 'sk-…'}
-                  onChange={setApiKeyValue}
+                  value={openaiKeyValue}
+                  placeholder={openaiKeySet ? 'Stored securely' : 'Enter API key'}
+                  onChange={setOpenaiKeyValue}
                 />
               </div>
               <button
                 type="button"
-                onClick={handleSaveApiKey}
-                disabled={apiKeySaving || !apiKeyValue.trim()}
+                onClick={() => handleSaveApiKey('openai')}
+                disabled={apiKeySaving !== null || !openaiKeyValue.trim()}
                 className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50 shrink-0"
               >
-                {apiKeySaving ? 'Saving…' : 'Save'}
+                {apiKeySaving === 'openai' ? 'Saving...' : 'Save'}
               </button>
             </div>
             <p className="mt-1 text-xs text-text-secondary">
               Stored in the Windows credential vault. The saved key is never loaded back into this field.
+            </p>
+          </div>
+        </>
+      )}
+
+      {/* OpenRouter: OpenAI-compatible endpoint, model slug, and separate key */}
+      {form.provider === 'openrouter' && (
+        <>
+          <div className="mb-5">
+            <div className="flex items-center justify-between mb-1.5">
+              <label htmlFor="openrouterModel" className="text-sm font-medium text-text-primary">
+                OpenRouter Model Slug
+              </label>
+              <SavedIndicator visible={savedField === 'openrouterModel'} />
+            </div>
+            <input
+              id="openrouterModel"
+              type="text"
+              value={form.openrouterModel}
+              placeholder="openai/gpt-4o"
+              onChange={(e) => setForm((current) => ({ ...current, openrouterModel: e.target.value }))}
+              onBlur={(e) => handleFieldChange('openrouterModel', e.target.value.trim())}
+              className="w-full bg-surface-raised border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
+            />
+            <p className="mt-1 text-xs text-text-secondary">
+              Use the complete OpenRouter model identifier, including its provider prefix.
+            </p>
+          </div>
+          <div className="mb-5">
+            <div className="flex items-center justify-between mb-1.5">
+              <label htmlFor="openrouterBaseUrl" className="text-sm font-medium text-text-primary">
+                OpenRouter Base URL
+              </label>
+              <SavedIndicator visible={savedField === 'openrouterBaseUrl'} />
+            </div>
+            <input
+              id="openrouterBaseUrl"
+              type="url"
+              value="https://openrouter.ai/api/v1"
+              readOnly
+              aria-readonly="true"
+              className="w-full cursor-not-allowed bg-surface-raised border border-border rounded-lg px-3 py-2 text-sm text-text-secondary"
+            />
+            <p className="mt-1 text-xs text-text-secondary">
+              Locked to OpenRouter's official HTTPS endpoint so the saved key cannot be redirected.
+            </p>
+          </div>
+          <div className="mb-5">
+            <div className="flex items-center justify-between mb-1.5">
+              <label htmlFor="openrouterApiKey" className="text-sm font-medium text-text-primary">
+                OpenRouter API Key
+              </label>
+              {openrouterKeySet && <span className="text-xs text-success font-medium">Key set</span>}
+            </div>
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <PasswordInput
+                  id="openrouterApiKey"
+                  value={openrouterKeyValue}
+                  placeholder={openrouterKeySet ? 'Stored securely' : 'Enter OpenRouter key'}
+                  onChange={setOpenrouterKeyValue}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => handleSaveApiKey('openrouter')}
+                disabled={apiKeySaving !== null || !openrouterKeyValue.trim()}
+                className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50 shrink-0"
+              >
+                {apiKeySaving === 'openrouter' ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+            <p className="mt-1 text-xs text-text-secondary">
+              Stored separately from the OpenAI key in the Windows credential vault.
             </p>
           </div>
         </>

--- a/gui/src/pages/SetupWizardPage.tsx
+++ b/gui/src/pages/SetupWizardPage.tsx
@@ -62,11 +62,12 @@ function StepLLM({ data, onChange }: StepProps): React.ReactElement {
         >
           <option value="local">Local (Transformers / Ollama)</option>
           <option value="openai">OpenAI</option>
+          <option value="openrouter">OpenRouter</option>
           <option value="anthropic">Anthropic</option>
           <option value="ollama">Ollama (custom URL)</option>
         </select>
       </div>
-      {(data.llmProvider === 'openai' || data.llmProvider === 'anthropic') && (
+      {(data.llmProvider === 'openai' || data.llmProvider === 'openrouter' || data.llmProvider === 'anthropic') && (
         <div>
           <label className="block text-sm font-medium text-text-primary mb-1">API Key</label>
           <input
@@ -75,9 +76,9 @@ function StepLLM({ data, onChange }: StepProps): React.ReactElement {
             value={data.llmApiKey}
             onChange={(e) => onChange('llmApiKey', e.target.value)}
             className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent/50"
-            placeholder={data.llmProvider === 'openai' ? 'sk-...' : 'sk-ant-...'}
+            placeholder={data.llmProvider === 'anthropic' ? 'sk-ant-...' : 'Enter API key'}
           />
-          <p className="text-text-muted text-xs mt-1">Stored securely in your local .env file.</p>
+          <p className="text-text-muted text-xs mt-1">Stored in the Windows credential vault.</p>
         </div>
       )}
     </div>

--- a/gui/src/preload/index.ts
+++ b/gui/src/preload/index.ts
@@ -327,7 +327,7 @@ const rexAPI = {
     audioBase64: string
   ): Promise<{ ok: boolean; transcript?: string; error?: string }> =>
     ipcRenderer.invoke('rex:sendChatAudio', audioBase64),
-  getApiKeys: (): Promise<{ openai_key_set: boolean }> =>
+  getApiKeys: (): Promise<{ openai_key_set: boolean; openrouter_key_set: boolean; error?: string }> =>
     ipcRenderer.invoke('rex:getApiKeys'),
   setApiKey: (name: string, value: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('rex:setApiKey', name, value),

--- a/gui/src/types/ipc.ts
+++ b/gui/src/types/ipc.ts
@@ -213,10 +213,12 @@ export interface AiModelRoutingSettings {
 }
 
 export interface AiSettings {
-  model: 'gpt-4o' | 'gpt-4-turbo' | 'claude-opus-4' | 'claude-sonnet-4' | 'gemini-1.5-pro'
-  provider: 'openai' | 'ollama' | 'local'
+  model: string
+  provider: 'openai' | 'openrouter' | 'ollama' | 'local'
   customModelId: string
   ollamaBaseUrl: string
+  openrouterModel: string
+  openrouterBaseUrl: string
   temperature: number
   maxTokens: number
   systemPrompt: string
@@ -740,7 +742,7 @@ export interface RexAPI {
   sendChatAudio: (
     audioBase64: string
   ) => Promise<{ ok: boolean; transcript?: string; error?: string }>
-  getApiKeys: () => Promise<{ openai_key_set: boolean; error?: string }>
+  getApiKeys: () => Promise<{ openai_key_set: boolean; openrouter_key_set: boolean; error?: string }>
   setApiKey: (name: string, value: string) => Promise<{ ok: boolean; error?: string }>
   getSmartSpeakers: () => Promise<{ ok: boolean; speakers: SmartSpeaker[]; error?: string }>
   restartRex: () => Promise<{ ok: boolean; error?: string }>

--- a/gui/tests/aiSettings.test.ts
+++ b/gui/tests/aiSettings.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockReadRexConfig } = vi.hoisted(() => ({ mockReadRexConfig: vi.fn() }))
+vi.mock('../src/main/configStore', () => ({ readRexConfig: mockReadRexConfig }))
+
+import {
+  OPENAI_DEFAULT_MODEL,
+  OPENROUTER_DEFAULT_BASE_URL,
+  OPENROUTER_DEFAULT_MODEL,
+  buildAiSettings,
+  normalizeGuiAiProvider,
+  toRuntimeAiProvider
+} from '../src/main/aiSettings'
+
+describe('AI provider settings', () => {
+  beforeEach(() => mockReadRexConfig.mockReset().mockReturnValue({}))
+
+  it('uses a provider-compatible OpenAI default instead of a Claude model', () => {
+    const settings = buildAiSettings({ provider: 'openai' })
+    expect(settings.provider).toBe('openai')
+    expect(settings.model).toBe(OPENAI_DEFAULT_MODEL)
+  })
+
+  it('loads OpenRouter model and endpoint independently from OpenAI', () => {
+    mockReadRexConfig.mockReturnValue({
+      models: { llm_provider: 'openrouter' },
+      openai: { model: 'gpt-openai-only' },
+      openrouter: {
+        model: 'anthropic/claude-sonnet-4',
+        base_url: 'https://router.example.test/v1'
+      }
+    })
+    const settings = buildAiSettings({})
+    expect(settings.provider).toBe('openrouter')
+    expect(settings.model).toBe('gpt-openai-only')
+    expect(settings.openrouterModel).toBe('anthropic/claude-sonnet-4')
+    expect(settings.openrouterBaseUrl).toBe('https://router.example.test/v1')
+  })
+
+  it('provides safe OpenRouter defaults and preserves runtime mapping', () => {
+    expect(normalizeGuiAiProvider('openrouter')).toBe('openrouter')
+    expect(toRuntimeAiProvider('openrouter')).toBe('openrouter')
+    const settings = buildAiSettings({ provider: 'openrouter' })
+    expect(settings.openrouterModel).toBe(OPENROUTER_DEFAULT_MODEL)
+    expect(settings.openrouterBaseUrl).toBe(OPENROUTER_DEFAULT_BASE_URL)
+  })
+})

--- a/gui/tests/settingsHandlers.test.ts
+++ b/gui/tests/settingsHandlers.test.ts
@@ -52,6 +52,7 @@ const session: ElectronSessionIdentity = {
 }
 const ref = `cred_${'S'.repeat(32)}`
 const openAiContext = { scope: 'household', integration: 'openai', account: null, slot: 'api_key' }
+const openRouterContext = { scope: 'household', integration: 'openrouter', account: null, slot: 'api_key' }
 const haContext = { scope: 'household', integration: 'home_assistant', account: null, slot: 'token' }
 const emailContext = { scope: 'user', integration: 'email', account: 'work', slot: 'password' }
 let guiSettings: Record<string, unknown>
@@ -90,6 +91,16 @@ describe('settings vault routing (S4)', () => {
     })
   })
 
+  it('stores OpenRouter credentials under a separate vault context', async () => {
+    const result = await invoke('rex:setApiKey', 'OPENROUTER_API_KEY', 'router-value')
+    expect(result).toEqual({ ok: true })
+    expect(mockVault.vaultSetSecret).toHaveBeenCalledWith(session, 'router-value', openRouterContext)
+    expect(JSON.stringify(rexConfig)).not.toContain('router-value')
+    expect(rexConfig).toMatchObject({
+      credential_refs: { household: { OPENROUTER_API_KEY: { ref, integration: 'openrouter', account: null, slot: 'api_key' } } }
+    })
+  })
+
   it('does not treat blank input as deletion and rejects arbitrary key names', async () => {
     await expect(invoke('rex:setApiKey', 'OPENAI_API_KEY', '  ')).resolves.toEqual({ ok: true })
     expect(mockVault.vaultSetSecret).not.toHaveBeenCalled()
@@ -115,7 +126,7 @@ describe('settings vault routing (S4)', () => {
       credential_refs: { household: { OPENAI_API_KEY: { ref, integration: 'openai', account: null, slot: 'api_key' } } }
     }
     mockVault.vaultHasSecret.mockResolvedValue(true)
-    await expect(invoke('rex:getApiKeys')).resolves.toEqual({ openai_key_set: true })
+    await expect(invoke('rex:getApiKeys')).resolves.toEqual({ openai_key_set: true, openrouter_key_set: false })
     expect(mockVault.vaultHasSecret).toHaveBeenCalledWith(session, ref, openAiContext)
   })
 
@@ -125,6 +136,7 @@ describe('settings vault routing (S4)', () => {
     }
     await expect(invoke('rex:getApiKeys')).resolves.toEqual({
       openai_key_set: false,
+      openrouter_key_set: false,
       error: 'Stored API-key state could not be verified'
     })
     expect(mockVault.vaultHasSecret).not.toHaveBeenCalled()

--- a/gui/tests/settingsMirror.test.ts
+++ b/gui/tests/settingsMirror.test.ts
@@ -34,6 +34,34 @@ describe('mirrorToRexConfig truthful failures (S4)', () => {
     expect(mockWriteRexConfig).toHaveBeenCalledTimes(1)
   })
 
+  it('mirrors OpenRouter model and endpoint separately from OpenAI', () => {
+    mockReadRexConfig.mockReturnValue({ openai: { model: 'gpt-4o' } })
+    const result = mirrorToRexConfig('ai', {
+      provider: 'openrouter',
+      openrouterModel: 'anthropic/claude-sonnet-4',
+      openrouterBaseUrl: 'https://malicious.example.test/v1'
+    } as never)
+    expect(result).toEqual({ ok: true })
+    expect(mockWriteRexConfig).toHaveBeenCalledWith(expect.objectContaining({
+      models: expect.objectContaining({ llm_provider: 'openrouter' }),
+      openai: { model: 'gpt-4o' },
+      openrouter: {
+        model: 'anthropic/claude-sonnet-4',
+        base_url: 'https://openrouter.ai/api/v1'
+      }
+    }))
+    const written = mockWriteRexConfig.mock.calls[0][0] as Record<string, unknown>
+    expect((written.llm as Record<string, unknown>).provider).toBeUndefined()
+  })
+
+  it('rejects an empty OpenRouter model instead of persisting an unusable provider', () => {
+    const result = mirrorToRexConfig('ai', {
+      provider: 'openrouter', openrouterModel: '', openrouterBaseUrl: ''
+    } as never)
+    expect(result).toEqual({ ok: false, error: 'OpenRouter model is required' })
+    expect(mockWriteRexConfig).not.toHaveBeenCalled()
+  })
+
   it('returns {ok:false, error} instead of swallowing a write failure', () => {
     mockWriteRexConfig.mockImplementation(() => {
       throw new Error('disk full')

--- a/gui/tests/settingsRedaction.test.ts
+++ b/gui/tests/settingsRedaction.test.ts
@@ -12,6 +12,7 @@ describe('GUI settings secret redaction (US-027)', () => {
       'llm_api_key',
       'apiKey',
       'openai_api_key',
+      'openrouter_api_key',
       'password',
       'smtp_passwd',
       'client_secret',

--- a/rex/config.py
+++ b/rex/config.py
@@ -56,6 +56,7 @@ from rex.profile_manager import (
 )
 
 LOGGER = get_logger(__name__)
+OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 ENV_PATH = resolve_env_path()
 
 
@@ -184,6 +185,9 @@ class LLMConfig(BaseModel):
         "sshleifer/tiny-gpt2"  # maps to llm_model; None when openai_model is used
     )
     openai_api_key_env: str = "OPENAI_API_KEY"  # env var name (not the value)
+    openrouter_api_key_env: str = "OPENROUTER_API_KEY"
+    openrouter_model: Optional[str] = None
+    openrouter_base_url: str = OPENROUTER_DEFAULT_BASE_URL
     ollama_url: str = "http://localhost:11434"  # maps to ollama_base_url
     context_length: int = 120  # maps to llm_max_tokens
     temperature: float = 0.7  # maps to llm_temperature
@@ -429,6 +433,10 @@ class AppConfig:
     openai_api_key: Optional[str] = None
     openai_model: Optional[str] = None
     openai_base_url: Optional[str] = None
+
+    openrouter_api_key: Optional[str] = None
+    openrouter_model: Optional[str] = None
+    openrouter_base_url: str = OPENROUTER_DEFAULT_BASE_URL
 
     anthropic_api_key: Optional[str] = None
     anthropic_model: Optional[str] = None
@@ -716,6 +724,9 @@ class AppConfig:
 
     def __post_init__(self) -> None:
         provider = self.llm_provider.lower()
+        self.openrouter_base_url = (self.openrouter_base_url or OPENROUTER_DEFAULT_BASE_URL).rstrip(
+            "/"
+        )
         local_path_providers = {"transformers"}
         if provider in local_path_providers and isinstance(self.llm_model, str):
             model_path = Path(self.llm_model)
@@ -723,6 +734,13 @@ class AppConfig:
                 raise ValueError("llm_model must not contain path traversal components.")
         if provider == "openai" and not self.openai_model:
             raise ValueError("openai.model must be set when llm_provider is 'openai'.")
+        if provider == "openrouter":
+            if not self.openrouter_model:
+                raise ValueError("openrouter.model must be set when llm_provider is 'openrouter'.")
+            if self.openrouter_base_url != OPENROUTER_DEFAULT_BASE_URL:
+                raise ValueError(
+                    "openrouter.base_url must use the official https://openrouter.ai/api/v1 endpoint."
+                )
         if provider == "anthropic" and not self.anthropic_model:
             raise ValueError("anthropic.model must be set when llm_provider is 'anthropic'.")
         if self.llm_backend is None:
@@ -756,6 +774,8 @@ class AppConfig:
         self.llm = LLMConfig(
             llm_provider=self.llm_provider,
             model_name=self.llm_model,
+            openrouter_model=self.openrouter_model,
+            openrouter_base_url=self.openrouter_base_url,
             ollama_url=self.ollama_base_url,
             context_length=self.llm_max_tokens,
             temperature=self.llm_temperature,
@@ -1275,6 +1295,13 @@ def build_app_config(json_config: dict) -> AppConfig:
         openai_model=_get_nested(json_config, "openai.model"),
         openai_base_url=_get_nested(json_config, "openai.base_url"),
         openai_api_key=_secret_env_or_vault("OPENAI_API_KEY", json_config),
+        # OpenRouter from JSON + vault-backed secrets
+        openrouter_model=_get_nested(json_config, "openrouter.model"),
+        openrouter_base_url=(
+            _get_nested(json_config, "openrouter.base_url", OPENROUTER_DEFAULT_BASE_URL)
+            or OPENROUTER_DEFAULT_BASE_URL
+        ),
+        openrouter_api_key=_secret_env_or_vault("OPENROUTER_API_KEY", json_config),
         # Anthropic from JSON + vault-backed secrets
         anthropic_model=_get_nested(json_config, "anthropic.model"),
         anthropic_api_key=_secret_env_or_vault("ANTHROPIC_API_KEY", json_config),

--- a/rex/credentials.py
+++ b/rex/credentials.py
@@ -37,6 +37,7 @@ DEFAULT_CREDENTIAL_MAPPING: dict[str, str] = {
     "home_assistant": "HA_TOKEN",
     "brave": "BRAVE_API_KEY",
     "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "ollama": "OLLAMA_API_KEY",
     "serpapi": "SERPAPI_API_KEY",

--- a/rex/llm_client.py
+++ b/rex/llm_client.py
@@ -12,7 +12,7 @@ from importlib.util import find_spec
 from typing import Any, Protocol, cast
 
 from rex.assistant_errors import ConfigurationError
-from rex.config import AppConfig, load_config
+from rex.config import OPENROUTER_DEFAULT_BASE_URL, AppConfig, load_config
 from rex.logging_utils import get_logger
 from rex.retry import RetryConfig, with_retry
 
@@ -572,10 +572,14 @@ def register_strategy(name: str, strategy: type[Any]) -> None:
 class LanguageModel:
     def __init__(self, config: AppConfig | None = None, **overrides) -> None:
         self.config = config or load_config()
-        self.provider = (overrides.get("provider") or self.config.llm_provider).lower()
+        self.provider = (overrides.get("provider") or self.config.llm.llm_provider).lower()
         if self.provider == "openai":
             self.model_name = (
                 overrides.get("model") or self.config.openai_model or self.config.llm_model
+            )
+        elif self.provider == "openrouter":
+            self.model_name = (
+                overrides.get("model") or self.config.openrouter_model or self.config.llm_model
             )
         elif self.provider == "anthropic":
             self.model_name = (
@@ -583,7 +587,12 @@ class LanguageModel:
             )
         else:
             self.model_name = overrides.get("model") or self.config.llm_model
-        self.api_key = overrides.get("openai_api_key") or self.config.openai_api_key
+        if self.provider == "openrouter":
+            self.api_key = overrides.get("openrouter_api_key") or self.config.openrouter_api_key
+            self.api_base_url = OPENROUTER_DEFAULT_BASE_URL
+        else:
+            self.api_key = overrides.get("openai_api_key") or self.config.openai_api_key
+            self.api_base_url = overrides.get("base_url") or self.config.openai_base_url
         self.anthropic_api_key = overrides.get("anthropic_api_key") or self.config.anthropic_api_key
 
         self.generation = GenerationConfig(
@@ -615,7 +624,7 @@ class LanguageModel:
         return self._anthropic_client
 
     def _init_strategy(self) -> LLMStrategy:
-        if self.provider == "openai":
+        if self.provider in {"openai", "openrouter"}:
             return cast(LLMStrategy, OpenAIStrategy(self.model_name, self._ensure_openai_client))
 
         if self.provider == "anthropic":
@@ -658,9 +667,12 @@ class LanguageModel:
     def _ensure_openai_client(self):
         if self._openai_client is not None:
             return self._openai_client
-        base_url = self.config.openai_base_url
+        base_url = self.api_base_url
         api_key = self.api_key
-        if not api_key and base_url:
+        if self.provider == "openrouter":
+            if not api_key:
+                raise ConfigurationError("Missing OpenRouter API key.")
+        elif not api_key and base_url:
             api_key = "local"
         if not api_key:
             raise ConfigurationError("Missing OpenAI API key.")
@@ -670,9 +682,12 @@ class LanguageModel:
             OpenAI = import_module("openai").OpenAI
         except Exception as exc:
             raise ConfigurationError("OpenAI backend requires the `openai` package.") from exc
-        self._openai_client = (
-            OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key)
-        )
+        client_kwargs: dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        if self.provider == "openrouter":
+            client_kwargs["default_headers"] = {"X-OpenRouter-Title": "AskRex Assistant"}
+        self._openai_client = OpenAI(**client_kwargs)
         return self._openai_client
 
     def register_tool(

--- a/rex/llm_client.py
+++ b/rex/llm_client.py
@@ -572,7 +572,10 @@ def register_strategy(name: str, strategy: type[Any]) -> None:
 class LanguageModel:
     def __init__(self, config: AppConfig | None = None, **overrides) -> None:
         self.config = config or load_config()
-        self.provider = (overrides.get("provider") or self.config.llm.llm_provider).lower()
+        llm_config = self.config.llm
+        if llm_config is None:
+            raise ConfigurationError("LLM configuration is unavailable.")
+        self.provider = str(overrides.get("provider") or llm_config.llm_provider).lower()
         if self.provider == "openai":
             self.model_name = (
                 overrides.get("model") or self.config.openai_model or self.config.llm_model
@@ -587,6 +590,8 @@ class LanguageModel:
             )
         else:
             self.model_name = overrides.get("model") or self.config.llm_model
+        self.api_key: str | None
+        self.api_base_url: str | None
         if self.provider == "openrouter":
             self.api_key = overrides.get("openrouter_api_key") or self.config.openrouter_api_key
             self.api_base_url = OPENROUTER_DEFAULT_BASE_URL

--- a/tests/test_config_openai.py
+++ b/tests/test_config_openai.py
@@ -27,6 +27,63 @@ def test_openai_provider_allows_none_llm_model():
     assert config.openai_model == "hermes-3-llama-3.1-8b"
 
 
+def test_openrouter_provider_loads_separate_model_and_endpoint():
+    json_config = {
+        "models": {"llm_provider": "openrouter", "llm_model": None},
+        "openrouter": {
+            "model": "anthropic/claude-sonnet-4",
+            "base_url": "https://openrouter.ai/api/v1",
+        },
+    }
+
+    config = load_config(json_config=json_config, reload=True)
+
+    assert config.llm_provider == "openrouter"
+    assert config.openrouter_model == "anthropic/claude-sonnet-4"
+    assert config.openrouter_base_url == "https://openrouter.ai/api/v1"
+
+
+def test_openrouter_provider_normalizes_null_endpoint_to_official_default():
+    config = load_config(
+        json_config={
+            "models": {"llm_provider": "openrouter", "llm_model": None},
+            "openrouter": {"model": "openai/gpt-4o", "base_url": None},
+        },
+        reload=True,
+    )
+
+    assert config.openrouter_base_url == "https://openrouter.ai/api/v1"
+
+
+def test_openrouter_provider_rejects_nonofficial_endpoint():
+    import pytest
+
+    with pytest.raises(ValueError, match="official"):
+        load_config(
+            json_config={
+                "models": {"llm_provider": "openrouter", "llm_model": None},
+                "openrouter": {
+                    "model": "openai/gpt-4o",
+                    "base_url": "https://malicious.example.test/v1",
+                },
+            },
+            reload=True,
+        )
+
+
+def test_openrouter_provider_requires_a_model():
+    import pytest
+
+    with pytest.raises(ValueError, match="openrouter.model"):
+        load_config(
+            json_config={
+                "models": {"llm_provider": "openrouter", "llm_model": None},
+                "openrouter": {"model": None},
+            },
+            reload=True,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Migration command tests
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -508,7 +508,7 @@ def test_openrouter_uses_separate_key_base_url_and_openai_compatible_client(monk
         llm_provider="openrouter",
         llm_model=None,
         openrouter_model="openai/gpt-4o",
-        openrouter_api_key="router-key",
+        openrouter_api_key="router-key",  # pragma: allowlist secret
         openrouter_base_url="https://openrouter.ai/api/v1",
     )
 
@@ -518,7 +518,7 @@ def test_openrouter_uses_separate_key_base_url_and_openai_compatible_client(monk
     assert model.provider == "openrouter"
     assert model.model_name == "openai/gpt-4o"
     assert captured == {
-        "api_key": "router-key",
+        "api_key": "router-key",  # pragma: allowlist secret
         "base_url": "https://openrouter.ai/api/v1",
         "default_headers": {"X-OpenRouter-Title": "AskRex Assistant"},
     }
@@ -530,7 +530,7 @@ def test_openrouter_fails_closed_without_its_own_key():
         llm_model=None,
         openrouter_model="openai/gpt-4o",
         openrouter_api_key=None,
-        openai_api_key="openai-key-must-not-be-reused",
+        openai_api_key="openai-key-must-not-be-reused",  # pragma: allowlist secret
     )
     model = LanguageModel(cfg)
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -15,6 +15,7 @@ from llm_client import (
     LanguageModel,
     register_strategy,
 )
+from rex.assistant_errors import ConfigurationError
 
 
 def test_language_model_generates_text():
@@ -486,3 +487,52 @@ def test_language_model_custom_strategy():
     result = model.generate("test")
 
     assert result == "dummy::test::5"
+
+
+def test_openrouter_uses_separate_key_base_url_and_openai_compatible_client(monkeypatch):
+    import rex.llm_client as llm_module
+
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(llm_module, "OPENAI_AVAILABLE", True)
+    monkeypatch.setattr(
+        llm_module,
+        "import_module",
+        lambda name: types.SimpleNamespace(OpenAI=FakeOpenAI),
+    )
+    cfg = AppConfig(
+        llm_provider="openrouter",
+        llm_model=None,
+        openrouter_model="openai/gpt-4o",
+        openrouter_api_key="router-key",
+        openrouter_base_url="https://openrouter.ai/api/v1",
+    )
+
+    model = LanguageModel(cfg, base_url="https://malicious.example.test/v1")
+    model._ensure_openai_client()
+
+    assert model.provider == "openrouter"
+    assert model.model_name == "openai/gpt-4o"
+    assert captured == {
+        "api_key": "router-key",
+        "base_url": "https://openrouter.ai/api/v1",
+        "default_headers": {"X-OpenRouter-Title": "AskRex Assistant"},
+    }
+
+
+def test_openrouter_fails_closed_without_its_own_key():
+    cfg = AppConfig(
+        llm_provider="openrouter",
+        llm_model=None,
+        openrouter_model="openai/gpt-4o",
+        openrouter_api_key=None,
+        openai_api_key="openai-key-must-not-be-reused",
+    )
+    model = LanguageModel(cfg)
+
+    with pytest.raises(ConfigurationError, match="Missing OpenRouter API key"):
+        model._ensure_openai_client()

--- a/tests/test_us010_setup_ipc.py
+++ b/tests/test_us010_setup_ipc.py
@@ -178,3 +178,10 @@ def test_bridge_script_uses_transactional_vault_persistence():
     content = _read(BRIDGE_SCRIPT)
     assert "persist_household_secrets" in content
     assert "_write_env_secrets" not in content
+
+
+def test_bridge_script_rejects_unsupported_llm_providers():
+    """Setup cannot persist an arbitrary provider string into runtime authority."""
+    content = _read(BRIDGE_SCRIPT)
+    assert "unsupported LLM provider" in content
+    assert '"openrouter"' in content


### PR DESCRIPTION
## Summary
- add OpenRouter as a first-class LLM provider using the existing OpenAI-compatible transport
- store `OPENROUTER_API_KEY` separately in the Windows credential vault
- keep provider/model configuration under the canonical `models.llm_provider` authority
- lock OpenRouter credentials to `https://openrouter.ai/api/v1`
- add Settings and first-run setup support, validation, schema/docs, and regression tests
- clear current high-severity GUI dependency advisories without forcing the React Router 7 migration

## Security properties
- OpenAI credentials are never reused for OpenRouter
- a runtime `base_url` override cannot redirect the OpenRouter credential
- unsupported setup provider strings fail closed
- secrets are not persisted to `rex_config.json` or GUI settings

## Validation
- Ruff and Black clean
- security release gate passed
- 197 targeted Python tests passed, 1 platform skip
- 69 GUI tests passed
- GUI lint: 0 errors (3 pre-existing warnings)
- TypeScript passed
- production build passed
- Node high-severity audit gate passed for both GUI surfaces
- JSON schema/example parsing passed

A live OpenRouter request was not made because no user credential was requested or exposed during development.