### PR TITLE
ci(tests): enforce skipped-test budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,9 +285,12 @@ jobs:
       - name: 🧪 Run tests with coverage
         shell: bash
         run: |
-          pytest -m "not slow and not audio and not gpu" --cov=rex --cov-fail-under=75 --cov-report=term-missing --cov-report=html --cov-report=xml 2>&1 | tee coverage.txt
+          pytest -m "not slow and not audio and not gpu" -rs --cov=rex --cov-fail-under=75 --cov-report=term-missing --cov-report=html --cov-report=xml 2>&1 | tee coverage.txt
         env:
           REX_FILE_LOGGING_ENABLED: "false"
+
+      - name: Enforce skipped-test budget
+        run: python scripts/check_skip_budget.py coverage.txt
 
       - name: 🔗 Run integration tests
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,17 @@ Targeted tests:
 
 pytest -q tests/<file>.py
 
+Skipped-test budget gate (the report must come from the primary CI marker set):
+
+```powershell
+pytest -m "not slow and not audio and not gpu" -rs -q | Tee-Object pytest.out
+python scripts/check_skip_budget.py pytest.out
+```
+
+The runtime budget is `scripts.check_skip_budget.SKIP_BUDGET`. When skips are
+removed, lower the budget in the same PR. Never raise it without updating
+`docs/testing/SKIPPED-TESTS-INVENTORY.md` with evidence and rationale.
+
 Electron GUI quality gates (run from `gui/`):
 
 ```powershell

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1368,6 +1368,8 @@ git status --porcelain -- ':!.coverage' ':!coverage.xml' ':!htmlcov/'
 
 ### US-037: Skip budget enforcement in CI
 
+**Implementation status (2026-08-04):** Implemented on `lead/us037-skip-budget` with a fail-closed parser, 119-test runtime budget, unit tests, CI enforcement, and documentation. The final GitHub-check criterion remains pending this PR.
+
 **Priority:** P0
 **Workstream:** CI / Tests
 **Description:** As a maintainer, I want CI to fail when total skipped tests exceed a documented budget.
@@ -1380,10 +1382,10 @@ git status --porcelain -- ':!.coverage' ':!coverage.xml' ':!htmlcov/'
 **Implementation notes:** Parse the pytest output (`-rs`) to count skipped tests. Compare against `SKIP_BUDGET` declared in `pyproject.toml` or a top-of-file constant. Default budget is the count from US-002.
 
 **Acceptance Criteria:**
-- [ ] Script enforces the budget and fails when exceeded.
-- [ ] Budget is documented and matches the post-US-002 count minus removals from US-039.
-- [ ] CI runs the script after the test suite.
-- [ ] All relevant GitHub checks pass.
+- [x] Script enforces the budget and fails when exceeded. *(`scripts/check_skip_budget.py`; parser and CLI regression tests in `tests/test_us037_skip_budget.py`.)*
+- [x] Budget is documented and matches the post-US-002 count minus removals from US-039. *(Runtime baseline: 119 skips from PR #347 CI run 968; source-site inventory remains separately classified.)*
+- [x] CI runs the script after the test suite. *(The Python 3.11 job captures `-rs` output to `coverage.txt`, then runs the gate before integration tests.)*
+- [ ] All relevant GitHub checks pass. *(Pending this story PR.)*
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1368,7 +1368,7 @@ git status --porcelain -- ':!.coverage' ':!coverage.xml' ':!htmlcov/'
 
 ### US-037: Skip budget enforcement in CI
 
-**Implementation status (2026-08-04):** Implemented on `lead/us037-skip-budget` with a fail-closed parser, 119-test runtime budget, unit tests, CI enforcement, and documentation. The final GitHub-check criterion remains pending this PR.
+**Reconciliation status (2026-08-04):** Complete. PR #348 implementation head `2579060` passed CI run 972 and commitlint run 631. The first Python runner was cancelled after an infrastructure-only Ubuntu package-install stall before project code ran; rerun job `92049529366` passed 8,304 tests with 119 skips, the 119-test budget gate, 36 integration tests, and the tracked-tree cleanliness check.
 
 **Priority:** P0
 **Workstream:** CI / Tests
@@ -1385,7 +1385,7 @@ git status --porcelain -- ':!.coverage' ':!coverage.xml' ':!htmlcov/'
 - [x] Script enforces the budget and fails when exceeded. *(`scripts/check_skip_budget.py`; parser and CLI regression tests in `tests/test_us037_skip_budget.py`.)*
 - [x] Budget is documented and matches the post-US-002 count minus removals from US-039. *(Runtime baseline: 119 skips from PR #347 CI run 968; source-site inventory remains separately classified.)*
 - [x] CI runs the script after the test suite. *(The Python 3.11 job captures `-rs` output to `coverage.txt`, then runs the gate before integration tests.)*
-- [ ] All relevant GitHub checks pass. *(Pending this story PR.)*
+- [x] All relevant GitHub checks pass. *(PR #348 head `2579060`: CI run 972 and commitlint run 631 succeeded; rerun job `92049529366` reported 8,304 passed / 119 skipped, and `check_skip_budget.py` passed at 119/119.)*
 
 **Validation commands:**
 ```bash

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1194,3 +1194,20 @@ Implemented a fail-closed runtime skipped-test budget gate:
 Baseline evidence: PR #347 CI run 968 reported 8,297 passed and 119 skipped
 in the primary Linux/Python 3.11 suite; 36 integration tests passed with 3
 skips. The final US-037 GitHub-check criterion remains pending the story PR.
+
+=== 2026-08-04 - US-037 GitHub verification close-out ===
+
+PR #348 implementation head `2579060` completed the required verification:
+- CI run 972: success
+- commitlint run 631: success
+- primary Python 3.11 suite: 8,304 passed, 119 skipped
+- skip-budget gate: `OK: pytest skipped 119 tests; budget is 119.`
+- integration suite: 36 passed, 3 skipped
+- tracked-tree cleanliness and coverage upload: passed
+
+The first Python runner was cancelled after remaining stuck in Ubuntu system
+dependency installation for more than ten minutes, before project dependencies,
+tests, or the new gate ran. Only that Python job was rerun; the isolated rerun
+completed successfully. This was infrastructure recovery, not code remediation.
+
+US-037 is now complete.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1179,3 +1179,18 @@ rule in normal operation: the wheel smoke job passed, CI run 966 and commitlint
 run 627 completed successfully, and the PR merged as `dac19c1`.
 
 US-033 is now complete.
+
+=== 2026-08-04 - US-037 skip-budget implementation ===
+
+Implemented a fail-closed runtime skipped-test budget gate:
+- added `scripts/check_skip_budget.py` with `SKIP_BUDGET = 119`
+- parser rejects missing/malformed pytest summaries
+- gate exits non-zero when the executed skip count exceeds the budget
+- added focused parser/CLI regression tests
+- primary CI suite now emits `-rs`, captures `coverage.txt`, and runs the gate
+- documented the runtime baseline separately from the static skip-site inventory
+- updated `CLAUDE.md` with the command and budget-maintenance rule
+
+Baseline evidence: PR #347 CI run 968 reported 8,297 passed and 119 skipped
+in the primary Linux/Python 3.11 suite; 36 integration tests passed with 3
+skips. The final US-037 GitHub-check criterion remains pending the story PR.

--- a/docs/testing/SKIPPED-TESTS-INVENTORY.md
+++ b/docs/testing/SKIPPED-TESTS-INVENTORY.md
@@ -2,6 +2,16 @@
 
 Generated for `US-002` on 2026-06-14 from the current `tests/` tree.
 
+## CI Runtime Skip Budget
+
+- **Budget:** 119 executed skipped tests in the primary Linux/Python 3.11 CI suite.
+- **Command scope:** `pytest -m "not slow and not audio and not gpu" -rs` with the existing coverage options.
+- **Evidence:** PR #347, CI run 968, primary suite: 8,297 passed and 119 skipped; integration suite: 36 passed and 3 skipped.
+- **Enforcement:** `python scripts/check_skip_budget.py coverage.txt` runs immediately after the primary suite and fails if the executed skip count exceeds 119 or the pytest summary cannot be parsed.
+- **Maintenance rule:** when a skipped test is removed, lower `SKIP_BUDGET` in the same PR. Any increase requires an updated inventory entry and explicit rationale.
+
+The runtime count is intentionally separate from the AST-confirmed source-site count below. A single skip marker can skip multiple parameterized tests, and platform or dependency guards may not execute on every runner.
+
 ## Validation Snapshot
 
 - `pytest --collect-only -q`: passed; collected 6635 tests, with 2 module-level skips during collection.

--- a/scripts/check_skip_budget.py
+++ b/scripts/check_skip_budget.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Enforce the documented pytest skipped-test budget (US-037).
+
+The CI test job captures pytest output with ``-rs`` and passes the report to
+this script. The gate fails closed when the report cannot be parsed and fails
+when the executed skip count exceeds the approved baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+SKIP_BUDGET = 119
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_COUNTER_RE = re.compile(
+    r"(?P<count>\d+)\s+"
+    r"(?P<label>passed|failed|errors?|skipped|deselected|warnings?|xfailed|xpassed)\b"
+)
+_DURATION_RE = re.compile(r"\bin\s+\d+(?:\.\d+)?s(?:\s|$)")
+_EXECUTION_LABELS = {"passed", "failed", "error", "errors"}
+
+
+def parse_pytest_summary(output: str) -> dict[str, int]:
+    """Return counters from the final pytest execution summary in *output*.
+
+    A valid summary must contain a duration and at least one execution counter.
+    This avoids mistaking ``SKIPPED [1]`` reason lines or unrelated prose for
+    the terminal summary.
+    """
+    for raw_line in reversed(output.splitlines()):
+        line = _ANSI_ESCAPE_RE.sub("", raw_line).strip(" =")
+        if not _DURATION_RE.search(line):
+            continue
+        counters = {
+            match.group("label"): int(match.group("count")) for match in _COUNTER_RE.finditer(line)
+        }
+        if counters.keys() & _EXECUTION_LABELS:
+            return counters
+    raise ValueError("pytest execution summary was not found")
+
+
+def count_skipped_tests(output: str) -> int:
+    """Return the skipped-test count from the final pytest summary."""
+    return parse_pytest_summary(output).get("skipped", 0)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path, help="Path to captured pytest output")
+    parser.add_argument(
+        "--budget",
+        type=int,
+        default=SKIP_BUDGET,
+        help=f"Maximum allowed skipped tests (default: {SKIP_BUDGET})",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.budget < 0:
+        print("ERROR: skip budget must be zero or greater.", file=sys.stderr)
+        return 2
+
+    try:
+        output = args.report.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        print(f"ERROR: unable to read pytest report {args.report}: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        skipped = count_skipped_tests(output)
+    except ValueError as exc:
+        print(f"ERROR: unable to parse {args.report}: {exc}", file=sys.stderr)
+        return 2
+
+    if skipped > args.budget:
+        excess = skipped - args.budget
+        print(
+            f"ERROR: pytest skipped {skipped} tests, exceeding the budget "
+            f"of {args.budget} by {excess}."
+        )
+        print(
+            "Reduce or repair skipped tests. Do not raise the budget without "
+            "updating the documented inventory and rationale."
+        )
+        return 1
+
+    print(f"OK: pytest skipped {skipped} tests; budget is {args.budget}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_us037_skip_budget.py
+++ b/tests/test_us037_skip_budget.py
@@ -1,0 +1,57 @@
+"""US-037: skipped-test budget parser and command gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts import check_skip_budget as checker
+
+
+def test_parse_summary_with_skips_and_ansi_noise() -> None:
+    output = (
+        "tests/test_example.py::test_optional SKIPPED [100%]\n"
+        "\x1b[32m= 8297 passed, 119 skipped, 282 warnings in 434.33s (0:07:14) =\x1b[0m\n"
+    )
+    assert checker.parse_pytest_summary(output) == {
+        "passed": 8297,
+        "skipped": 119,
+        "warnings": 282,
+    }
+    assert checker.count_skipped_tests(output) == 119
+
+
+def test_summary_without_skips_counts_zero() -> None:
+    assert checker.count_skipped_tests("= 12 passed in 0.42s =\n") == 0
+
+
+def test_final_pytest_summary_wins() -> None:
+    output = "= 4 passed, 9 skipped in 1.00s =\n= 7 passed, 2 skipped in 0.50s =\n"
+    assert checker.count_skipped_tests(output) == 2
+
+
+def test_missing_summary_fails_closed() -> None:
+    with pytest.raises(ValueError, match="summary was not found"):
+        checker.count_skipped_tests("tests/test_example.py SKIPPED [100%]\n")
+
+
+def test_main_passes_at_budget(tmp_path, capsys) -> None:
+    report = tmp_path / "pytest.out"
+    report.write_text("= 10 passed, 3 skipped in 0.20s =\n", encoding="utf-8")
+    assert checker.main([str(report), "--budget", "3"]) == 0
+    assert "skipped 3 tests; budget is 3" in capsys.readouterr().out
+
+
+def test_main_fails_when_budget_is_exceeded(tmp_path, capsys) -> None:
+    report = tmp_path / "pytest.out"
+    report.write_text("= 10 passed, 4 skipped in 0.20s =\n", encoding="utf-8")
+    assert checker.main([str(report), "--budget", "3"]) == 1
+    output = capsys.readouterr().out
+    assert "exceeding the budget of 3 by 1" in output
+    assert "Do not raise the budget" in output
+
+
+def test_main_rejects_unparseable_report(tmp_path, capsys) -> None:
+    report = tmp_path / "pytest.out"
+    report.write_text("collection interrupted\n", encoding="utf-8")
+    assert checker.main([str(report)]) == 2
+    assert "unable to parse" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- add a fail-closed parser for the final pytest execution summary
- enforce the primary Linux/Python 3.11 runtime skip budget at 119 tests
- add focused parser and CLI failure-mode tests
- capture `-rs` output in the existing Python CI job and run the budget gate before integration tests
- distinguish the runtime executed-test budget from the static AST skip-site inventory
- update `CLAUDE.md`, the production-readiness tracker, and its progress ledger

## Baseline evidence
PR #347, CI run 968:
- primary suite: 8,297 passed, 119 skipped
- integration suite: 36 passed, 3 skipped

## Local validation
- Python 3.11.9 targeted tests: 7 passed
- boundary 119/119: pass
- forced 119/118: exits 1
- malformed summary: fails closed
- full-repo Ruff: passed
- full CI Black scope: 1,015 files unchanged
- CI YAML parse: passed
- compileall scripts: passed
- security release gate: passed
- generated-artifact gate: passed
- pre-commit Ruff, Black, and detect-secrets: passed
- `git diff --check`: passed

## Tracker state
The implementation criteria are complete. The final US-037 GitHub-check criterion remains pending until this PR's complete checks pass.