### PR TITLE
test(inventory): classify skipped-test actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: 🗑️ Check no generated artifacts are committed
         run: python scripts/check_no_generated_artifacts.py
 
+      - name: Validate skipped-test inventory
+        run: python scripts/check_skip_inventory.py
+
   security-audit:
     name: Security Audit Gate
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,6 +398,17 @@ The runtime budget is `scripts.check_skip_budget.SKIP_BUDGET`. When skips are
 removed, lower the budget in the same PR. Never raise it without updating
 `docs/testing/SKIPPED-TESTS-INVENTORY.md` with evidence and rationale.
 
+Validate the source-site inventory after adding, removing, or moving any pytest
+skip call/decorator:
+
+```powershell
+python scripts/check_skip_inventory.py
+```
+
+Every inventory row must use one action: `keep`, `fix`, `replace`, or `archive`.
+Permanent guards need a written rationale; non-trivial actions need a non-circular
+`US-###` follow-up. Update the inventory in the same PR as skip-site changes.
+
 Electron GUI quality gates (run from `gui/`):
 
 ```powershell

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1397,6 +1397,8 @@ python scripts/check_skip_budget.py /tmp/pytest.out
 
 ### US-038: Classify each skipped test and link to a follow-up if needed
 
+**Implementation status (2026-08-04):** Implemented on `lead/us038-skip-actions`. The current 143 executable skip sites were regenerated from AST, assigned explicit actions, linked to US-039 or US-040 where work remains, and protected by a CI drift validator. Final GitHub verification remains pending.
+
 **Priority:** P1
 **Workstream:** Tests / Docs
 **Description:** As a maintainer, I want every entry in the skip inventory tied to an action (keep, remove, replace, fix).
@@ -1406,9 +1408,9 @@ python scripts/check_skip_budget.py /tmp/pytest.out
 - `tests/` (annotation only)
 
 **Acceptance Criteria:**
-- [ ] Every inventory row has an action and, where action is non-trivial, a follow-up story ID.
-- [ ] Inventory is committed and current.
-- [ ] All relevant GitHub checks pass.
+- [x] Every inventory row has an action and, where action is non-trivial, a follow-up story ID. *(143 rows: 35 `keep`, 92 `fix`, 2 `replace`, 14 `archive`; non-trivial rows link to US-039 or US-040.)*
+- [x] Inventory is committed and current. *(`scripts/check_skip_inventory.py` verifies exact file, line, type, reason, action, and follow-up parity against the current `tests/` AST.)*
+- [ ] All relevant GitHub checks pass. *(Pending this story PR.)*
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1397,7 +1397,7 @@ python scripts/check_skip_budget.py /tmp/pytest.out
 
 ### US-038: Classify each skipped test and link to a follow-up if needed
 
-**Implementation status (2026-08-04):** Implemented on `lead/us038-skip-actions`. The current 143 executable skip sites were regenerated from AST, assigned explicit actions, linked to US-039 or US-040 where work remains, and protected by a CI drift validator. Final GitHub verification remains pending.
+**Implementation status (2026-08-04):** Complete on `lead/us038-skip-actions`. The current 143 executable skip sites were regenerated from AST, assigned explicit actions, linked to US-039 or US-040 where work remains, protected by a CI drift validator, and verified by all relevant GitHub checks.
 
 **Priority:** P1
 **Workstream:** Tests / Docs
@@ -1410,12 +1410,20 @@ python scripts/check_skip_budget.py /tmp/pytest.out
 **Acceptance Criteria:**
 - [x] Every inventory row has an action and, where action is non-trivial, a follow-up story ID. *(143 rows: 35 `keep`, 92 `fix`, 2 `replace`, 14 `archive`; non-trivial rows link to US-039 or US-040.)*
 - [x] Inventory is committed and current. *(`scripts/check_skip_inventory.py` verifies exact file, line, type, reason, action, and follow-up parity against the current `tests/` AST.)*
-- [ ] All relevant GitHub checks pass. *(Pending this story PR.)*
+- [x] All relevant GitHub checks pass. *(PR #349 head `996b076`; CI attempt 2 passed after an unnecessary operator cancellation/retry of the first still-running Python job.)*
 
 **Validation commands:**
 ```bash
 grep -E "TODO|FIXME|none" docs/testing/SKIPPED-TESTS-INVENTORY.md || echo "ok"
 ```
+
+**US-038 remote verification evidence (2026-08-04):**
+- PR #349 head `996b076` passed CodeFactor, GitGuardian, commitlint, Ruff, Black, mypy, GUI lint/typecheck/tests/build, dependency audits, pre-commit, secret scan, security release gate, raw-API guard, wheel contents smoke, and the skip-inventory validator.
+- Python 3.11 coverage suite: 8,308 passed, 119 skipped; 82.36% coverage.
+- Skip budget: 119 skipped against a budget of 119.
+- Integration suite: 36 passed, 3 skipped.
+- Tests left the tracked working tree clean and the coverage artifact uploaded successfully.
+- The first Python job was cancelled while still running because its UTC timestamp was misread as five hours old; it had actually run for only about six minutes. Attempt 2 supplied the valid remote evidence.
 
 ---
 

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1211,3 +1211,23 @@ tests, or the new gate ran. Only that Python job was rerun; the isolated rerun
 completed successfully. This was infrastructure recovery, not code remediation.
 
 US-037 is now complete.
+
+=== 2026-08-04 - US-038 skip inventory actions ===
+
+Regenerated the skipped-test inventory from the current test AST and found:
+- 143 executable skip sites
+- 29 stale line locations in the prior snapshot
+- 32 current locations absent from the prior snapshot
+- three net-new Windows/DPAPI platform guards
+
+Every row now carries one explicit action:
+- 35 `keep` rows for optional-dependency or platform guards
+- 92 `fix` rows linked to US-040
+- 2 `replace` rows linked to US-040
+- 14 `archive` rows linked to US-039
+
+Added `scripts/check_skip_inventory.py`, focused regression tests, and a CI lint
+step. The validator fails on missing/stale rows, reason drift, invalid actions,
+missing permanent rationales, and circular or absent follow-up stories. Updated
+`CLAUDE.md` with the required maintenance command and rule. Final GitHub checks
+remain pending the story PR.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1231,3 +1231,17 @@ step. The validator fails on missing/stale rows, reason drift, invalid actions,
 missing permanent rationales, and circular or absent follow-up stories. Updated
 `CLAUDE.md` with the required maintenance command and rule. Final GitHub checks
 remain pending the story PR.
+
+
+=== 2026-08-04 - US-038 remote verification complete ===
+
+PR #349 head `996b076` passed all relevant checks. The Python 3.11 suite
+reported 8,308 passed and 119 skipped with 82.36% coverage; the skip-budget
+gate held at 119; integration tests reported 36 passed and 3 skipped; and the
+tracked working tree remained clean. CodeFactor also passed after the validator
+policy logic was split into a focused helper.
+
+The first Python job was cancelled unnecessarily after its UTC timestamp was
+misread as indicating a five-hour runtime. It had actually run for roughly six
+minutes. Attempt 2 completed successfully and is the authoritative evidence.
+US-038 is complete.

--- a/docs/testing/SKIPPED-TESTS-INVENTORY.md
+++ b/docs/testing/SKIPPED-TESTS-INVENTORY.md
@@ -1,174 +1,178 @@
 # Skipped Tests Inventory
 
-Generated for `US-002` on 2026-06-14 from the current `tests/` tree.
+Regenerated for `US-038` on 2026-08-04 from the current executable skip sites under `tests/`.
 
 ## CI Runtime Skip Budget
 
 - **Budget:** 119 executed skipped tests in the primary Linux/Python 3.11 CI suite.
 - **Command scope:** `pytest -m "not slow and not audio and not gpu" -rs` with the existing coverage options.
-- **Evidence:** PR #347, CI run 968, primary suite: 8,297 passed and 119 skipped; integration suite: 36 passed and 3 skipped.
+- **Evidence:** PR #348, CI run 972 rerun job `92049529366`: 8,304 passed and 119 skipped; integration suite: 36 passed and 3 skipped.
 - **Enforcement:** `python scripts/check_skip_budget.py coverage.txt` runs immediately after the primary suite and fails if the executed skip count exceeds 119 or the pytest summary cannot be parsed.
 - **Maintenance rule:** when a skipped test is removed, lower `SKIP_BUDGET` in the same PR. Any increase requires an updated inventory entry and explicit rationale.
 
-The runtime count is intentionally separate from the AST-confirmed source-site count below. A single skip marker can skip multiple parameterized tests, and platform or dependency guards may not execute on every runner.
+The runtime count is intentionally separate from the executable source-site count below. A single skip marker can skip multiple parameterized tests, and platform or dependency guards may not execute on every runner.
 
 ## Validation Snapshot
 
-- `pytest --collect-only -q`: passed; collected 6635 tests, with 2 module-level skips during collection.
-- `rg -n "pytest\.mark\.skip|pytest\.skip\b" tests | Measure-Object`: 143 grep-style matches.
-- AST-confirmed skip marker/call sites inventoried below: 140.
-- Grep-style matches excluded from the inventory because they are not executable skip sites: `tests/test_us129_smoke.py:369`, `tests/test_us129_smoke.py:370`, `tests/test_us174.py:4`.
+- `python scripts/check_skip_inventory.py`: passed; 143 executable skip sites match the inventory exactly by file, line, type, and reason.
+- Every row has one explicit action: `keep`, `fix`, `replace`, or `archive`.
+- Permanent guards retain a written rationale; all non-trivial actions link to a non-circular follow-up story.
+- The previous 140-row snapshot had 29 stale line locations and missed 32 current locations; regeneration resolved the drift and added three current Windows/DPAPI platform guards.
 
-## Classification Summary
+## Classification and Action Summary
 
-| Classification | Count | Follow-up |
-|---|---:|---|
-| `optional-dep-skip` | 22 | permanent: optional dependency/tool/environment guard |
-| `platform-skip` | 10 | permanent: platform/runtime-specific guard |
-| `retired-surface-skip` | 14 | US-039 |
-| `temporary-bug-skip` | 94 | US-038 |
+| Classification | Count | Action | Follow-up |
+|---|---:|---|---|
+| `optional-dep-skip` | 22 | `keep` | permanent: optional dependency/tool/environment guard |
+| `platform-skip` | 13 | `keep` | permanent: platform/runtime-specific guard |
+| `retired-surface-skip` | 14 | `archive` | US-039 |
+| `temporary-bug-skip` | 92 | `fix` | US-040 |
+| `temporary-bug-skip` | 2 | `replace` | US-040 |
 
 ## Inventory
 
-| File | Line | Skip type | Skip reason text | Classification | Follow-up |
-|---|---:|---|---|---|---|
-| `tests/conftest.py` | 160 | `skip` | No async test runner installed (anyio or pytest-asyncio required) | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_audio_device_selection.py` | 9 | `pytest.skip` | f"sounddevice unavailable: {exc}" | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_calendar_service.py` | 131 | `skipif` | CalendarService event-bus style API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 184 | `skipif` | CalendarEvent is not a pydantic-style model in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 211 | `skipif` | CalendarEvent.overlaps_with not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 241 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 251 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 261 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 270 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 287 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 299 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 309 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 337 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 352 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 367 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 383 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 393 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 403 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 422 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 431 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 440 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 463 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 485 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 495 | `skipif` | CalendarService.get_upcoming_events not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 506 | `skipif` | CalendarService.get_upcoming_events not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 517 | `skipif` | CalendarService.get_all_events not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 528 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_calendar_service.py` | 552 | `skipif` | CalendarEvent serialization test applies to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 96 | `skipif` | EmailService event-bus style API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 187 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 212 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 222 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 232 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 241 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 253 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 263 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 273 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 290 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 299 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 308 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 326 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 344 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 362 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 380 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 399 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 417 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 430 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 440 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 450 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 464 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 474 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 498 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_email_service.py` | 528 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 79 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 96 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 123 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 137 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 151 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 161 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 173 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 189 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 210 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 233 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 259 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 274 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_event_bus.py` | 293 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_install_scripts.py` | 15 | `pytest.skip` | bash not available | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_install_scripts.py` | 24 | `pytest.skip` | bash not usable on Windows | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_openclaw_root_voice_loop_flag.py` | 19 | `skipif` | openwakeword is not installed | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_openclaw_root_voice_loop_text_mode.py` | 20 | `skipif` | openwakeword is not installed | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_scheduler.py` | 90 | `skipif` | Legacy Scheduler(storage_path, now_func) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 115 | `skipif` | Legacy Scheduler(storage_path, now_func) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 157 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 167 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 191 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 211 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 225 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 241 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 254 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 266 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 279 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 311 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 337 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 363 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 391 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 407 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 427 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 450 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 463 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 493 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 502 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_scheduler.py` | 521 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | US-038 |
-| `tests/test_skill_loader.py` | 213 | `pytest.skip` | example_weather_skill.py not found | `temporary-bug-skip` | US-038 |
-| `tests/test_transformers_shim.py` | 30 | `pytest.skip` | f"transformers not installed or BeamSearchScorer unavailable: {e}" | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_transformers_shim.py` | 48 | `pytest.skip` | transformers not installed | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_transformers_shim.py` | 63 | `pytest.skip` | transformers not installed | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us011_voice_deps.py` | 43 | `pytest.skip` | edge-tts not installed in this environment | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us011_voice_deps.py` | 53 | `pytest.skip` | pyttsx3 not installed in this environment | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us017_stt_backend.py` | 72 | `skipif` | numpy required for SpeechToText.transcribe | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us027_device_approval.py` | 129 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_us027_device_approval.py` | 161 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_us027_device_approval.py` | 168 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_us027_device_approval.py` | 180 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_us027_device_approval.py` | 205 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_us027_device_approval.py` | 230 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_us030_clarification.py` | 184 | `pytest.skip` | HABridge not importable (requests not installed) | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us030_clarification.py` | 204 | `pytest.skip` | HABridge not importable (requests not installed) | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us033_acknowledgment.py` | 11 | `skipif` | numpy not installed | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us034_progressive_response.py` | 22 | `skipif` | numpy not installed | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us053_secret_management.py` | 125 | `pytest.skip` | .env.example not found | `temporary-bug-skip` | US-038 |
-| `tests/test_us071_debug_mode.py` | 18 | `skipif` | rex.cli unavailable on this Python version | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_us074_voice_loop_pipeline.py` | 33 | `skipif` | numpy not installed | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us096_secret_scan.py` | 130 | `pytest.skip` | PyYAML not installed; skipping YAML parse test | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us098_test_coverage.py` | 28 | `pytest.skip` | coverage.txt has not been generated yet | `temporary-bug-skip` | US-038 |
-| `tests/test_us098_test_coverage.py` | 31 | `pytest.skip` | coverage.txt is still being written by the current coverage run | `temporary-bug-skip` | US-038 |
-| `tests/test_us120_performance_baseline.py` | 180 | `pytest.skip` | docs/performance-baseline.md not yet created | `temporary-bug-skip` | US-038 |
-| `tests/test_us120_performance_baseline.py` | 187 | `pytest.skip` | docs/performance-baseline.md not yet created | `temporary-bug-skip` | US-038 |
-| `tests/test_us129_smoke.py` | 54 | `pytest.skip` | Local Rex instance not running — start with 'python flask_proxy.py' to exercise live-server smoke tests | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us129_smoke.py` | 323 | `pytest.skip` | f"agent_server optional dependency not available: {exc}" | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us139_install_scripts.py` | 139 | `skipif` | executable bit not relevant on Windows | `platform-skip` | permanent: platform/runtime-specific guard |
-| `tests/test_us140_full_extra.py` | 138 | `pytest.skip` | install.sh not present | `temporary-bug-skip` | US-038 |
-| `tests/test_us140_full_extra.py` | 145 | `pytest.skip` | install.ps1 not present | `temporary-bug-skip` | US-038 |
-| `tests/test_us149_gui_shell.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us150_design_system.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us151_nav_state.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us152_chat_message_list.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us153_chat_input.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us157_voice_waveform.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us161_schedule_coming_up.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us163_overview_quick_actions.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us164_hover_focus_states.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us165_loading_error_states.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us166_responsive_layout.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us172_thinking_indicator.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us174.py` | 11 | `skip` | dashboard routes retired — see test_us174_voice_max_tokens.py | `retired-surface-skip` | US-039 |
-| `tests/test_us174_voice_max_tokens.py` | 129 | `skip` | rex/dashboard/routes.py retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | US-039 |
-| `tests/test_us304_chat_stream_electron_verification.py` | 15 | `skipif` | electron.cmd not found | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us304_chat_stream_electron_verification.py` | 30 | `pytest.skip` | f"Electron verification unavailable: {exc}" | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_voice_id_mvp.py` | 590 | `pytest.skip` | speechbrain is installed — cannot test missing-dep path | `optional-dep-skip` | permanent: optional dependency/tool/environment guard |
-| `tests/test_windows_service.py` | 10 | `pytest.skip` | rex.windows_service is Windows-only | `platform-skip` | permanent: platform/runtime-specific guard |
+| File | Line | Skip type | Skip reason text | Classification | Action | Follow-up |
+|---|---:|---|---|---|---|---|
+| `tests/conftest.py` | 221 | `skip` | No async test runner installed (anyio or pytest-asyncio required) | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_audio_device_selection.py` | 9 | `pytest.skip` | f"sounddevice unavailable: {exc}" | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_calendar_service.py` | 131 | `skipif` | CalendarService event-bus style API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 185 | `skipif` | CalendarEvent is not a pydantic-style model in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 212 | `skipif` | CalendarEvent.overlaps_with not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 242 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 252 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 262 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 271 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 288 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 300 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 310 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 338 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 353 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 368 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 384 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 394 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 404 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 423 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 432 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 441 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 464 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 486 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 496 | `skipif` | CalendarService.get_upcoming_events not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 507 | `skipif` | CalendarService.get_upcoming_events not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 518 | `skipif` | CalendarService.get_all_events not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 529 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 553 | `skipif` | CalendarEvent serialization test applies to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_credential_vault.py` | 134 | `pytest.skip` | This assertion applies to non-Windows production | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_credential_vault.py` | 139 | `skipif` | DPAPI vault is Windows-only | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_email_account_isolation.py` | 67 | `skipif` | Real DPAPI isolation is Windows-only | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_email_service.py` | 96 | `skipif` | EmailService event-bus style API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 187 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 212 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 222 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 232 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 241 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 253 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 263 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 273 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 290 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 299 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 308 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 326 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 344 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 362 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 380 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 399 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 417 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 430 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 440 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 450 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 464 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 474 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 498 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 528 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 79 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 96 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 123 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 137 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 151 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 161 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 173 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 189 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 210 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 233 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 259 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 274 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_event_bus.py` | 293 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_install_scripts.py` | 15 | `pytest.skip` | bash not available | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_install_scripts.py` | 24 | `pytest.skip` | bash not usable on Windows | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_openclaw_root_voice_loop_flag.py` | 19 | `skipif` | openwakeword is not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_openclaw_root_voice_loop_text_mode.py` | 20 | `skipif` | openwakeword is not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_scheduler.py` | 90 | `skipif` | Legacy Scheduler(storage_path, now_func) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 115 | `skipif` | Legacy Scheduler(storage_path, now_func) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 157 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 167 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 191 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 211 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 225 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 241 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 254 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 266 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 279 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 311 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 337 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 363 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 391 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 407 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 427 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 450 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 463 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 493 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 502 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 521 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_skill_loader.py` | 213 | `pytest.skip` | example_weather_skill.py not found | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_transformers_shim.py` | 30 | `pytest.skip` | f"transformers not installed or BeamSearchScorer unavailable: {e}" | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_transformers_shim.py` | 48 | `pytest.skip` | transformers not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_transformers_shim.py` | 63 | `pytest.skip` | transformers not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us011_voice_deps.py` | 43 | `pytest.skip` | edge-tts not installed in this environment | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us011_voice_deps.py` | 53 | `pytest.skip` | pyttsx3 not installed in this environment | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us017_stt_backend.py` | 72 | `skipif` | numpy required for SpeechToText.transcribe | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us027_device_approval.py` | 129 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_us027_device_approval.py` | 161 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_us027_device_approval.py` | 168 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_us027_device_approval.py` | 180 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_us027_device_approval.py` | 205 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_us027_device_approval.py` | 230 | `skipif` | rex.cli requires Python 3.11 | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_us030_clarification.py` | 184 | `pytest.skip` | HABridge not importable (requests not installed) | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us030_clarification.py` | 204 | `pytest.skip` | HABridge not importable (requests not installed) | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us033_acknowledgment.py` | 11 | `skipif` | numpy not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us034_progressive_response.py` | 22 | `skipif` | numpy not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us053_secret_management.py` | 125 | `pytest.skip` | .env.example not found | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_us071_debug_mode.py` | 18 | `skipif` | rex.cli unavailable on this Python version | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_us074_voice_loop_pipeline.py` | 33 | `skipif` | numpy not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us096_secret_scan.py` | 171 | `pytest.skip` | PyYAML not installed; skipping YAML parse test | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us098_test_coverage.py` | 28 | `pytest.skip` | coverage.txt has not been generated yet | `temporary-bug-skip` | `replace` | `US-040` |
+| `tests/test_us098_test_coverage.py` | 31 | `pytest.skip` | coverage.txt is still being written by the current coverage run | `temporary-bug-skip` | `replace` | `US-040` |
+| `tests/test_us120_performance_baseline.py` | 180 | `pytest.skip` | docs/performance-baseline.md not yet created | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_us120_performance_baseline.py` | 187 | `pytest.skip` | docs/performance-baseline.md not yet created | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_us129_smoke.py` | 54 | `pytest.skip` | Local Rex instance not running — start with 'python flask_proxy.py' to exercise live-server smoke tests | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us129_smoke.py` | 323 | `pytest.skip` | f"agent_server optional dependency not available: {exc}" | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us139_install_scripts.py` | 139 | `skipif` | executable bit not relevant on Windows | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
+| `tests/test_us140_full_extra.py` | 138 | `pytest.skip` | install.sh not present | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_us140_full_extra.py` | 145 | `pytest.skip` | install.ps1 not present | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_us149_gui_shell.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us150_design_system.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us151_nav_state.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us152_chat_message_list.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us153_chat_input.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us157_voice_waveform.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us161_schedule_coming_up.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us163_overview_quick_actions.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us164_hover_focus_states.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us165_loading_error_states.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us166_responsive_layout.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us172_thinking_indicator.py` | 10 | `skip` | rex/dashboard retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us174.py` | 11 | `skip` | dashboard routes retired — see test_us174_voice_max_tokens.py | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us174_voice_max_tokens.py` | 129 | `skip` | rex/dashboard/routes.py retired in OpenClaw migration (US-P7-014) | `retired-surface-skip` | `archive` | `US-039` |
+| `tests/test_us304_chat_stream_electron_verification.py` | 16 | `skipif` | electron.cmd not found | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_us304_chat_stream_electron_verification.py` | 41 | `pytest.skip` | f"Electron verification unavailable: {exc}" | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_voice_id_mvp.py` | 590 | `pytest.skip` | speechbrain is installed — cannot test missing-dep path | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
+| `tests/test_windows_service.py` | 10 | `pytest.skip` | rex.windows_service is Windows-only | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |

--- a/scripts/check_skip_inventory.py
+++ b/scripts/check_skip_inventory.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Validate the skipped-test inventory against executable pytest skip sites.
+
+US-038 requires every current skip site to carry an explicit action and a
+non-circular follow-up when work remains. The checker uses only the standard
+library so it can run in the lightweight CI lint job.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+INVENTORY_PATH = Path("docs/testing/SKIPPED-TESTS-INVENTORY.md")
+TESTS_ROOT = Path("tests")
+VALID_ACTIONS = {"keep", "fix", "replace", "archive"}
+VALID_CLASSIFICATIONS = {
+    "optional-dep-skip",
+    "platform-skip",
+    "retired-surface-skip",
+    "temporary-bug-skip",
+}
+FOLLOW_UP_RE = re.compile(r"^US-\d+$")
+
+
+@dataclass(frozen=True, order=True)
+class SkipSite:
+    path: str
+    line: int
+    skip_type: str
+    reason: str
+
+
+@dataclass(frozen=True, order=True)
+class InventoryRow:
+    path: str
+    line: int
+    skip_type: str
+    reason: str
+    classification: str
+    action: str
+    follow_up: str
+
+    @property
+    def site(self) -> SkipSite:
+        return SkipSite(self.path, self.line, self.skip_type, self.reason)
+
+
+def _dotted_name(node: ast.AST) -> str:
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _reason_node(call: ast.Call, skip_type: str) -> ast.AST | None:
+    for keyword in call.keywords:
+        if keyword.arg == "reason":
+            return keyword.value
+    if skip_type == "skipif" and len(call.args) >= 2:
+        return call.args[1]
+    if skip_type in {"skip", "pytest.skip"} and call.args:
+        return call.args[0]
+    return None
+
+
+def _reason_text(source: str, node: ast.AST | None) -> str:
+    if node is None:
+        return "<reason missing>"
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return (ast.get_source_segment(source, node) or ast.unparse(node)).strip()
+
+
+def _skip_type(call: ast.Call) -> str | None:
+    name = _dotted_name(call.func)
+    if name == "pytest.skip":
+        return "pytest.skip"
+    if name == "skip":
+        return "skip"
+    if name == "pytest.mark.skip" or name.endswith(".mark.skip"):
+        return "skip"
+    if name == "pytest.mark.skipif" or name.endswith(".mark.skipif"):
+        return "skipif"
+    return None
+
+
+def scan_skip_sites(tests_root: Path = TESTS_ROOT) -> list[SkipSite]:
+    """Return all executable pytest skip calls/decorators under *tests_root*."""
+    sites: list[SkipSite] = []
+    for path in sorted(tests_root.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            skip_type = _skip_type(node)
+            if skip_type is None:
+                continue
+            reason = _reason_text(source, _reason_node(node, skip_type))
+            sites.append(SkipSite(path.as_posix(), node.lineno, skip_type, reason))
+    return sorted(sites)
+
+
+def parse_inventory(path: Path = INVENTORY_PATH) -> list[InventoryRow]:
+    """Parse the seven-column Markdown inventory table."""
+    rows: list[InventoryRow] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.startswith("| `tests/"):
+            continue
+        parts = [part.strip() for part in line.strip("|").split("|")]
+        if len(parts) != 7:
+            raise ValueError(
+                f"{path}:{line_number}: expected 7 inventory columns, found {len(parts)}"
+            )
+        file_text, line_text, skip_type, reason, classification, action, follow_up = parts
+        rows.append(
+            InventoryRow(
+                path=file_text.strip("`"),
+                line=int(line_text),
+                skip_type=skip_type.strip("`"),
+                reason=reason,
+                classification=classification.strip("`"),
+                action=action.strip("`"),
+                follow_up=follow_up.strip("`"),
+            )
+        )
+    return sorted(rows)
+
+
+def validate_inventory(
+    actual_sites: list[SkipSite], inventory_rows: list[InventoryRow]
+) -> list[str]:
+    """Return actionable inventory validation errors."""
+    errors: list[str] = []
+    actual_by_location = {(site.path, site.line, site.skip_type): site for site in actual_sites}
+    inventory_by_location = {(row.path, row.line, row.skip_type): row for row in inventory_rows}
+
+    missing = sorted(actual_by_location.keys() - inventory_by_location.keys())
+    stale = sorted(inventory_by_location.keys() - actual_by_location.keys())
+    for path, line, skip_type in missing:
+        errors.append(f"missing inventory row: {path}:{line} ({skip_type})")
+    for path, line, skip_type in stale:
+        errors.append(f"stale inventory row: {path}:{line} ({skip_type})")
+
+    for location in sorted(actual_by_location.keys() & inventory_by_location.keys()):
+        site = actual_by_location[location]
+        row = inventory_by_location[location]
+        if row.reason != site.reason:
+            errors.append(
+                f"reason drift at {site.path}:{site.line}: "
+                f"inventory={row.reason!r}, source={site.reason!r}"
+            )
+        if row.classification not in VALID_CLASSIFICATIONS:
+            errors.append(
+                f"invalid classification at {row.path}:{row.line}: {row.classification!r}"
+            )
+        if row.action not in VALID_ACTIONS:
+            errors.append(f"invalid action at {row.path}:{row.line}: {row.action!r}")
+            continue
+        if row.classification in {"optional-dep-skip", "platform-skip"}:
+            if row.action != "keep":
+                errors.append(f"permanent guard must use keep at {row.path}:{row.line}")
+            if not row.follow_up.startswith("permanent:"):
+                errors.append(f"kept guard needs permanent rationale at {row.path}:{row.line}")
+        elif row.classification == "retired-surface-skip":
+            if row.action != "archive" or row.follow_up != "US-039":
+                errors.append(f"retired surface must archive under US-039 at {row.path}:{row.line}")
+        elif row.classification == "temporary-bug-skip":
+            if row.action not in {"fix", "replace"}:
+                errors.append(f"temporary bug must use fix/replace at {row.path}:{row.line}")
+            if not FOLLOW_UP_RE.fullmatch(row.follow_up) or row.follow_up == "US-038":
+                errors.append(f"temporary bug needs non-circular story ID at {row.path}:{row.line}")
+    return errors
+
+
+def main() -> int:
+    try:
+        sites = scan_skip_sites()
+        rows = parse_inventory()
+    except (OSError, SyntaxError, ValueError) as exc:
+        print(f"ERROR: unable to validate skip inventory: {exc}", file=sys.stderr)
+        return 2
+    errors = validate_inventory(sites, rows)
+    if errors:
+        print("ERROR: skipped-test inventory is out of date:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+    print(f"OK: {len(rows)} executable skip sites are current and have explicit actions.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_skip_inventory.py
+++ b/scripts/check_skip_inventory.py
@@ -134,6 +134,30 @@ def parse_inventory(path: Path = INVENTORY_PATH) -> list[InventoryRow]:
     return sorted(rows)
 
 
+def _validate_row_policy(row: InventoryRow) -> list[str]:
+    """Return classification/action/follow-up errors for one inventory row."""
+    errors: list[str] = []
+    if row.classification not in VALID_CLASSIFICATIONS:
+        return [f"invalid classification at {row.path}:{row.line}: {row.classification!r}"]
+    if row.action not in VALID_ACTIONS:
+        return [f"invalid action at {row.path}:{row.line}: {row.action!r}"]
+
+    if row.classification in {"optional-dep-skip", "platform-skip"}:
+        if row.action != "keep":
+            errors.append(f"permanent guard must use keep at {row.path}:{row.line}")
+        if not row.follow_up.startswith("permanent:"):
+            errors.append(f"kept guard needs permanent rationale at {row.path}:{row.line}")
+    elif row.classification == "retired-surface-skip":
+        if row.action != "archive" or row.follow_up != "US-039":
+            errors.append(f"retired surface must archive under US-039 at {row.path}:{row.line}")
+    elif row.classification == "temporary-bug-skip":
+        if row.action not in {"fix", "replace"}:
+            errors.append(f"temporary bug must use fix/replace at {row.path}:{row.line}")
+        if not FOLLOW_UP_RE.fullmatch(row.follow_up) or row.follow_up == "US-038":
+            errors.append(f"temporary bug needs non-circular story ID at {row.path}:{row.line}")
+    return errors
+
+
 def validate_inventory(
     actual_sites: list[SkipSite], inventory_rows: list[InventoryRow]
 ) -> list[str]:
@@ -157,26 +181,7 @@ def validate_inventory(
                 f"reason drift at {site.path}:{site.line}: "
                 f"inventory={row.reason!r}, source={site.reason!r}"
             )
-        if row.classification not in VALID_CLASSIFICATIONS:
-            errors.append(
-                f"invalid classification at {row.path}:{row.line}: {row.classification!r}"
-            )
-        if row.action not in VALID_ACTIONS:
-            errors.append(f"invalid action at {row.path}:{row.line}: {row.action!r}")
-            continue
-        if row.classification in {"optional-dep-skip", "platform-skip"}:
-            if row.action != "keep":
-                errors.append(f"permanent guard must use keep at {row.path}:{row.line}")
-            if not row.follow_up.startswith("permanent:"):
-                errors.append(f"kept guard needs permanent rationale at {row.path}:{row.line}")
-        elif row.classification == "retired-surface-skip":
-            if row.action != "archive" or row.follow_up != "US-039":
-                errors.append(f"retired surface must archive under US-039 at {row.path}:{row.line}")
-        elif row.classification == "temporary-bug-skip":
-            if row.action not in {"fix", "replace"}:
-                errors.append(f"temporary bug must use fix/replace at {row.path}:{row.line}")
-            if not FOLLOW_UP_RE.fullmatch(row.follow_up) or row.follow_up == "US-038":
-                errors.append(f"temporary bug needs non-circular story ID at {row.path}:{row.line}")
+        errors.extend(_validate_row_policy(row))
     return errors
 
 

--- a/tests/test_us038_skip_inventory.py
+++ b/tests/test_us038_skip_inventory.py
@@ -1,0 +1,70 @@
+"""US-038: skipped-test inventory classification and drift checks."""
+
+from __future__ import annotations
+
+from scripts import check_skip_inventory as checker
+
+
+def test_scanner_extracts_skip_decorators_and_runtime_calls(tmp_path) -> None:
+    tests_root = tmp_path / "tests"
+    tests_root.mkdir()
+    (tests_root / "test_example.py").write_text(
+        """import pytest
+
+@pytest.mark.skipif(True, reason="platform-only")
+def test_guarded():
+    pass
+
+def test_optional():
+    tool = "tool"
+    pytest.skip(f"missing {tool}")
+""",
+        encoding="utf-8",
+    )
+
+    sites = checker.scan_skip_sites(tests_root)
+    assert [(site.line, site.skip_type, site.reason) for site in sites] == [
+        (3, "skipif", "platform-only"),
+        (9, "pytest.skip", 'f"missing {tool}"'),
+    ]
+
+
+def test_validator_rejects_circular_temporary_follow_up() -> None:
+    site = checker.SkipSite("tests/test_example.py", 3, "skipif", "broken")
+    row = checker.InventoryRow(
+        path=site.path,
+        line=site.line,
+        skip_type=site.skip_type,
+        reason=site.reason,
+        classification="temporary-bug-skip",
+        action="fix",
+        follow_up="US-038",
+    )
+    errors = checker.validate_inventory([site], [row])
+    assert any("non-circular story ID" in error for error in errors)
+
+
+def test_validator_rejects_missing_and_stale_rows() -> None:
+    actual = checker.SkipSite("tests/test_current.py", 10, "skip", "current")
+    stale = checker.InventoryRow(
+        path="tests/test_old.py",
+        line=5,
+        skip_type="skip",
+        reason="old",
+        classification="retired-surface-skip",
+        action="archive",
+        follow_up="US-039",
+    )
+    errors = checker.validate_inventory([actual], [stale])
+    assert any("missing inventory row" in error for error in errors)
+    assert any("stale inventory row" in error for error in errors)
+
+
+def test_current_inventory_matches_current_test_tree() -> None:
+    sites = checker.scan_skip_sites()
+    rows = checker.parse_inventory()
+    assert len(sites) == 143
+    assert len(rows) == 143
+    assert checker.validate_inventory(sites, rows) == []
+    assert {row.action for row in rows} == {"keep", "fix", "replace", "archive"}
+    assert all(row.follow_up != "US-038" for row in rows)


### PR DESCRIPTION
## Summary
- regenerate the skipped-test inventory from the current executable test AST
- update the source-site count from 140 to 143 and correct 29 stale line locations
- add explicit `keep`, `fix`, `replace`, or `archive` actions to every row
- link all non-trivial actions to US-039 or US-040 instead of circular US-038 references
- add a stdlib validator that checks exact file, line, type, reason, classification, action, and follow-up parity
- run the validator in the lightweight CI lint job
- update `CLAUDE.md`, the production-readiness tracker, and its required progress ledger

## Inventory result
- 35 `keep`
- 92 `fix`
- 2 `replace`
- 14 `archive`
- 143 total executable skip sites

## Local validation
- Python 3.11 targeted tests: 4 passed
- `python scripts/check_skip_inventory.py`: passed, 143/143 current
- full-repo Ruff: passed
- Black CI scope: 1,017 files unchanged
- CI YAML parse: passed
- compileall scripts: passed
- security release gate: passed
- generated-artifact gate: passed
- pre-commit Ruff, Black, and detect-secrets: passed
- `git diff --check`: passed

## Tracker state
US-038 implementation criteria are complete. The final GitHub-check criterion remains pending this PR.