### PR TITLE
test(coverage): reconcile supported surface contracts

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1476,7 +1476,7 @@ pytest -q
 **Acceptance Criteria:**
 - [x] At least one direct test per shippable surface. *(CLI: `tests/test_console_scripts_smoke.py`; SkillTrainer: `tests/test_skill_trainer.py` + `tests/test_skills_trainer.py`; Electron/installer: `tests/smoke/test_electron_package.sh` plus Windows artifact smoke workflow. Legacy-note bridge/`rex_loop.py` paths: `tests/test_us005_bridge_json_io.py` + `tests/test_us074_voice_loop_pipeline.py`. Local focused runs: 26/26 and 39/39 passed on Python 3.11.9; Windows artifact run 31148746251 passed installed-artifact smoke.)*
 - [x] Coverage gate (`fail_under = 75`) still passes. *(`python -m pytest -q --cov=rex --cov-fail-under=75`: 8,449 passed, 49 skipped, 0 failed; total coverage 83.26% on Python 3.11.9.)*
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. *(PR #352 implementation head `f127392`; CI run 31213049056 plus commitlint run 31213049246: all 17 checks passed. Python 3.11 Tests & Coverage job 92980116557 passed in 9m37s, including coverage, skip-budget enforcement, integration tests, working-tree-clean verification, and coverage artifact upload.)*
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1457,20 +1457,25 @@ pytest -q
 
 ### US-040: Add or restore tests for current supported surfaces that lost coverage
 
+**Implementation status (2026-08-07):** Direct contract coverage is present for every current shippable surface in `SURFACE-CLASSIFICATION.md`, and the stricter legacy implementation-note paths are also covered. The exact PRD coverage command exposed one obsolete generated-artifact assertion in the historical US-098 coverage tests; US-040 replaces that assertion with stable coverage/reporting contracts rather than requiring an ignored `coverage.txt` scratch file. Remaining unrelated temporary skip debt is routed to US-089 through US-093 instead of being falsely closed by this story.
+
 **Priority:** P1
 **Workstream:** Tests
 **Description:** As a maintainer, I want the test suite to actually cover the surfaces this PRD classifies as shippable.
 
 **Files/areas likely involved:**
-- `tests/test_cli_smoke.py` or equivalent
-- `tests/test_voice_loop_smoke.py`
-- `tests/test_electron_bridge_contract.py`
+- `tests/test_console_scripts_smoke.py`
+- `tests/test_skill_trainer.py` and `tests/test_skills_trainer.py`
+- `tests/smoke/test_electron_package.sh`
+- `tests/test_us005_bridge_json_io.py`
+- `tests/test_us074_voice_loop_pipeline.py`
+- `tests/test_us098_test_coverage.py`
 
-**Implementation notes:** Identify shippable surfaces (`rex` CLI, packaged Electron app, bridge scripts, `rex_loop.py`) with weak or missing coverage. Add minimum-viable tests that exercise the public contract.
+**Implementation notes:** `SURFACE-CLASSIFICATION.md` is authoritative: the `rex` CLI and Electron desktop app are shippable user-facing surfaces, `SkillTrainer` is a shippable internal user-facing capability, and the Windows Electron Voice installer is the shippable distribution artifact. Bridge wrappers and `rex_loop.py` are developer-only today, but direct tests remain required here because the original US-040 note named them. Add tests only where a real public-contract gap exists; do not add meta-tests that merely assert other tests exist.
 
 **Acceptance Criteria:**
-- [ ] At least one direct test per shippable surface.
-- [ ] Coverage gate (`fail_under = 75`) still passes.
+- [x] At least one direct test per shippable surface. *(CLI: `tests/test_console_scripts_smoke.py`; SkillTrainer: `tests/test_skill_trainer.py` + `tests/test_skills_trainer.py`; Electron/installer: `tests/smoke/test_electron_package.sh` plus Windows artifact smoke workflow. Legacy-note bridge/`rex_loop.py` paths: `tests/test_us005_bridge_json_io.py` + `tests/test_us074_voice_loop_pipeline.py`. Local focused runs: 26/26 and 39/39 passed on Python 3.11.9; Windows artifact run 31148746251 passed installed-artifact smoke.)*
+- [x] Coverage gate (`fail_under = 75`) still passes. *(`python -m pytest -q --cov=rex --cov-fail-under=75`: 8,449 passed, 49 skipped, 0 failed; total coverage 83.26% on Python 3.11.9.)*
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**
@@ -3070,6 +3075,87 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 
 ---
 
+### US-089: Remove obsolete CalendarService compatibility skips
+
+**Priority:** P2
+**Workstream:** Tests / Technical Debt
+**Description:** As a maintainer, I want `tests/test_calendar_service.py` to test the canonical CalendarService API directly instead of carrying alternate-generation skip branches.
+
+**Acceptance Criteria:**
+- [ ] The canonical CalendarService/Event model API is identified from current production code and documented in the test module.
+- [ ] Obsolete alternate-API tests are removed or rewritten against the canonical API; no `temporary-bug-skip` site remains in `tests/test_calendar_service.py`.
+- [ ] Direct calendar service/backend tests pass.
+- [ ] Skip inventory and runtime budget are updated if the executed skip count changes.
+- [ ] All relevant GitHub checks pass.
+
+---
+
+### US-090: Remove obsolete EmailService compatibility skips
+
+**Priority:** P2
+**Workstream:** Tests / Technical Debt
+**Description:** As a maintainer, I want `tests/test_email_service.py` to test the canonical EmailService API directly instead of carrying alternate-generation skip branches.
+
+**Acceptance Criteria:**
+- [ ] The canonical EmailService/EmailSummary API is identified from current production code and documented in the test module.
+- [ ] Obsolete alternate-API tests are removed or rewritten against the canonical API; no `temporary-bug-skip` site remains in `tests/test_email_service.py`.
+- [ ] Direct email service/backend tests pass.
+- [ ] Skip inventory and runtime budget are updated if the executed skip count changes.
+- [ ] All relevant GitHub checks pass.
+
+---
+
+### US-091: Remove obsolete Scheduler compatibility skips
+
+**Priority:** P2
+**Workstream:** Tests / Technical Debt
+**Description:** As a maintainer, I want `tests/test_scheduler.py` to target the canonical Scheduler API without legacy/newer implementation skip branches.
+
+**Acceptance Criteria:**
+- [ ] The canonical Scheduler constructor and persistence API are identified from current production code.
+- [ ] Obsolete alternate-API tests are removed or rewritten; no `temporary-bug-skip` site remains in `tests/test_scheduler.py`.
+- [ ] Scheduler and scheduling integration tests pass.
+- [ ] Skip inventory and runtime budget are updated if the executed skip count changes.
+- [ ] All relevant GitHub checks pass.
+
+---
+
+### US-092: Remove obsolete EventBus compatibility skips
+
+**Priority:** P2
+**Workstream:** Tests / Technical Debt
+**Description:** As a maintainer, I want `tests/test_event_bus.py` to target the canonical EventBus contract without alternate-generation skip branches.
+
+**Acceptance Criteria:**
+- [ ] The canonical EventBus publish/subscribe contract is identified from current production code.
+- [ ] Obsolete alternate-contract tests are removed or rewritten; no `temporary-bug-skip` site remains in `tests/test_event_bus.py`.
+- [ ] Event bus and OpenClaw event bridge tests pass.
+- [ ] Skip inventory and runtime budget are updated if the executed skip count changes.
+- [ ] All relevant GitHub checks pass.
+
+---
+
+### US-093: Replace remaining generated/missing-artifact test skips
+
+**Priority:** P2
+**Workstream:** Tests / Technical Debt
+**Description:** As a maintainer, I want the remaining temporary skips caused by missing generated docs/scripts/examples to become stable assertions or be removed when their historical artifact is no longer part of the supported repo contract.
+
+**Files/areas likely involved:**
+- `tests/test_us120_performance_baseline.py`
+- `tests/test_us140_full_extra.py`
+- `tests/test_skill_loader.py`
+- `tests/test_us053_secret_management.py`
+
+**Acceptance Criteria:**
+- [ ] Each remaining temporary skip is reconciled against the current supported repo contract rather than silently kept.
+- [ ] Valid requirements become direct tests; obsolete historical requirements are removed with evidence.
+- [ ] No `temporary-bug-skip` site remains in the listed files.
+- [ ] Skip inventory and runtime budget are updated.
+- [ ] All relevant GitHub checks pass.
+
+---
+
 ## 9. Global Acceptance Criteria
 
 Every story in Section 8 inherits these criteria. They are checked in addition to the per-story criteria.
@@ -3137,7 +3223,7 @@ This policy is enforced by Section 9's global acceptance criteria. It is restate
 The release candidate is "Production Ready" when ALL of the following are true on a single commit on `master`:
 
 - [ ] Every P0/P1 User Story US-001 through US-058 and US-064 through US-088 is `[x]`.
-- [ ] Satisfied P2 stories US-059 through US-062 remain documented as baseline evidence, and open P2 story US-063 is either completed or explicitly deferred without partial decomposition on `master`.
+- [ ] Satisfied P2 stories US-059 through US-062 remain documented as baseline evidence, and open P2 stories US-063 and US-089 through US-093 are either completed or explicitly deferred without partial decomposition on `master`.
 - [ ] `python scripts/security_audit.py` exits 0 OR all findings are documented in `docs/security/AUDIT-INVENTORY.md` and accepted with an owner and expiry.
 - [ ] `python scripts/check_no_renderer_api_fetch.py` exits 0 with an empty allowlist.
 - [ ] `python scripts/check_wheel_contents.py` exits 0.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1268,3 +1268,21 @@ GitHub checks remain pending the story PR.
 US-039 rebase verification (2026-08-07): rebased cleanly onto master@79b0a97; Python 3.11 collect-only measured 8,541 tests on base and 8,504 after the story, with no collection error. Focused tests test_us038_skip_inventory.py + test_us174_voice_max_tokens.py: 19 passed.
 
 US-039 GitHub verification (2026-08-07): PR #351 head b6d2f4e passed the complete required check set. CI run 31176594845 passed CodeFactor, dependency/security scans, lint/format, mypy, GUI lint/typecheck/tests/build, pre-commit, wheel smoke, commitlint, and Python 3.11 coverage/integration. Python job 92859835933 completed in 10m51s, including skip-budget enforcement, integration tests, tracked-working-tree cleanliness, and coverage artifact upload. US-039 is now fully satisfied.
+
+
+=== 2026-08-07 - US-040 supported-surface coverage reconciliation ===
+
+Fresh direct-contract evidence on master@6ce4bbe:
+- CLI + bridge + rex_loop focused suite: 26 passed on Python 3.11.9
+- SkillTrainer direct suites: 39 passed
+- Windows Electron Artifact run 31148746251: installed-artifact job 92773771118 passed, including managed runtime/installer build, package-content verification, and installed-artifact exercise without machine Python or Node
+
+The exact PRD command `pytest -q --cov=rex --cov-fail-under=75` initially reached 83.28% coverage but exited 1 because historical `test_us098_test_coverage.py::test_coverage_txt_exists` required an ignored `coverage.txt` file that only CI creates via `tee`. Repository history confirms the artifact assertion predates the later skip-budget pipeline. US-040 replaces that generated-file dependency with stable pytest-cov/config/reporting contracts; the rewritten US-098 suite passes 9/9 with `coverage.txt` absent.
+
+The US-038 inventory had routed 94 unrelated temporary compatibility/artifact skip sites to US-040. Two generated-coverage skips are removed here. The remaining debt is reassigned to atomic follow-ups: US-089 CalendarService (26), US-090 EmailService (25), US-091 Scheduler (22), US-092 EventBus (13), and US-093 miscellaneous generated/missing-artifact tests (6). This prevents US-040 from falsely closing unrelated test debt.
+
+Full post-fix coverage and GitHub verification remain pending.
+
+US-040 skip-inventory verification: `python scripts/check_skip_inventory.py` passes with 127/127 executable sites current; focused US-038 + US-098 inventory/coverage-contract tests pass 13/13.
+
+US-040 exact post-fix coverage gate: PASS. `python -m pytest -q --cov=rex --cov-fail-under=75` collected 8,498 tests and finished 8,449 passed, 49 skipped, 0 failed in 562.87s. Coverage: 83.26% (required: 75%). The command exited 0 with `coverage.txt` absent, proving the generated-artifact dependency was removed. GitHub checks remain pending before final story closeout.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1286,3 +1286,5 @@ Full post-fix coverage and GitHub verification remain pending.
 US-040 skip-inventory verification: `python scripts/check_skip_inventory.py` passes with 127/127 executable sites current; focused US-038 + US-098 inventory/coverage-contract tests pass 13/13.
 
 US-040 exact post-fix coverage gate: PASS. `python -m pytest -q --cov=rex --cov-fail-under=75` collected 8,498 tests and finished 8,449 passed, 49 skipped, 0 failed in 562.87s. Coverage: 83.26% (required: 75%). The command exited 0 with `coverage.txt` absent, proving the generated-artifact dependency was removed. GitHub checks remain pending before final story closeout.
+
+US-040 GitHub implementation-head gate: PASS. PR #352 head f127392; CI run 31213049056 and commitlint run 31213049246 completed with all 17 checks green. Python job 92980116557 passed in 9m37s and included coverage, skip-budget enforcement, integration tests, tracked-tree cleanliness, and coverage artifact upload. US-040 acceptance criteria are now fully satisfied; this tracker closeout commit must itself receive a final green rerun before merge.

--- a/docs/testing/SKIPPED-TESTS-INVENTORY.md
+++ b/docs/testing/SKIPPED-TESTS-INVENTORY.md
@@ -1,6 +1,6 @@
 # Skipped Tests Inventory
 
-Updated for `US-039` on 2026-08-04 after archiving tests for the retired Flask dashboard surface.
+Updated for `US-040` on 2026-08-07 after replacing the generated-coverage-artifact skips and routing the remaining temporary compatibility/test-artifact debt to dedicated follow-up stories.
 
 ## CI Runtime Skip Budget
 
@@ -14,11 +14,11 @@ The runtime count is intentionally separate from the executable source-site coun
 
 ## Validation Snapshot
 
-- `python scripts/check_skip_inventory.py`: passed; 129 executable skip sites match the inventory exactly by file, line, type, and reason.
-- Python 3.11 `pytest --collect-only -q`: 8,451 tests before US-039 and 8,414 after, with no collection error.
-- Every remaining row has one explicit action: `keep`, `fix`, or `replace`; all 14 `archive` actions were completed by US-039.
+- `python scripts/check_skip_inventory.py`: passed; 127 executable skip sites match the inventory exactly by file, line, type, and reason.
+- Python 3.11 US-040 full coverage validation collected 8,498 tests and completed with 8,449 passed, 49 skipped, 0 failed; total coverage was 83.26%.
+- Every remaining row has one explicit action: `keep` or `fix`; all `archive` and `replace` actions from US-039/US-040 are complete.
 - Permanent guards retain a written rationale; all non-trivial actions link to a non-circular follow-up story.
-- US-039 removed 14 retired-surface skip sites from the active suite; the remaining 129 sites cover supported code, temporary repair work, and legitimate platform/dependency guards.
+- US-039 removed 14 retired-surface skip sites; US-040 removes two generated-artifact skip sites. The remaining 127 sites cover supported code, dedicated follow-up repair work, and legitimate platform/dependency guards.
 
 ## Classification and Action Summary
 
@@ -26,8 +26,11 @@ The runtime count is intentionally separate from the executable source-site coun
 |---|---:|---|---|
 | `optional-dep-skip` | 22 | `keep` | permanent: optional dependency/tool/environment guard |
 | `platform-skip` | 13 | `keep` | permanent: platform/runtime-specific guard |
-| `temporary-bug-skip` | 92 | `fix` | US-040 |
-| `temporary-bug-skip` | 2 | `replace` | US-040 |
+| `temporary-bug-skip` | 26 | `fix` | US-089 |
+| `temporary-bug-skip` | 25 | `fix` | US-090 |
+| `temporary-bug-skip` | 22 | `fix` | US-091 |
+| `temporary-bug-skip` | 13 | `fix` | US-092 |
+| `temporary-bug-skip` | 6 | `fix` | US-093 |
 
 ## Inventory
 
@@ -35,100 +38,100 @@ The runtime count is intentionally separate from the executable source-site coun
 |---|---:|---|---|---|---|---|
 | `tests/conftest.py` | 221 | `skip` | No async test runner installed (anyio or pytest-asyncio required) | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_audio_device_selection.py` | 9 | `pytest.skip` | f"sounddevice unavailable: {exc}" | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
-| `tests/test_calendar_service.py` | 131 | `skipif` | CalendarService event-bus style API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 185 | `skipif` | CalendarEvent is not a pydantic-style model in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 212 | `skipif` | CalendarEvent.overlaps_with not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 242 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 252 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 262 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 271 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 288 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 300 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 310 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 338 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 353 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 368 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 384 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 394 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 404 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 423 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 432 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 441 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 464 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 486 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 496 | `skipif` | CalendarService.get_upcoming_events not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 507 | `skipif` | CalendarService.get_upcoming_events not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 518 | `skipif` | CalendarService.get_all_events not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 529 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_calendar_service.py` | 553 | `skipif` | CalendarEvent serialization test applies to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_calendar_service.py` | 131 | `skipif` | CalendarService event-bus style API not available in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 185 | `skipif` | CalendarEvent is not a pydantic-style model in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 212 | `skipif` | CalendarEvent.overlaps_with not available in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 242 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 252 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 262 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 271 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 288 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 300 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 310 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 338 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 353 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 368 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 384 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 394 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 404 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 423 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 432 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 441 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 464 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 486 | `skipif` | CalendarService.find_conflicts not available in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 496 | `skipif` | CalendarService.get_upcoming_events not available in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 507 | `skipif` | CalendarService.get_upcoming_events not available in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 518 | `skipif` | CalendarService.get_all_events not available in this build. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 529 | `skipif` | Mock-file calendar service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
+| `tests/test_calendar_service.py` | 553 | `skipif` | CalendarEvent serialization test applies to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-089` |
 | `tests/test_credential_vault.py` | 134 | `pytest.skip` | This assertion applies to non-Windows production | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
 | `tests/test_credential_vault.py` | 139 | `skipif` | DPAPI vault is Windows-only | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
 | `tests/test_email_account_isolation.py` | 67 | `skipif` | Real DPAPI isolation is Windows-only | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
-| `tests/test_email_service.py` | 96 | `skipif` | EmailService event-bus style API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 187 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 212 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 222 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 232 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 241 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 253 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 263 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 273 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 290 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 299 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 308 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 326 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 344 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 362 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 380 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 399 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 417 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 430 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 440 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 450 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 464 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 474 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 498 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_email_service.py` | 528 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 79 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 96 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 123 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 137 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 151 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 161 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 173 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 189 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 210 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 233 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 259 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 274 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_event_bus.py` | 293 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_email_service.py` | 96 | `skipif` | EmailService event-bus style API not available in this build. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 187 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 212 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 222 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 232 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 241 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 253 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 263 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 273 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 290 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 299 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 308 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 326 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 344 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 362 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 380 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 399 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 417 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 430 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 440 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 450 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 464 | `skipif` | Mock-file email service tests apply to the newer implementation only. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 474 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 498 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_email_service.py` | 528 | `skipif` | EmailSummary pydantic-style model not available in this build. | `temporary-bug-skip` | `fix` | `US-090` |
+| `tests/test_event_bus.py` | 79 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 96 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 123 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 137 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 151 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 161 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 173 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 189 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 210 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 233 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 259 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 274 | `skipif` | Legacy EventBus.publish(event_type, payload) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
+| `tests/test_event_bus.py` | 293 | `skipif` | Newer EventBus.publish(Event) API not available in this build. | `temporary-bug-skip` | `fix` | `US-092` |
 | `tests/test_install_scripts.py` | 15 | `pytest.skip` | bash not available | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_install_scripts.py` | 24 | `pytest.skip` | bash not usable on Windows | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
 | `tests/test_openclaw_root_voice_loop_flag.py` | 19 | `skipif` | openwakeword is not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_openclaw_root_voice_loop_text_mode.py` | 20 | `skipif` | openwakeword is not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
-| `tests/test_scheduler.py` | 90 | `skipif` | Legacy Scheduler(storage_path, now_func) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 115 | `skipif` | Legacy Scheduler(storage_path, now_func) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 157 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 167 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 191 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 211 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 225 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 241 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 254 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 266 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 279 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 311 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 337 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 363 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 391 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 407 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 427 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 450 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 463 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 493 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 502 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_scheduler.py` | 521 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_skill_loader.py` | 213 | `pytest.skip` | example_weather_skill.py not found | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_scheduler.py` | 90 | `skipif` | Legacy Scheduler(storage_path, now_func) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 115 | `skipif` | Legacy Scheduler(storage_path, now_func) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 157 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 167 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 191 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 211 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 225 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 241 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 254 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 266 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 279 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 311 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 337 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 363 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 391 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 407 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 427 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 450 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 463 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 493 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 502 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_scheduler.py` | 521 | `skipif` | Newer Scheduler(jobs_file=...) API not available in this build. | `temporary-bug-skip` | `fix` | `US-091` |
+| `tests/test_skill_loader.py` | 213 | `pytest.skip` | example_weather_skill.py not found | `temporary-bug-skip` | `fix` | `US-093` |
 | `tests/test_transformers_shim.py` | 30 | `pytest.skip` | f"transformers not installed or BeamSearchScorer unavailable: {e}" | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_transformers_shim.py` | 48 | `pytest.skip` | transformers not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_transformers_shim.py` | 63 | `pytest.skip` | transformers not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
@@ -145,19 +148,17 @@ The runtime count is intentionally separate from the executable source-site coun
 | `tests/test_us030_clarification.py` | 204 | `pytest.skip` | HABridge not importable (requests not installed) | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_us033_acknowledgment.py` | 11 | `skipif` | numpy not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_us034_progressive_response.py` | 22 | `skipif` | numpy not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us053_secret_management.py` | 125 | `pytest.skip` | .env.example not found | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_us053_secret_management.py` | 125 | `pytest.skip` | .env.example not found | `temporary-bug-skip` | `fix` | `US-093` |
 | `tests/test_us071_debug_mode.py` | 18 | `skipif` | rex.cli unavailable on this Python version | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
 | `tests/test_us074_voice_loop_pipeline.py` | 33 | `skipif` | numpy not installed | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_us096_secret_scan.py` | 171 | `pytest.skip` | PyYAML not installed; skipping YAML parse test | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
-| `tests/test_us098_test_coverage.py` | 28 | `pytest.skip` | coverage.txt has not been generated yet | `temporary-bug-skip` | `replace` | `US-040` |
-| `tests/test_us098_test_coverage.py` | 31 | `pytest.skip` | coverage.txt is still being written by the current coverage run | `temporary-bug-skip` | `replace` | `US-040` |
-| `tests/test_us120_performance_baseline.py` | 180 | `pytest.skip` | docs/performance-baseline.md not yet created | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_us120_performance_baseline.py` | 187 | `pytest.skip` | docs/performance-baseline.md not yet created | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_us120_performance_baseline.py` | 180 | `pytest.skip` | docs/performance-baseline.md not yet created | `temporary-bug-skip` | `fix` | `US-093` |
+| `tests/test_us120_performance_baseline.py` | 187 | `pytest.skip` | docs/performance-baseline.md not yet created | `temporary-bug-skip` | `fix` | `US-093` |
 | `tests/test_us129_smoke.py` | 54 | `pytest.skip` | Local Rex instance not running — start with 'python flask_proxy.py' to exercise live-server smoke tests | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_us129_smoke.py` | 323 | `pytest.skip` | f"agent_server optional dependency not available: {exc}" | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_us139_install_scripts.py` | 139 | `skipif` | executable bit not relevant on Windows | `platform-skip` | `keep` | permanent: platform/runtime-specific guard |
-| `tests/test_us140_full_extra.py` | 138 | `pytest.skip` | install.sh not present | `temporary-bug-skip` | `fix` | `US-040` |
-| `tests/test_us140_full_extra.py` | 145 | `pytest.skip` | install.ps1 not present | `temporary-bug-skip` | `fix` | `US-040` |
+| `tests/test_us140_full_extra.py` | 138 | `pytest.skip` | install.sh not present | `temporary-bug-skip` | `fix` | `US-093` |
+| `tests/test_us140_full_extra.py` | 145 | `pytest.skip` | install.ps1 not present | `temporary-bug-skip` | `fix` | `US-093` |
 | `tests/test_us304_chat_stream_electron_verification.py` | 16 | `skipif` | electron.cmd not found | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_us304_chat_stream_electron_verification.py` | 41 | `pytest.skip` | f"Electron verification unavailable: {exc}" | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |
 | `tests/test_voice_id_mvp.py` | 590 | `pytest.skip` | speechbrain is installed — cannot test missing-dep path | `optional-dep-skip` | `keep` | permanent: optional dependency/tool/environment guard |

--- a/tests/test_us038_skip_inventory.py
+++ b/tests/test_us038_skip_inventory.py
@@ -63,8 +63,8 @@ def test_validator_rejects_missing_and_stale_rows() -> None:
 def test_current_inventory_matches_current_test_tree() -> None:
     sites = checker.scan_skip_sites()
     rows = checker.parse_inventory()
-    assert len(sites) == 129
-    assert len(rows) == 129
+    assert len(sites) == 127
+    assert len(rows) == 127
     assert checker.validate_inventory(sites, rows) == []
-    assert {row.action for row in rows} == {"keep", "fix", "replace"}
+    assert {row.action for row in rows} == {"keep", "fix"}
     assert all(row.follow_up != "US-038" for row in rows)

--- a/tests/test_us098_test_coverage.py
+++ b/tests/test_us098_test_coverage.py
@@ -1,234 +1,87 @@
-"""
-US-098: Measure and document baseline test coverage
+"""Coverage-contract regression tests.
 
-Acceptance criteria:
-- pytest --cov=rex --cov-report=term-missing runs without error
-- coverage report saved to coverage.txt or equivalent
-- modules with below-50% coverage listed explicitly in the report
-- agreed minimum coverage threshold documented in pyproject.toml or setup.cfg
-- Typecheck passes
+US-098 originally required a generated ``coverage.txt`` file in the repository
+root. That file is now intentionally ignored and is created only by CI's
+``tee`` pipeline so the skip-budget checker can parse the pytest summary.
+Coverage correctness is enforced by pytest-cov and the configured threshold,
+not by the presence of a leftover generated text file.
 """
 
 from __future__ import annotations
 
+import importlib.util
+import json
 import re
 from pathlib import Path
 
-import pytest
-
-PROJECT_ROOT = Path(__file__).parent.parent
-COVERAGE_TXT = PROJECT_ROOT / "coverage.txt"
-COVERAGE_JSON = PROJECT_ROOT / "coverage.json"
-PYPROJECT = PROJECT_ROOT / "pyproject.toml"
-
-
-def _read_coverage_txt() -> str:
-    """Return coverage.txt contents or skip when the file is still being written."""
-    if not COVERAGE_TXT.exists():
-        pytest.skip("coverage.txt has not been generated yet")
-    content = COVERAGE_TXT.read_text(encoding="utf-8")
-    if "TOTAL" not in content:
-        pytest.skip("coverage.txt is still being written by the current coverage run")
-    return content
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+CI_YML = ROOT / ".github" / "workflows" / "ci.yml"
+GITIGNORE = ROOT / ".gitignore"
+GAP_REPORT = ROOT / "test-audit-coverage-gaps.json"
 
 
-# ---------------------------------------------------------------------------
-# AC1: pytest-cov is installed and importable
-# ---------------------------------------------------------------------------
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _fail_under() -> int:
+    content = _read(PYPROJECT)
+    section = re.search(r"\[tool\.coverage\.report\](.*?)(?=\n\[|\Z)", content, re.DOTALL)
+    assert section, "pyproject.toml missing [tool.coverage.report]"
+    match = re.search(r"fail_under\s*=\s*(\d+)", section.group(1))
+    assert match, "[tool.coverage.report] missing fail_under"
+    return int(match.group(1))
 
 
 def test_pytest_cov_installed() -> None:
-    """pytest-cov package must be available."""
-    import importlib
-
-    spec = importlib.util.find_spec("pytest_cov")
-    assert spec is not None, "pytest-cov is not installed"
+    assert importlib.util.find_spec("pytest_cov") is not None
 
 
 def test_coverage_module_importable() -> None:
-    """coverage package must be importable."""
-    import importlib
-
-    spec = importlib.util.find_spec("coverage")
-    assert spec is not None, "coverage package is not installed"
+    assert importlib.util.find_spec("coverage") is not None
 
 
-# ---------------------------------------------------------------------------
-# AC2: coverage report saved to coverage.txt or equivalent
-# ---------------------------------------------------------------------------
+def test_ci_generates_human_and_machine_readable_coverage_reports() -> None:
+    ci = _read(CI_YML)
+    assert "--cov=rex" in ci
+    assert "--cov-report=term-missing" in ci
+    assert "--cov-report=html" in ci
+    assert "--cov-report=xml" in ci
 
 
-def test_coverage_txt_exists() -> None:
-    """coverage.txt must exist in the project root."""
-    assert COVERAGE_TXT.exists(), (
-        f"coverage.txt not found at {COVERAGE_TXT}. "
-        "Run: python -m pytest --cov=rex --cov-report=term-missing -q 2>&1 | tee coverage.txt"
-    )
+def test_ci_text_capture_is_ephemeral_not_a_required_repo_artifact() -> None:
+    ci = _read(CI_YML)
+    assert "tee coverage.txt" in ci
+    assert "coverage.txt" in _read(GITIGNORE)
 
 
-def test_coverage_txt_non_empty() -> None:
-    """coverage.txt must contain actual content."""
-    content = _read_coverage_txt()
-    assert len(content) > 500, f"coverage.txt appears too short ({len(content)} bytes)"
+def test_committed_gap_inventory_is_parseable() -> None:
+    data = json.loads(_read(GAP_REPORT))
+    assert isinstance(data, list) and data
+    assert all("module_path" in row and "current_coverage_pct" in row for row in data)
 
 
-def test_coverage_txt_has_summary_line() -> None:
-    """coverage.txt must contain the TOTAL summary line."""
-    content = _read_coverage_txt()
-    assert "TOTAL" in content, "coverage.txt does not contain TOTAL summary line"
+def test_committed_gap_inventory_identifies_low_coverage_modules() -> None:
+    data = json.loads(_read(GAP_REPORT))
+    below_50 = [row for row in data if int(row["current_coverage_pct"]) < 50]
+    assert below_50, "coverage-gap inventory must explicitly identify below-50% modules"
 
 
-def test_coverage_txt_has_rex_modules() -> None:
-    """coverage.txt must list rex package modules."""
-    content = _read_coverage_txt()
-    assert "rex\\" in content or "rex/" in content, "coverage.txt does not list rex package modules"
+def test_pyproject_has_coverage_source_and_threshold() -> None:
+    content = _read(PYPROJECT)
+    assert "[tool.coverage.run]" in content
+    assert 'source = ["rex"]' in content
+    assert "[tool.coverage.report]" in content
+    assert 50 <= _fail_under() <= 100
 
 
-# ---------------------------------------------------------------------------
-# AC3: modules with below-50% coverage are identifiable
-# ---------------------------------------------------------------------------
+def test_ci_threshold_matches_pyproject() -> None:
+    ci = _read(CI_YML)
+    match = re.search(r"--cov-fail-under=(\d+)", ci)
+    assert match, "CI pytest invocation missing --cov-fail-under"
+    assert int(match.group(1)) == _fail_under()
 
 
-def _parse_coverage_txt() -> list[tuple[str, int]]:
-    """Parse coverage.txt and return list of (module, coverage_pct) tuples."""
-    content = _read_coverage_txt()
-    results: list[tuple[str, int]] = []
-    # Match lines like: rex\foo.py   123   45   63%   ...
-    pattern = re.compile(r"^(rex[\\/]\S+)\s+\d+\s+\d+\s+(\d+)%", re.MULTILINE)
-    for match in pattern.finditer(content):
-        module = match.group(1)
-        pct = int(match.group(2))
-        results.append((module, pct))
-    return results
-
-
-def test_coverage_txt_parseable() -> None:
-    """coverage.txt must contain parseable module coverage lines."""
-    rows = _parse_coverage_txt()
-    assert len(rows) > 50, f"Expected >50 module lines in coverage.txt, found {len(rows)}"
-
-
-def test_below_50_modules_present_in_report() -> None:
-    """coverage.txt must contain modules with below-50% coverage.
-
-    These are known low-coverage modules that rely on heavy optional
-    dependencies (audio, GPU, Windows services).
-    """
-    rows = _parse_coverage_txt()
-    assert rows, "Could not parse any module lines from coverage.txt"
-
-    below_50 = [(mod, pct) for mod, pct in rows if pct < 50]
-    assert len(below_50) > 0, (
-        "Expected at least one module below 50% coverage. "
-        "If all modules are now above 50%, update this threshold."
-    )
-
-
-def test_known_low_coverage_modules_visible() -> None:
-    """Known low-coverage modules must appear in the report."""
-    content = _read_coverage_txt()
-
-    # These modules are known to have low coverage due to optional heavy deps
-    known_low = [
-        "wakeword",  # optional audio/ML dependency
-    ]
-    for fragment in known_low:
-        assert (
-            fragment in content
-        ), f"Expected to find '{fragment}' in coverage.txt but it was missing"
-
-
-def test_below_50_modules_list() -> None:
-    """Verify the list of below-50% modules is non-trivial and stable."""
-    rows = _parse_coverage_txt()
-    below_50 = sorted([(mod, pct) for mod, pct in rows if pct < 50])
-
-    # Keep representative legacy/optional surfaces visible until their direct
-    # coverage is improved. This list must track the current report rather than
-    # modules that have already crossed 50%, or the guard becomes a false failure.
-    expected_low = {
-        "rex\\compat.py",
-        "rex/compat.py",
-        "rex\\digest_job.py",
-        "rex/digest_job.py",
-        "rex\\integrations.py",
-        "rex/integrations.py",
-        "rex\\mobile_api\\chat.py",
-        "rex/mobile_api/chat.py",
-        "rex\\mobile_api\\voice.py",
-        "rex/mobile_api/voice.py",
-    }
-    found_low_names = {mod for mod, _ in below_50}
-    # At least one of the expected low-coverage modules must appear
-    overlap = expected_low & found_low_names
-    assert overlap, (
-        f"Expected at least one of {expected_low} in below-50% modules. "
-        f"Found below-50%: {found_low_names}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# AC4: agreed minimum coverage threshold documented in pyproject.toml
-# ---------------------------------------------------------------------------
-
-
-def test_pyproject_has_coverage_section() -> None:
-    """pyproject.toml must have a [tool.coverage.report] section."""
-    content = PYPROJECT.read_text(encoding="utf-8")
-    assert (
-        "[tool.coverage.report]" in content
-    ), "pyproject.toml missing [tool.coverage.report] section"
-
-
-def test_pyproject_has_fail_under() -> None:
-    """pyproject.toml must document a minimum coverage threshold via fail_under."""
-    content = PYPROJECT.read_text(encoding="utf-8")
-    assert (
-        "fail_under" in content
-    ), "pyproject.toml [tool.coverage.report] section must contain 'fail_under'"
-
-
-def test_fail_under_value_reasonable() -> None:
-    """fail_under threshold must be between 50 and 100."""
-    content = PYPROJECT.read_text(encoding="utf-8")
-    match = re.search(r"fail_under\s*=\s*(\d+)", content)
-    assert match, "Could not parse fail_under value from pyproject.toml"
-    value = int(match.group(1))
-    assert 50 <= value <= 100, f"fail_under = {value} is outside acceptable range [50, 100]"
-
-
-def test_total_coverage_meets_threshold() -> None:
-    """Total coverage reported in coverage.txt must meet the documented threshold."""
-    # Parse fail_under from pyproject.toml
-    pyproject_content = PYPROJECT.read_text(encoding="utf-8")
-    match = re.search(r"fail_under\s*=\s*(\d+)", pyproject_content)
-    assert match, "Could not parse fail_under value from pyproject.toml"
-    threshold = int(match.group(1))
-
-    # Parse total from coverage.txt
-    txt_content = _read_coverage_txt()
-    total_match = re.search(r"^TOTAL\s+\d+\s+\d+\s+(\d+)%", txt_content, re.MULTILINE)
-    assert total_match, "Could not parse TOTAL line from coverage.txt"
-    total_pct = int(total_match.group(1))
-
-    assert (
-        total_pct >= threshold
-    ), f"Total coverage {total_pct}% is below fail_under threshold {threshold}%"
-
-
-# ---------------------------------------------------------------------------
-# Utility: print below-50% modules (informational, always passes)
-# ---------------------------------------------------------------------------
-
-
-def test_print_below_50_modules() -> None:
-    """Print modules below 50% coverage for visibility (always passes)."""
-    rows = _parse_coverage_txt()
-    below_50 = sorted([(mod, pct) for mod, pct in rows if pct < 50])
-    if below_50:
-        lines = "\n".join(f"  {pct:3d}%  {mod}" for mod, pct in below_50)
-        print(f"\nModules below 50% coverage ({len(below_50)} total):\n{lines}")
-    else:
-        print("\nAll modules are at or above 50% coverage.")
-    # This test always passes — it's for visibility only
-    assert True
+def test_agreed_coverage_threshold_is_75_percent() -> None:
+    assert _fail_under() == 75


### PR DESCRIPTION
## Summary
- verify direct contract coverage for every current shippable AskRex surface plus the stricter legacy US-040 paths
- replace historical coverage.txt artifact-dependent tests with stable pytest-cov/config/reporting contracts
- remove two obsolete generated-artifact skip sites and route remaining unrelated temporary skip debt to US-089 through US-093

## Local verification
- `python -m pytest -q --cov=rex --cov-fail-under=75` -> 8,449 passed, 49 skipped, 0 failed; 83.26% coverage
- focused surface/inventory suite -> 78 passed
- `python scripts/check_skip_inventory.py` -> 127/127 sites current
- Ruff + Black on changed Python tests -> pass
- `git diff --check` -> pass
- Windows Electron Artifact run 31148746251 previously passed installed-artifact smoke on the unchanged packaged surface

## Tracker
- US-040 direct-surface and coverage criteria are checked with evidence
- GitHub-check criterion remains open until this PR head is green