### PR TITLE
feat(voice): default source loop to hold-to-talk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,9 +381,11 @@ python -m rex
 
 Voice mode:
 
-python rex_loop.py
+python rex_loop.py --mode hold-to-talk
+# beta opt-in only:
+python rex_loop.py --mode wake-word
 
-Electron Hold-to-Talk is the supported production voice path. It runs
+The source CLI defaults to Hold-to-Talk/manual activation and must not initialize the wake-word detector unless `--mode wake-word` is explicitly selected. Electron Hold-to-Talk is the supported production voice path. It runs
 renderer recording -> persistent managed Whisper STT -> streamed assistant
 response -> configured TTS -> selected output-device playback. Preserve
 cancellation/barge-in, replay, microphone device-loss fallback, repeated turns,

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1535,7 +1535,7 @@ docker run --rm askrex-assistant:smoke python -m rex doctor
 - [x] A test confirms the default mode resolves to Hold-to-Talk when no flag is provided. *(`tests/test_voice_loop_default_mode.py` also covers explicit wake-word opt-in and the manual activation listener.)*
 - [x] `README.md` says Hold-to-Talk is the supported production voice mode. *(Electron is the true press/hold production UX; the source CLI documents its Enter-triggered manual activation honestly.)*
 - [x] `SURFACE-CLASSIFICATION.md` classifies wake word as `beta`/`developer-only` until US-046.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. *(PR #354 implementation head `10d47cb`: CI run `31221345052`, commitlint run `31221345005`, and Windows Electron Artifact run `31221345114` all passed; Python coverage job `93006401557` and installed-artifact job `93006401583` were green.)*
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1531,10 +1531,10 @@ docker run --rm askrex-assistant:smoke python -m rex doctor
 **Implementation notes:** Add a `--mode hold-to-talk` and `--mode wake-word` flag to the voice loop entry, with `hold-to-talk` as the default. Document that wake word is beta until reliability tests pass (US-046).
 
 **Acceptance Criteria:**
-- [ ] CLI default is Hold-to-Talk.
-- [ ] A test confirms the default mode resolves to Hold-to-Talk when no flag is provided.
-- [ ] `README.md` says Hold-to-Talk is the supported production voice mode.
-- [ ] `SURFACE-CLASSIFICATION.md` classifies wake word as `beta`/`developer-only` until US-046.
+- [x] CLI default is Hold-to-Talk. *(`rex_loop.py` exposes `--mode {hold-to-talk,wake-word}` with `hold-to-talk` as the parser default and passes the selected mode into the canonical builder.)*
+- [x] A test confirms the default mode resolves to Hold-to-Talk when no flag is provided. *(`tests/test_voice_loop_default_mode.py` also covers explicit wake-word opt-in and the manual activation listener.)*
+- [x] `README.md` says Hold-to-Talk is the supported production voice mode. *(Electron is the true press/hold production UX; the source CLI documents its Enter-triggered manual activation honestly.)*
+- [x] `SURFACE-CLASSIFICATION.md` classifies wake word as `beta`/`developer-only` until US-046.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Electron resolves one validated session identity in the main process. Chat, hist
 | **Electron desktop app** | Installed AskRex app; source development: `cd gui; npm.cmd run dev` | **Primary user-facing interface** — Windows artifact is locally validated but unsigned |
 | CLI text chat | `rex` or `python -m rex` | Working basic chat (developer / advanced) |
 | Diagnostics | `rex doctor` or `python -m rex doctor` | Working |
-| Voice loop | `python rex_loop.py` | Developer / advanced source path; wake word is beta |
+| Voice loop | `python rex_loop.py` | Developer / advanced source path; defaults to manual Hold-to-Talk activation. Use `--mode wake-word` to opt into beta wake-word mode. |
 | Python/Flask local API | `rex-gui` | Developer-only compatibility/API surface; not spawned or required by Electron |
 | TTS API | `rex-speak-api` | Implemented service, default `127.0.0.1:5005` (developer / advanced) |
 | OpenClaw tool server | `rex-tool-server` | Implemented service, default `127.0.0.1:18790` (developer / advanced) |
@@ -164,7 +164,7 @@ The Electron app under `gui/` is the current primary GUI. `rex-gui` remains usef
 | Area | Current repo state |
 |---|---|
 | Text chat | Basic CLI and GUI chat work through `rex.assistant.Assistant` and the configured LLM provider. Common day/date phrasing coverage has improved; provider quality still depends on model/configuration. |
-| Voice pipeline | Hold to Talk is the supported production path: record, Whisper STT, streamed response, TTS, selected-device playback, cancel/barge-in, replay, device-loss fallback, and repeated turns. Wake-word mode remains beta while hardware reliability and latency are still being tuned. |
+| Voice pipeline | Hold-to-Talk is the supported production path: the packaged Electron app provides real press/hold recording, Whisper STT, streamed response, TTS, selected-device playback, cancel/barge-in, replay, device-loss fallback, and repeated turns. The source `rex_loop.py` defaults to an explicit Enter-to-talk trigger and accepts `--mode wake-word` for the beta wake detector. |
 | Custom wake support | Built-in openWakeWord remains the safe fallback path. `custom_embedding` is usable as an interim path, and `custom_onnx` is the target path for a real `Hey Rex` wake model. The repo does not ship that custom asset by default. |
 | LLM providers | Local Transformers, OpenAI-compatible API settings, and Ollama routing are supported by config. Local model output quality varies by model and prompt path. |
 | Configuration | Runtime settings live in `config/rex_config.json`; secrets live in the OS-backed credential vault; profiles live in `profiles/`. |

--- a/SURFACE-CLASSIFICATION.md
+++ b/SURFACE-CLASSIFICATION.md
@@ -52,7 +52,8 @@ The mobile API gateway is a CLI subcommand, not a `[project.scripts]` console sc
 
 | File | Classification | Notes |
 |------|----------------|-------|
-| `rex_loop.py` | `developer-only` | Source voice-loop entry point. The packaged Electron Hold-to-Talk path is the supported end-user voice surface; wake word remains beta. |
+| `rex_loop.py` | `developer-only` | Source voice-loop entry point. Defaults to manual Hold-to-Talk activation; `--mode wake-word` is the explicit beta opt-in. The packaged Electron Hold-to-Talk path is the supported end-user voice surface. |
+| Wake-word voice activation | `beta` / `developer-only` | Available from `rex_loop.py --mode wake-word`; not a production claim until US-046 reliability evidence passes. |
 | `rex_speak_api.py` | `developer-only` | Same function as `rex-speak-api` entry point. Root-level script kept for direct invocation (`python rex_speak_api.py`). |
 | `wsgi.py` | `developer-only` | WSGI deployment entry point for `rex-gui`. Operator use for production deployments (e.g., gunicorn). |
 | `sitecustomize.py` | `developer-only` | Windows UTF-8 encoding fix; applied automatically at interpreter start. Not a user-facing entry point. |

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1314,3 +1314,18 @@ Local evidence:
 - GitHub checks remain pending before final story closeout.
 
 US-041 GitHub implementation-head gate: PASS. PR #353 head `ced2908`; CI run `31218152883` and commitlint run `31218150711` completed successfully. Windows Electron Artifact run `31218151625`, job `92996384714`, passed in 12m36s after building the managed runtime/installer, verifying packaged resources/privacy, and exercising the installed artifact without machine Python or Node. US-041 acceptance criteria are fully satisfied; this tracker closeout commit must itself receive a final green rerun before merge.
+
+
+=== 2026-08-07 - US-042 Hold-to-Talk production default ===
+
+Implementation:
+- `rex_loop.py` now exposes `--mode {hold-to-talk,wake-word}` and defaults to `hold-to-talk`.
+- Source Hold-to-Talk uses a lightweight Enter-key manual activation listener and does not initialize or consume wake-detection audio. The packaged Electron app remains the true press/hold production UX.
+- Existing direct `build_voice_loop()` callers retain their historical wake-word default for compatibility; the user-facing source entry point passes its explicit mode.
+- Wake-word remains an explicit beta/developer-only opt-in pending US-046 reliability evidence.
+- README, usage, voice-identity, surface classification, CLI help, and CLAUDE.md now describe the same boundary.
+
+Local evidence so far:
+- `pytest tests/test_voice_loop_default_mode.py tests/test_voice_loop.py tests/test_us074_voice_loop_pipeline.py -q`: 38 passed.
+- Ruff and Black on changed Python paths: pass.
+- Relevant GitHub checks remain pending the story PR.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1329,3 +1329,9 @@ Local evidence so far:
 - `pytest tests/test_voice_loop_default_mode.py tests/test_voice_loop.py tests/test_us074_voice_loop_pipeline.py -q`: 38 passed.
 - Ruff and Black on changed Python paths: pass.
 - Relevant GitHub checks remain pending the story PR.
+
+CI dependency drift found during US-042:
+- PR #354 run `31220716305` failed only the GUI Node Dependency Audit because the public advisory feed began flagging transitive `nanoid` 3.3.16 as high severity.
+- `npm audit fix --package-lock-only` safely refreshed the transitive lock to `nanoid` 3.3.18 without changing `package.json` or forcing the breaking React Router v7 migration.
+- `npm audit --audit-level=high` now exits clean with only two moderate React Router advisories remaining; `npm run typecheck` and all 99 GUI Vitest tests pass after a clean `npm ci`.
+- The lock refresh is included in US-042 because the story cannot satisfy its required GitHub gate while the external audit feed rejects the inherited lockfile.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1337,3 +1337,5 @@ CI dependency drift found during US-042:
 - The lock refresh is included in US-042 because the story cannot satisfy its required GitHub gate while the external audit feed rejects the inherited lockfile.
 
 - The same new high-severity `nanoid` advisory was also present in the separate developer-only `rex/ui/` lockfile. Its transitive lock was refreshed from 3.3.16 to 3.3.18 as well. `npm audit --audit-level=high` is now clean for both Node trees; the two remaining React Router findings are moderate and require a breaking major upgrade, so they are not forced into US-042.
+
+US-042 GitHub implementation-head gate: PASS. PR #354 head `10d47cb`; CI run `31221345052`, commitlint run `31221345005`, and Windows Electron Artifact run `31221345114` all completed successfully. Python coverage job `93006401557` and Windows installed-artifact job `93006401583` passed. This tracker closeout commit must itself receive a final green rerun before merge.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1335,3 +1335,5 @@ CI dependency drift found during US-042:
 - `npm audit fix --package-lock-only` safely refreshed the transitive lock to `nanoid` 3.3.18 without changing `package.json` or forcing the breaking React Router v7 migration.
 - `npm audit --audit-level=high` now exits clean with only two moderate React Router advisories remaining; `npm run typecheck` and all 99 GUI Vitest tests pass after a clean `npm ci`.
 - The lock refresh is included in US-042 because the story cannot satisfy its required GitHub gate while the external audit feed rejects the inherited lockfile.
+
+- The same new high-severity `nanoid` advisory was also present in the separate developer-only `rex/ui/` lockfile. Its transitive lock was refreshed from 3.3.16 to 3.3.18 as well. `npm audit --audit-level=high` is now clean for both Node trees; the two remaining React Router findings are moderate and require a breaking major upgrade, so they are not forced into US-042.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,25 +30,30 @@ Install the ML/audio stack first:
 pip install -r requirements-cpu.txt
 ```
 
-Then run:
+Then run the supported source default:
 
 ```bash
 python rex_loop.py
+# equivalent to: python rex_loop.py --mode hold-to-talk
 ```
+
+The source CLI's Hold-to-Talk mode uses an explicit Enter-key trigger followed by the existing VAD-bounded phrase capture. The packaged Electron app provides the production press/hold recording UX. Source Hold-to-Talk does not initialize the wake-word detector.
 
 Optional:
 
 ```bash
 python rex_loop.py --user james
 python rex_loop.py --enable-plugin web_search
+python rex_loop.py --mode wake-word
 ```
 
-Voice mode uses wake word detection, Whisper STT, the configured LLM provider, and TTS. Wake-word settings live under the canonical `wakeword` key in `config/rex_config.json`.
+Wake-word mode uses the configured wake detector before Whisper STT, the configured LLM provider, and TTS. It is an explicit beta opt-in until US-046 reliability evidence passes. Wake-word settings live under the canonical `wakeword` key in `config/rex_config.json`.
 
 Current voice state:
 
-- Hold to Talk is usable in current live testing.
-- Wake-word mode is wired and can work end to end, but reliability and latency are still being improved.
+- Electron Hold-to-Talk is the supported production voice path.
+- Source `rex_loop.py` defaults to manual Hold-to-Talk activation.
+- Wake-word mode is wired and can work end to end, but remains beta while reliability and latency are being measured.
 - Long answers now use a cleaner spoken handoff to the on-screen transcript.
 - Custom wake support is wired for built-in fallback, `custom_embedding`, and `custom_onnx`, but the repo does not ship a real `Hey Rex` custom asset by default.
 

--- a/docs/voice_identity.md
+++ b/docs/voice_identity.md
@@ -128,7 +128,7 @@ Without `--write-config`, the report is printed only.  With `--write-config
 
 ## How runtime recognition works
 
-1. The voice loop records audio after wake word detection.
+1. The voice loop records audio after the selected activation: Hold-to-Talk by default in `rex_loop.py`, or the beta wake-word detector when `--mode wake-word` is requested.
 2. If `voice_identity.enabled=true` and at least one user is enrolled, an
    `identify_speaker` callback is built at startup and wired into the voice loop.
 3. The callback converts the recorded numpy audio to PCM bytes and passes them

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -5455,9 +5455,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/rex/commands/_epilog.py
+++ b/rex/commands/_epilog.py
@@ -15,6 +15,10 @@ Examples:
   rex approvals --approve <id>
   rex workflows
 
+Voice commands:
+  python rex_loop.py --mode hold-to-talk   # supported default
+  python rex_loop.py --mode wake-word      # beta opt-in
+
 Planning and execution commands:
   rex plan "send monthly newsletter"
   rex plan "check weather in Dallas" --execute

--- a/rex/ui/package-lock.json
+++ b/rex/ui/package-lock.json
@@ -1524,9 +1524,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/rex/voice/activation.py
+++ b/rex/voice/activation.py
@@ -1,0 +1,45 @@
+"""Manual activation source for the source voice-loop hold-to-talk mode."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+
+DetectionSource = Callable[[], Awaitable[Any]]
+Trigger = Callable[[str], str]
+
+
+class ManualActivationListener:
+    """Yield an interaction when the user explicitly starts a source-CLI turn.
+
+    The packaged Electron application implements true press/hold recording in
+    the renderer.  The source CLI uses an Enter-key trigger followed by the
+    existing VAD-bounded phrase capture, which keeps wake-word detection fully
+    out of the default path without adding a platform-specific keyboard hook.
+    """
+
+    def __init__(
+        self,
+        *,
+        prompt: str = "Press Enter to talk (Ctrl+C to exit): ",
+        trigger: Trigger = input,
+    ) -> None:
+        self._prompt = prompt
+        self._trigger = trigger
+
+    async def listen(self, _source: DetectionSource) -> AsyncIterator[bytes]:
+        while True:
+            try:
+                await asyncio.to_thread(self._trigger, self._prompt)
+            except EOFError:
+                return
+            # VoiceLoop treats bytes as an activation-only frame and therefore
+            # will not prepend it to the separately captured command audio.
+            yield b""
+
+    def mark_listening_started(self, *, reason: str = "manual") -> None:
+        """Compatibility no-op for the VoiceLoop activation lifecycle."""
+
+    def reset(self, *, reason: str = "manual") -> None:
+        """Compatibility no-op for the VoiceLoop activation lifecycle."""

--- a/rex/voice/builder.py
+++ b/rex/voice/builder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shutil
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from rex.assistant_errors import (
     AudioDeviceError,
@@ -152,6 +152,7 @@ def _build_voice_id_callback() -> IdentifySpeakerCallable | None:
 def build_voice_loop(
     assistant,
     *,
+    activation_mode: str = "wake-word",
     sample_rate: int = 16000,
     detection_seconds: float = 1.0,
     capture_seconds: float | None = None,
@@ -197,7 +198,8 @@ def build_voice_loop(
         },
     )
 
-    from rex.wakeword.listener import build_default_detector
+    if activation_mode not in {"hold-to-talk", "wake-word"}:
+        raise ValueError(f"Unsupported voice activation mode: {activation_mode!r}")
 
     # Smart speaker microphone input (US-SP-003)
     smart_mic_recorder = None
@@ -243,35 +245,55 @@ def build_voice_loop(
         recorder=smart_mic_recorder,
     )
 
-    _vl().logger.info(
-        "[Pipeline] Initialising wake-word detector...",
-        extra={"event": "pipeline_stage_start", "stage": "wake_word"},
-    )
-    try:
-        wake_listener = build_default_detector(
-            sample_rate=sample_rate,
-            chunk_duration=detection_seconds,
-            threshold=getattr(_vl().settings, "wakeword_threshold", 0.1),
-            poll_interval=getattr(_vl().settings, "wakeword_poll_interval", 0.01),
-            keyword=getattr(_vl().settings, "wakeword_keyword", None)
-            or getattr(_vl().settings, "wakeword", None),
-            model_path=getattr(_vl().settings, "wakeword_model_path", None),
-            embedding_path=getattr(_vl().settings, "wakeword_embedding_path", None),
-            backend=getattr(_vl().settings, "wakeword_backend", None),
-            fallback_to_builtin=getattr(_vl().settings, "wakeword_fallback_to_builtin", True),
-            fallback_keyword=getattr(_vl().settings, "wakeword_fallback_keyword", "hey jarvis"),
+    wake_listener: Any
+    if activation_mode == "hold-to-talk":
+        from rex.voice.activation import ManualActivationListener
+
+        wake_listener = ManualActivationListener()
+        _vl().logger.info(
+            "[Pipeline] Manual hold-to-talk activation ready; wake detector not loaded",
+            extra={
+                "event": "pipeline_stage_ok",
+                "stage": "activation",
+                "activation_mode": activation_mode,
+            },
         )
-    except Exception as exc:
-        _vl().logger.error(
-            "[Pipeline] Wake-word stage failed: %s",
-            exc,
-            extra={"event": "pipeline_stage_failed", "stage": "wake_word", "error": str(exc)},
+    else:
+        from rex.wakeword.listener import build_default_detector
+
+        _vl().logger.info(
+            "[Pipeline] Initialising wake-word detector...",
+            extra={"event": "pipeline_stage_start", "stage": "wake_word"},
         )
-        raise
-    _vl().logger.info(
-        "[Pipeline] Wake-word detector ready",
-        extra={"event": "pipeline_stage_ok", "stage": "wake_word"},
-    )
+        try:
+            wake_listener = build_default_detector(
+                sample_rate=sample_rate,
+                chunk_duration=detection_seconds,
+                threshold=getattr(_vl().settings, "wakeword_threshold", 0.1),
+                poll_interval=getattr(_vl().settings, "wakeword_poll_interval", 0.01),
+                keyword=getattr(_vl().settings, "wakeword_keyword", None)
+                or getattr(_vl().settings, "wakeword", None),
+                model_path=getattr(_vl().settings, "wakeword_model_path", None),
+                embedding_path=getattr(_vl().settings, "wakeword_embedding_path", None),
+                backend=getattr(_vl().settings, "wakeword_backend", None),
+                fallback_to_builtin=getattr(_vl().settings, "wakeword_fallback_to_builtin", True),
+                fallback_keyword=getattr(_vl().settings, "wakeword_fallback_keyword", "hey jarvis"),
+            )
+        except Exception as exc:
+            _vl().logger.error(
+                "[Pipeline] Wake-word stage failed: %s",
+                exc,
+                extra={
+                    "event": "pipeline_stage_failed",
+                    "stage": "wake_word",
+                    "error": str(exc),
+                },
+            )
+            raise
+        _vl().logger.info(
+            "[Pipeline] Wake-word detector ready",
+            extra={"event": "pipeline_stage_ok", "stage": "wake_word"},
+        )
 
     _vl().logger.info(
         "[Pipeline] Initialising STT (model=%s, device=%s)...",

--- a/rex_loop.py
+++ b/rex_loop.py
@@ -110,6 +110,7 @@ async def _run(args) -> None:
         wake_sound_path = getattr(rex.settings, "wake_sound_path", None)
         voice_loop = build_voice_loop(
             assistant,
+            activation_mode=args.mode,
             sample_rate=rex.settings.sample_rate,
             detection_seconds=rex.settings.detection_frame_seconds,
             capture_seconds=rex.settings.capture_seconds,
@@ -146,8 +147,17 @@ async def _run(args) -> None:
         shutdown_plugins(plugin_specs)
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Run the Rex voice assistant loop.")
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the AskRex voice assistant loop.")
+    parser.add_argument(
+        "--mode",
+        choices=("hold-to-talk", "wake-word"),
+        default="hold-to-talk",
+        help=(
+            "Voice activation mode (default: hold-to-talk). "
+            "Use wake-word to opt into the beta wake detector."
+        ),
+    )
     parser.add_argument("--user", help="Override the active user profile")
     parser.add_argument(
         "--enable-plugin",
@@ -155,8 +165,11 @@ def main(argv: list[str] | None = None) -> int:
         metavar="NAME",
         help="Explicitly enable a plugin by name (omit to load all)",
     )
+    return parser
 
-    args = parser.parse_args(argv)
+
+def main(argv: list[str] | None = None) -> int:
+    args = _create_parser().parse_args(argv)
 
     try:
         asyncio.run(_run(args))

--- a/tests/test_voice_loop_default_mode.py
+++ b/tests/test_voice_loop_default_mode.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import rex_loop
+
+
+def test_voice_loop_cli_defaults_to_hold_to_talk() -> None:
+    args = rex_loop._create_parser().parse_args([])
+    assert args.mode == "hold-to-talk"
+
+
+def test_voice_loop_cli_allows_explicit_wake_word_mode() -> None:
+    args = rex_loop._create_parser().parse_args(["--mode", "wake-word"])
+    assert args.mode == "wake-word"
+
+
+def test_manual_activation_listener_does_not_consume_detection_audio() -> None:
+    from rex.voice.activation import ManualActivationListener
+
+    trigger_calls = 0
+    detection_calls = 0
+
+    def trigger(_prompt: str) -> str:
+        nonlocal trigger_calls
+        trigger_calls += 1
+        return ""
+
+    async def detection_source():
+        nonlocal detection_calls
+        detection_calls += 1
+        raise AssertionError("hold-to-talk mode must not consume wake-detection audio")
+
+    async def first_activation() -> bytes:
+        listener = ManualActivationListener(trigger=trigger)
+        stream = listener.listen(detection_source)
+        return await anext(stream)
+
+    assert asyncio.run(first_activation()) == b""
+    assert trigger_calls == 1
+    assert detection_calls == 0
+
+
+def test_manual_activation_listener_ends_cleanly_on_eof() -> None:
+    from rex.voice.activation import ManualActivationListener
+
+    def eof(_prompt: str) -> str:
+        raise EOFError
+
+    async def no_activation() -> None:
+        listener = ManualActivationListener(trigger=eof)
+        stream = listener.listen(lambda: pytest.fail("detection source should not run"))
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+
+    asyncio.run(no_activation())


### PR DESCRIPTION
## Summary
- add `--mode {hold-to-talk,wake-word}` to `rex_loop.py` with Hold-to-Talk as the source CLI default
- keep direct/internal `build_voice_loop()` callers backward-compatible while routing the user-facing entry point explicitly
- add lightweight manual activation that does not initialize or consume wake-detection audio in Hold-to-Talk mode
- keep packaged Electron press/hold recording as the supported production voice UX and label wake-word mode beta/developer-only until US-046
- align README, usage, voice-identity, surface classification, CLI help, CLAUDE.md, PRD, and progress evidence

## Local verification
- `pytest tests/test_voice_loop_default_mode.py -q` -> 4 passed
- focused voice/builder compatibility sweep -> 92 passed
- mypy on changed voice modules -> pass
- Ruff and Black on changed Python paths -> pass
- skip inventory -> 127/127 current
- `git diff --check` -> pass
- `python rex_loop.py --help` shows Hold-to-Talk default and wake-word opt-in
- `python -m rex --help` surfaces the Hold-to-Talk and wake-word commands

## Tracker
- US-042 local/code/docs criteria are checked with evidence
- GitHub-check criterion remains open until this PR head is green