### PR TITLE
feat(voice): add structured pipeline timing logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,7 +385,7 @@ python rex_loop.py --mode hold-to-talk
 # beta opt-in only:
 python rex_loop.py --mode wake-word
 
-The source CLI defaults to Hold-to-Talk/manual activation and must not initialize the wake-word detector unless `--mode wake-word` is explicitly selected. Electron Hold-to-Talk is the supported production voice path. It runs
+The source CLI defaults to Hold-to-Talk/manual activation and must not initialize the wake-word detector unless `--mode wake-word` is explicitly selected. Electron Hold-to-Talk is the supported production voice path. Canonical voice-stage timing events are documented in `docs/voice_pipeline.md`; preserve those event names and their `session_id`/monotonic timing fields when changing the pipeline. It runs
 renderer recording -> persistent managed Whisper STT -> streamed assistant
 response -> configured TTS -> selected output-device playback. Preserve
 cancellation/barge-in, replay, microphone device-loss fallback, repeated turns,

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1562,9 +1562,9 @@ python -m rex --help | grep -i "voice\|hold"
 **Implementation notes:** Emit JSON log records for `wake_detected`, `capture_started`, `capture_ended`, `stt_started`, `stt_completed`, `llm_started`, `llm_completed`, `tts_started`, `playback_completed`. Each record includes a `session_id`, monotonic `start_ns`, and `duration_ms` where applicable.
 
 **Acceptance Criteria:**
-- [ ] All nine events are emitted with the documented fields.
-- [ ] A test captures the log stream and asserts every expected event for one happy-path session.
-- [ ] `docs/voice_identity.md` (or new `docs/voice_pipeline.md`) documents the log contract.
+- [x] All nine events are emitted with the documented fields. *(`rex/voice/loop.py` emits stable JSON-extra fields using the process logging session ID and `time.monotonic_ns()` timing.)*
+- [x] A test captures the log stream and asserts every expected event for one happy-path session. *(`tests/test_voice_pipeline_logs.py` validates event order, fields, durations, and JSON serialization.)*
+- [x] `docs/voice_identity.md` (or new `docs/voice_pipeline.md`) documents the log contract. *(`docs/voice_pipeline.md` documents event semantics, timing fields, streaming overlap, and failure behavior.)*
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1565,7 +1565,7 @@ python -m rex --help | grep -i "voice\|hold"
 - [x] All nine events are emitted with the documented fields. *(`rex/voice/loop.py` emits stable JSON-extra fields using the process logging session ID and `time.monotonic_ns()` timing.)*
 - [x] A test captures the log stream and asserts every expected event for one happy-path session. *(`tests/test_voice_pipeline_logs.py` validates event order, fields, durations, and JSON serialization.)*
 - [x] `docs/voice_identity.md` (or new `docs/voice_pipeline.md`) documents the log contract. *(`docs/voice_pipeline.md` documents event semantics, timing fields, streaming overlap, and failure behavior.)*
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. *(PR #355 implementation head `c022660`: CI run `31223622521`, commitlint run `31223622680`, and Windows Electron Artifact run `31223622614` all passed; Python job `93013287284` completed in 8m09s and installed-artifact job `93013287155` in 12m42s.)*
 
 **Validation commands:**
 ```bash

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -76,6 +76,7 @@ This index covers active documentation under `docs/`. Files under `docs/archive/
 | [followup_engine.md](followup_engine.md) | Follow-up cue engine |
 | [knowledge_base.md](knowledge_base.md) | Knowledge base storage and search |
 | [memory.md](memory.md) | Memory systems |
+| [voice_pipeline.md](voice_pipeline.md) | Canonical structured voice-pipeline timing log contract |
 | [voice_identity.md](voice_identity.md) | Voice identity and enrollment |
 | [openclaw-agent-setup.md](openclaw-agent-setup.md) | OpenClaw gateway setup |
 | [openclaw-migration-status.md](openclaw-migration-status.md) | OpenClaw migration history/status |

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1339,3 +1339,18 @@ CI dependency drift found during US-042:
 - The same new high-severity `nanoid` advisory was also present in the separate developer-only `rex/ui/` lockfile. Its transitive lock was refreshed from 3.3.16 to 3.3.18 as well. `npm audit --audit-level=high` is now clean for both Node trees; the two remaining React Router findings are moderate and require a breaking major upgrade, so they are not forced into US-042.
 
 US-042 GitHub implementation-head gate: PASS. PR #354 head `10d47cb`; CI run `31221345052`, commitlint run `31221345005`, and Windows Electron Artifact run `31221345114` all completed successfully. Python coverage job `93006401557` and Windows installed-artifact job `93006401583` passed. This tracker closeout commit must itself receive a final green rerun before merge.
+
+
+=== 2026-08-07 - US-043 voice pipeline structured logs ===
+
+Implementation:
+- Added nine canonical structured voice timing events at real pipeline boundaries without removing legacy logs or `VoiceLatencyTracker`.
+- Every canonical event carries the process logging `session_id`, voice `interaction_id`, and monotonic `start_ns`; completed/ended stages carry `duration_ms`.
+- Streaming LLM/TTS/playback overlap is labeled truthfully with `timing_scope=streaming_llm_tts_playback` rather than presenting overlapping durations as isolated measurements.
+- Added `docs/voice_pipeline.md` and indexed it from `docs/INDEX.md`; the contract clarifies that `wake_detected` means accepted activation in Hold-to-Talk as well as literal wake-word mode.
+
+Local evidence so far:
+- Test-first `tests/test_voice_pipeline_logs.py` failed with 0/9 canonical events before implementation, then passed after instrumentation; the final contract test also exercises the overlapping streaming path.
+- Focused voice/log/latency/streaming regression sweep: 84 passed.
+- Ruff + Black on changed Python paths: pass. Mypy on `rex/logging_utils.py` and `rex/voice/loop.py`: pass.
+- Relevant GitHub checks remain pending the story PR.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1354,3 +1354,5 @@ Local evidence so far:
 - Focused voice/log/latency/streaming regression sweep: 84 passed.
 - Ruff + Black on changed Python paths: pass. Mypy on `rex/logging_utils.py` and `rex/voice/loop.py`: pass.
 - Relevant GitHub checks remain pending the story PR.
+
+US-043 GitHub implementation-head gate: PASS. PR #355 head `c022660`; CI run `31223622521`, commitlint run `31223622680`, and Windows Electron Artifact run `31223622614` completed successfully. Python job `93013287284` passed in 8m09s and installed Windows artifact job `93013287155` passed in 12m42s. This tracker closeout commit must itself receive a final green rerun before merge.

--- a/docs/voice_pipeline.md
+++ b/docs/voice_pipeline.md
@@ -1,0 +1,37 @@
+# Voice Pipeline Structured Log Contract
+
+AskRex emits a stable set of structured timing records for each successful voice interaction. These records are additive to the existing human-readable voice logs and `VoiceLatencyTracker` summary; operators can use the canonical event names below without scraping log messages.
+
+## Record fields
+
+Every canonical voice-pipeline record includes:
+
+- `event` ? one of the canonical event names below.
+- `session_id` ? the process-scoped AskRex logging session identifier. It is stable for the lifetime of the running process.
+- `interaction_id` ? the monotonically increasing voice interaction number within the `VoiceLoop` instance.
+- `start_ns` ? an integer timestamp from `time.monotonic_ns()`. It is for elapsed-time calculations only and is not a wall-clock timestamp.
+- `duration_ms` ? present on completed/ended stages where an elapsed interval is meaningful. It is a floating-point number of milliseconds.
+
+When JSON logging is enabled, these fields appear under the record's `extra` object.
+
+## Canonical events
+
+| Event | Meaning | `duration_ms` |
+|---|---|---|
+| `wake_detected` | An activation was accepted and an interaction began. The historical event name is retained for compatibility; in default Hold-to-Talk mode this means manual activation, not wake-word detection. | No |
+| `capture_started` | Command-audio capture started. | No |
+| `capture_ended` | Command-audio capture returned. | Yes, capture interval |
+| `stt_started` | The captured audio was handed to STT. | No |
+| `stt_completed` | STT returned successfully. | Yes, STT interval |
+| `llm_started` | Assistant response generation started. | No |
+| `llm_completed` | Assistant response generation completed. | Yes, LLM interval; on the streaming path the scope overlaps TTS/playback and is labeled `timing_scope=streaming_llm_tts_playback` |
+| `tts_started` | Spoken-response synthesis/playback handling began. | No |
+| `playback_completed` | The configured speak/streaming-speak operation returned successfully, meaning AskRex finished the response-audio operation it can directly observe. | Yes, TTS/playback operation interval |
+
+## Streaming overlap
+
+The streaming path deliberately overlaps LLM token generation, sentence buffering, TTS, and playback. For that path `tts_started` may occur before `llm_completed`, and the `llm_completed` and `playback_completed` records carry `timing_scope=streaming_llm_tts_playback`. Those durations therefore describe the observable combined streaming interval rather than pretending the overlapping components were isolated.
+
+## Failure behavior
+
+A completion event is emitted only when that stage completes successfully. Existing `pipeline_timeout`, `stt_error`, `tts_error`, and other stage-specific error records remain the failure contract. AskRex must not emit a successful completion record for a timed-out or failed stage.

--- a/rex/logging_utils.py
+++ b/rex/logging_utils.py
@@ -28,6 +28,12 @@ DEFAULT_ERROR_FILE = DEFAULT_ERROR_LOG_FILE
 _SESSION_ID = f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
 _SESSION_MARKED_PATHS: set[str] = set()
 
+
+def runtime_session_id() -> str:
+    """Return the stable identifier shared by structured logs in this runtime."""
+    return _SESSION_ID
+
+
 # Mapping from string name → logging constant
 _LEVEL_NAMES: dict[str, int] = {
     "DEBUG": logging.DEBUG,

--- a/rex/voice/loop.py
+++ b/rex/voice/loop.py
@@ -127,6 +127,34 @@ class VoiceLoop:
         self._post_interaction_cooldown = max(0.0, post_interaction_cooldown)
         self._post_wake_preroll_seconds = max(0.0, post_wake_preroll_seconds)
         self._interaction_id = 0
+        from rex.logging_utils import runtime_session_id
+
+        self._session_id = runtime_session_id()
+
+    def _log_pipeline_event(
+        self,
+        event: str,
+        *,
+        interaction_id: int,
+        start_ns: int,
+        duration_ms: float | None = None,
+        **fields: object,
+    ) -> None:
+        """Emit one stable structured timing record for a voice pipeline stage."""
+        extra: dict[str, object] = {
+            "event": event,
+            "session_id": self._session_id,
+            "interaction_id": interaction_id,
+            "start_ns": start_ns,
+            **fields,
+        }
+        if duration_ms is not None:
+            extra["duration_ms"] = float(duration_ms)
+        _vl().logger.info("[VoicePipeline] %s", event, extra=extra)
+
+    @staticmethod
+    def _duration_ms(start_ns: int) -> float:
+        return round((time.monotonic_ns() - start_ns) / 1_000_000, 3)
 
     @staticmethod
     def _resolve_identify_speaker_signature(
@@ -442,6 +470,10 @@ class VoiceLoop:
                     self._interaction_id += 1
                     interaction_id = self._interaction_id
                     tracker = VoiceLatencyTracker()
+                    wake_detected_ns = time.monotonic_ns()
+                    self._log_pipeline_event(
+                        "wake_detected", interaction_id=interaction_id, start_ns=wake_detected_ns
+                    )
                     _vl().logger.info(
                         "[Wake] Interaction accepted",
                         extra={"event": "wake_interaction_start", "interaction_id": interaction_id},
@@ -464,6 +496,10 @@ class VoiceLoop:
                     # because no-pause commands can otherwise be clipped before
                     # phrase capture begins.
                     capture_started_at = time.perf_counter()
+                    capture_start_ns = time.monotonic_ns()
+                    self._log_pipeline_event(
+                        "capture_started", interaction_id=interaction_id, start_ns=capture_start_ns
+                    )
                     _vl().logger.info(
                         "[Audio] Post-wake phrase capture starting",
                         extra={
@@ -476,6 +512,12 @@ class VoiceLoop:
                         wake_frame,
                         audio,
                         interaction_id=interaction_id,
+                    )
+                    self._log_pipeline_event(
+                        "capture_ended",
+                        interaction_id=interaction_id,
+                        start_ns=capture_start_ns,
+                        duration_ms=self._duration_ms(capture_start_ns),
                     )
                     await self._settle_wake_acknowledgement(ack_task, interaction_id=interaction_id)
 
@@ -516,6 +558,10 @@ class VoiceLoop:
                         },
                     )
                     tracker.mark("stt_start")
+                    stt_start_ns = time.monotonic_ns()
+                    self._log_pipeline_event(
+                        "stt_started", interaction_id=interaction_id, start_ns=stt_start_ns
+                    )
                     try:
                         transcript = await asyncio.wait_for(
                             self._transcribe(audio), timeout=self._stt_timeout
@@ -532,6 +578,12 @@ class VoiceLoop:
                         )
                         continue
                     tracker.mark("stt_end")
+                    self._log_pipeline_event(
+                        "stt_completed",
+                        interaction_id=interaction_id,
+                        start_ns=stt_start_ns,
+                        duration_ms=self._duration_ms(stt_start_ns),
+                    )
                     raw_transcript = transcript.strip()
                     stripped_transcript = _strip_wake_prefix(raw_transcript)
                     transcript = (
@@ -697,10 +749,21 @@ class VoiceLoop:
                     # Get LLM response - voice_mode=True enables conciseness prompt
                     _emit("executing")
                     tracker.mark("llm_start")
+                    llm_start_ns = time.monotonic_ns()
+                    self._log_pipeline_event(
+                        "llm_started", interaction_id=interaction_id, start_ns=llm_start_ns
+                    )
                     llm_response: str | None = None
                     if _speak_streaming is not None and callable(stream_reply):
                         tracker.mark("tts_synthesis_start")
                         tracker.mark("tts_first_chunk")
+                        tts_start_ns = time.monotonic_ns()
+                        self._log_pipeline_event(
+                            "tts_started",
+                            interaction_id=interaction_id,
+                            start_ns=tts_start_ns,
+                            timing_scope="streaming_llm_tts_playback",
+                        )
                         try:
                             token = _VOICE_INTERACTION_ID.set(interaction_id)
                             try:
@@ -726,6 +789,20 @@ class VoiceLoop:
                             )
                             continue
                         tracker.mark("llm_end")
+                        self._log_pipeline_event(
+                            "llm_completed",
+                            interaction_id=interaction_id,
+                            start_ns=llm_start_ns,
+                            duration_ms=self._duration_ms(llm_start_ns),
+                            timing_scope="streaming_llm_tts_playback",
+                        )
+                        self._log_pipeline_event(
+                            "playback_completed",
+                            interaction_id=interaction_id,
+                            start_ns=tts_start_ns,
+                            duration_ms=self._duration_ms(tts_start_ns),
+                            timing_scope="streaming_llm_tts_playback",
+                        )
                     else:
                         try:
                             llm_response = await asyncio.wait_for(
@@ -744,6 +821,12 @@ class VoiceLoop:
                             )
                             continue
                         tracker.mark("llm_end")
+                        self._log_pipeline_event(
+                            "llm_completed",
+                            interaction_id=interaction_id,
+                            start_ns=llm_start_ns,
+                            duration_ms=self._duration_ms(llm_start_ns),
+                        )
 
                         if not llm_response:
                             continue
@@ -761,6 +844,10 @@ class VoiceLoop:
                                 },
                             )
                             tracker.mark("tts_synthesis_start")
+                            tts_start_ns = time.monotonic_ns()
+                            self._log_pipeline_event(
+                                "tts_started", interaction_id=interaction_id, start_ns=tts_start_ns
+                            )
                             token = _VOICE_INTERACTION_ID.set(interaction_id)
                             try:
                                 await asyncio.wait_for(
@@ -768,6 +855,12 @@ class VoiceLoop:
                                 )
                             finally:
                                 _VOICE_INTERACTION_ID.reset(token)
+                            self._log_pipeline_event(
+                                "playback_completed",
+                                interaction_id=interaction_id,
+                                start_ns=tts_start_ns,
+                                duration_ms=self._duration_ms(tts_start_ns),
+                            )
                         except TimeoutError:
                             _vl().logger.error(
                                 "TTS stage timed out after %.0fs — resetting pipeline",

--- a/tests/test_voice_pipeline_logs.py
+++ b/tests/test_voice_pipeline_logs.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+from rex.logging_utils import JsonFormatter
+from rex.voice_loop import VoiceLoop
+
+EXPECTED_EVENTS = [
+    "wake_detected",
+    "capture_started",
+    "capture_ended",
+    "stt_started",
+    "stt_completed",
+    "llm_started",
+    "llm_completed",
+    "tts_started",
+    "playback_completed",
+]
+
+
+class _OnceListener:
+    async def listen(self, _source):
+        yield b"wake"
+
+    def mark_listening_started(self, *, reason: str = "test") -> None:
+        return None
+
+    def reset(self, *, reason: str = "test") -> None:
+        return None
+
+
+def test_happy_path_emits_structured_voice_pipeline_events(caplog) -> None:
+    async def detection_source():
+        return b"wake"
+
+    async def record_phrase():
+        return b"audio"
+
+    async def transcribe(_audio):
+        return "hello rex"
+
+    async def speak(_text: str) -> None:
+        return None
+
+    assistant = MagicMock()
+    assistant.generate_reply = AsyncMock(return_value="Hello there.")
+    del assistant.stream_reply
+
+    loop = VoiceLoop(
+        assistant,
+        wake_listener=_OnceListener(),
+        detection_source=detection_source,
+        record_phrase=record_phrase,
+        transcribe=transcribe,
+        speak=speak,
+        post_interaction_cooldown=0,
+    )
+
+    with caplog.at_level(logging.INFO, logger="rex.voice_loop"):
+        asyncio.run(loop.run(max_interactions=1))
+
+    records = [r for r in caplog.records if getattr(r, "event", None) in EXPECTED_EVENTS]
+    assert [r.event for r in records] == EXPECTED_EVENTS
+
+    session_ids = {r.session_id for r in records}
+    assert len(session_ids) == 1
+    assert next(iter(session_ids))
+
+    for record in records:
+        assert isinstance(record.start_ns, int)
+        assert record.start_ns > 0
+
+        payload = json.loads(JsonFormatter().format(record))
+        assert payload["extra"]["event"] == record.event
+        assert payload["extra"]["session_id"] == record.session_id
+        assert payload["extra"]["start_ns"] == record.start_ns
+
+    completed = {
+        "capture_ended",
+        "stt_completed",
+        "llm_completed",
+        "playback_completed",
+    }
+    for record in records:
+        if record.event in completed:
+            assert isinstance(record.duration_ms, float)
+            assert record.duration_ms >= 0.0
+        else:
+            assert not hasattr(record, "duration_ms")
+
+
+def test_streaming_happy_path_emits_same_canonical_event_set(caplog) -> None:
+    async def detection_source():
+        return b"wake"
+
+    async def record_phrase():
+        return b"audio"
+
+    async def transcribe(_audio):
+        return "hello rex"
+
+    async def speak(_text: str) -> None:
+        raise AssertionError("non-streaming speak should not be used")
+
+    async def stream_reply(_text: str, *, voice_mode: bool = False):
+        assert voice_mode is True
+        yield "Hello "
+        yield "there."
+
+    async def speak_streaming(chunks) -> None:
+        async for _chunk in chunks:
+            pass
+
+    assistant = MagicMock()
+    assistant.generate_reply = AsyncMock()
+    assistant.stream_reply = stream_reply
+
+    loop = VoiceLoop(
+        assistant,
+        wake_listener=_OnceListener(),
+        detection_source=detection_source,
+        record_phrase=record_phrase,
+        transcribe=transcribe,
+        speak=speak,
+        speak_streaming=speak_streaming,
+        post_interaction_cooldown=0,
+    )
+
+    with caplog.at_level(logging.INFO, logger="rex.voice_loop"):
+        asyncio.run(loop.run(max_interactions=1))
+
+    records = [r for r in caplog.records if getattr(r, "event", None) in EXPECTED_EVENTS]
+    assert {r.event for r in records} == set(EXPECTED_EVENTS)
+    assert len(records) == len(EXPECTED_EVENTS)
+    assistant.generate_reply.assert_not_awaited()
+
+    streaming_completed = {
+        r.event: r for r in records if r.event in {"llm_completed", "playback_completed"}
+    }
+    assert streaming_completed["llm_completed"].timing_scope == "streaming_llm_tts_playback"
+    assert streaming_completed["playback_completed"].timing_scope == "streaming_llm_tts_playback"


### PR DESCRIPTION
## Summary
- emit the nine canonical US-043 voice pipeline timing events at real stage boundaries
- attach stable process `session_id`, voice `interaction_id`, monotonic `start_ns`, and `duration_ms` on completed/ended stages
- preserve existing human-readable logs and `VoiceLatencyTracker`
- document streaming overlap truthfully with `timing_scope=streaming_llm_tts_playback`
- add the structured log contract to `docs/voice_pipeline.md` and the docs index

## Local verification
- `pytest tests/test_voice_pipeline_logs.py -q` -> 2 passed
- voice/log/latency/streaming regression sweep -> 84 passed
- logging regression suite -> 30 passed
- Ruff + Black changed Python paths -> pass
- mypy `rex/logging_utils.py rex/voice/loop.py` -> pass
- skip inventory -> 127/127 current
- `git diff --check` -> pass

## Tracker
- US-043 local/code/docs criteria are checked with evidence
- GitHub-check criterion remains open until this PR head is green