### PR TITLE
test(voice): add US-044 latency budget gate

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1590,7 +1590,7 @@ pytest tests/test_voice_pipeline_logs.py -q
 - [x] Budget table documented in `docs/voice_pipeline.md`.
 - [x] At least one test enforces a budget on each stage.
 - [x] Test runs on CI under `slow` only OR under default markers if fast enough.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. (PR #356 implementation head `9a8e706`; CI run `31231785722` and commitlint run `31231785762` passed.)
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1587,9 +1587,9 @@ pytest tests/test_voice_pipeline_logs.py -q
 **Implementation notes:** Define stage budgets (e.g., STT < 1500 ms, LLM token-to-first < 500 ms for local provider) and assert under a synthetic input fixture. Mark as `slow` if needed.
 
 **Acceptance Criteria:**
-- [ ] Budget table documented in `docs/voice_pipeline.md`.
-- [ ] At least one test enforces a budget on each stage.
-- [ ] Test runs on CI under `slow` only OR under default markers if fast enough.
+- [x] Budget table documented in `docs/voice_pipeline.md`.
+- [x] At least one test enforces a budget on each stage.
+- [x] Test runs on CI under `slow` only OR under default markers if fast enough.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1356,3 +1356,18 @@ Local evidence so far:
 - Relevant GitHub checks remain pending the story PR.
 
 US-043 GitHub implementation-head gate: PASS. PR #355 head `c022660`; CI run `31223622521`, commitlint run `31223622680`, and Windows Electron Artifact run `31223622614` completed successfully. Python job `93013287284` passed in 8m09s and installed Windows artifact job `93013287155` passed in 12m42s. This tracker closeout commit must itself receive a final green rerun before merge.
+
+
+=== 2026-08-07 - US-044 voice latency budget tests ===
+
+Implementation:
+- Added `tests/test_voice_latency_budget.py`, which drives the real canonical `VoiceLoop` with synthetic callbacks and enforces per-stage orchestration budgets for activation-to-capture, capture, STT, LLM, TTS/playback, and total interaction latency.
+- Added matching synthetic CI budget documentation to `docs/voice_pipeline.md` and explicitly separated these regression guards from real hardware/network/model SLAs.
+- The test remains in the default pytest marker set because it is synthetic and completes well under one second; no `slow`, `audio`, or `gpu` marker is required.
+
+Local evidence so far:
+- Red phase: new budget-contract test failed because the budget table was not documented yet; the runtime budget assertion already passed.
+- After documentation: `pytest tests/test_voice_latency_budget.py tests/test_voice_pipeline_logs.py tests/test_us167_voice_latency.py -q`: 34 passed.
+- Ruff and Black on `tests/test_voice_latency_budget.py`: pass.
+- `git diff --check`: pass.
+- Relevant GitHub checks remain pending the story PR.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1371,3 +1371,5 @@ Local evidence so far:
 - Ruff and Black on `tests/test_voice_latency_budget.py`: pass.
 - `git diff --check`: pass.
 - Relevant GitHub checks remain pending the story PR.
+
+US-044 GitHub implementation-head gate: PASS. PR #356 head `9a8e706`; CI run `31231785722` and commitlint run `31231785762` completed successfully. The corrected head also passed skip-inventory validation after removing the UTF-8 BOM from the new test file. This tracker closeout commit must itself receive a final green rerun before merge.

--- a/docs/voice_pipeline.md
+++ b/docs/voice_pipeline.md
@@ -35,3 +35,28 @@ The streaming path deliberately overlaps LLM token generation, sentence bufferin
 ## Failure behavior
 
 A completion event is emitted only when that stage completes successfully. Existing `pipeline_timeout`, `stt_error`, `tts_error`, and other stage-specific error records remain the failure contract. AskRex must not emit a successful completion record for a timed-out or failed stage.
+
+
+## Synthetic CI latency budgets
+
+`tests/test_voice_latency_budget.py` exercises the real canonical `VoiceLoop` with synthetic,
+non-hardware callbacks. The budgets below are regression guards for AskRex orchestration and
+stage hand-offs; they are not end-user hardware, network, or model-provider SLAs. Real Whisper,
+LLM, TTS, audio-driver, and speaker latency is tracked separately by runtime telemetry and the
+performance baseline.
+
+The first release uses intentionally wide margins so shared CI runners do not create false
+failures while still catching accidental blocking calls, sleeps, or serial regressions.
+
+| Synthetic stage | Budget key | Maximum |
+|---|---|---|
+| Activation accepted -> capture start | `activation_to_capture` | 250 ms |
+| Capture callback | `capture` | 500 ms |
+| STT callback | `stt` | 500 ms |
+| LLM response callback | `llm` | 500 ms |
+| TTS/playback callback | `tts_playback` | 500 ms |
+| Activation -> playback complete | `total` | 2000 ms |
+
+The budget test runs in the default pytest marker set because it uses synthetic callbacks and
+completes in well under one second. If a budget is intentionally changed, update this table and
+the enforced constants in the same change so documentation and CI cannot drift apart.

--- a/tests/test_voice_latency_budget.py
+++ b/tests/test_voice_latency_budget.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/tests/test_voice_latency_budget.py
+++ b/tests/test_voice_latency_budget.py
@@ -1,0 +1,116 @@
+﻿from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from rex.voice_loop import VoiceLoop
+
+VOICE_PIPELINE_DOC = Path(__file__).parent.parent / "docs" / "voice_pipeline.md"
+
+STAGE_BUDGETS_MS = {
+    "activation_to_capture": 250.0,
+    "capture": 500.0,
+    "stt": 500.0,
+    "llm": 500.0,
+    "tts_playback": 500.0,
+    "total": 2000.0,
+}
+
+
+class _OnceListener:
+    async def listen(self, _source):
+        yield b"wake"
+
+    def mark_listening_started(self, *, reason: str = "test") -> None:
+        return None
+
+    def reset(self, *, reason: str = "test") -> None:
+        return None
+
+
+def _run_synthetic_pipeline(caplog) -> dict[str, logging.LogRecord]:
+    async def detection_source():
+        return b"wake"
+
+    async def record_phrase():
+        return b"audio"
+
+    async def transcribe(_audio):
+        return "hello rex"
+
+    async def speak(_text: str) -> None:
+        return None
+
+    assistant = MagicMock()
+    assistant.generate_reply = AsyncMock(return_value="Hello there.")
+    del assistant.stream_reply
+
+    loop = VoiceLoop(
+        assistant,
+        wake_listener=_OnceListener(),
+        detection_source=detection_source,
+        record_phrase=record_phrase,
+        transcribe=transcribe,
+        speak=speak,
+        post_interaction_cooldown=0,
+    )
+
+    with caplog.at_level(logging.INFO, logger="rex.voice_loop"):
+        asyncio.run(loop.run(max_interactions=1))
+
+    expected = {
+        "wake_detected",
+        "capture_started",
+        "capture_ended",
+        "stt_completed",
+        "llm_completed",
+        "playback_completed",
+    }
+    records = {
+        record.event: record
+        for record in caplog.records
+        if getattr(record, "event", None) in expected
+    }
+    assert records.keys() == expected
+    return records
+
+
+def test_synthetic_voice_pipeline_stays_within_stage_budgets(caplog) -> None:
+    records = _run_synthetic_pipeline(caplog)
+    wake = records["wake_detected"]
+    capture_started = records["capture_started"]
+    playback = records["playback_completed"]
+
+    measured_ms = {
+        "activation_to_capture": (capture_started.start_ns - wake.start_ns) / 1_000_000,
+        "capture": records["capture_ended"].duration_ms,
+        "stt": records["stt_completed"].duration_ms,
+        "llm": records["llm_completed"].duration_ms,
+        "tts_playback": playback.duration_ms,
+        "total": ((playback.start_ns - wake.start_ns) / 1_000_000) + playback.duration_ms,
+    }
+
+    for stage, budget_ms in STAGE_BUDGETS_MS.items():
+        assert measured_ms[stage] <= budget_ms, (
+            f"{stage} latency {measured_ms[stage]:.3f} ms exceeded "
+            f"the synthetic CI budget of {budget_ms:.0f} ms"
+        )
+
+
+def test_documented_budget_table_matches_enforced_contract() -> None:
+    document = VOICE_PIPELINE_DOC.read_text(encoding="utf-8")
+    labels = {
+        "activation_to_capture": "Activation accepted -> capture start",
+        "capture": "Capture callback",
+        "stt": "STT callback",
+        "llm": "LLM response callback",
+        "tts_playback": "TTS/playback callback",
+        "total": "Activation -> playback complete",
+    }
+
+    for stage, label in labels.items():
+        budget_ms = STAGE_BUDGETS_MS[stage]
+        expected_row = f"| {label} | `{stage}` | {budget_ms:.0f} ms |"
+        assert expected_row in document


### PR DESCRIPTION
## Summary
- add a fast synthetic VoiceLoop latency-budget regression test
- document the matching CI budgets and distinguish them from real hardware/model SLAs
- update the authoritative production-readiness tracker and progress evidence

## Local validation
- `pytest tests/test_voice_latency_budget.py tests/test_voice_pipeline_logs.py tests/test_us167_voice_latency.py -q` — 34 passed
- `ruff check tests/test_voice_latency_budget.py` — pass
- `black --check tests/test_voice_latency_budget.py` — pass
- `git diff --check` — pass

The GitHub-check acceptance criterion remains open until this exact PR head is green.