### PR TITLE
fix(voice): surface audio device diagnostics

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1618,7 +1618,7 @@ pytest tests/test_voice_latency_budget.py -q
 - [x] On speaker init failure, the same holds.
 - [x] A test confirms the error is surfaced to the IPC handler with a user-actionable message.
 - [x] `docs/troubleshooting.md` lists the new errors.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. (PR #357 corrected implementation head `3657005`; CI run `31234847034`, commitlint run `31234847011`, and Windows Electron Artifact run `31234847017` passed. Python job `93045346469` passed in 9m13s and installed Windows artifact job `93045346341` passed in 12m12s.)
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1614,10 +1614,10 @@ pytest tests/test_voice_latency_budget.py -q
 - `tests/test_audio_diagnostics.py`
 
 **Acceptance Criteria:**
-- [ ] On mic init failure, voice loop emits a structured error AND the Electron GUI shows a visible error toast/banner.
-- [ ] On speaker init failure, the same holds.
-- [ ] A test confirms the error is surfaced to the IPC handler with a user-actionable message.
-- [ ] `docs/troubleshooting.md` lists the new errors.
+- [x] On mic init failure, voice loop emits a structured error AND the Electron GUI shows a visible error toast/banner.
+- [x] On speaker init failure, the same holds.
+- [x] A test confirms the error is surfaced to the IPC handler with a user-actionable message.
+- [x] `docs/troubleshooting.md` lists the new errors.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/bridge/rex_voice_bridge.py
+++ b/bridge/rex_voice_bridge.py
@@ -237,6 +237,20 @@ def emit_log(level: str, message: str, extra: dict[str, object] | None = None) -
     )
 
 
+def emit_audio_diagnostic(diagnostic: dict[str, object]) -> None:
+    """Forward a structured audio diagnostic to the Electron error channel."""
+    user_message = str(diagnostic.get("user_message") or "Voice audio device unavailable.")
+    emit_log("ERROR", "Voice audio device unavailable", diagnostic)
+    emit(
+        {
+            "type": "error",
+            "error": user_message,
+            "code": diagnostic.get("code"),
+            "device_kind": diagnostic.get("device_kind"),
+        }
+    )
+
+
 def time_ms() -> int:
     return int(time.time() * 1000)
 
@@ -763,6 +777,7 @@ async def _run_real_loop() -> None:
         acknowledge=ack.play,
         post_stt_acknowledge=wrapped_post_stt_ack,
         state_callback=emit_voice_loop_state,
+        diagnostic_callback=emit_audio_diagnostic,
     )
 
     # Start stdin watcher after startup. On Windows, reading a live stdin pipe

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1373,3 +1373,21 @@ Local evidence so far:
 - Relevant GitHub checks remain pending the story PR.
 
 US-044 GitHub implementation-head gate: PASS. PR #356 head `9a8e706`; CI run `31231785722` and commitlint run `31231785762` completed successfully. The corrected head also passed skip-inventory validation after removing the UTF-8 BOM from the new test file. This tracker closeout commit must itself receive a final green rerun before merge.
+
+=== 2026-08-07 - US-045 mic/speaker diagnostics surfaced to the user ===
+
+Implementation:
+- Added a stable `audio_device_error` diagnostic contract with `microphone_unavailable` and `speaker_unavailable` codes plus actionable Voice-settings/OS recovery guidance.
+- `VoiceLoop` now emits structured microphone/speaker diagnostics at the real failing stage and forwards them through an optional diagnostic callback without replacing the useful error with the old generic state error.
+- The Electron voice bridge forwards the diagnostic through the existing `rex:voiceError` IPC channel; the Voice page renders the message in an assertive visible alert.
+- Local TTS playback failures now propagate as `AudioDeviceError` instead of being silently reduced to stdout text, while non-device provider/synthesis failures retain their existing fallback behavior.
+- `docs/troubleshooting.md` documents the microphone and speaker errors and recovery steps.
+
+Local evidence so far:
+- TDD red phase: `tests/test_audio_diagnostics.py` initially failed 2/2 because `VoiceLoop` had no diagnostic callback contract.
+- Final `tests/test_audio_diagnostics.py`: 4 passed, including bridge preservation and real TTS device-failure propagation.
+- Voice/audio regression sweep: 91 passed.
+- TTS regression sweep: 90 passed.
+- GUI diagnostic + microphone-routing Vitest tests: 2 passed; GUI TypeScript typecheck and touched-file ESLint: pass.
+- Ruff, Black, mypy, skip-inventory validation, and `git diff --check`: pass on the relevant changed paths.
+- Relevant GitHub checks remain pending the story PR.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1391,3 +1391,5 @@ Local evidence so far:
 - GUI diagnostic + microphone-routing Vitest tests: 2 passed; GUI TypeScript typecheck and touched-file ESLint: pass.
 - Ruff, Black, mypy, skip-inventory validation, and `git diff --check`: pass on the relevant changed paths.
 - Relevant GitHub checks remain pending the story PR.
+
+US-045 GitHub implementation-head gate: PASS. PR #357 corrected head `3657005`; CI run `31234847034`, commitlint run `31234847011`, and Windows Electron Artifact run `31234847017` all completed successfully. Python job `93045346469` passed in 9m13s and installed Windows artifact job `93045346341` passed in 12m12s. This tracker closeout commit must itself receive a final green rerun before merge.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -135,3 +135,30 @@ REX_SPEAK_STORAGE_URI=redis://localhost:6379/0
 1. Use smaller Whisper model: `REX_WHISPER_MODEL=tiny` or `base`
 2. Reduce max tokens: `REX_LLM_MAX_TOKENS=50`
 3. Switch to CPU: `REX_DEVICE=cpu` and `REX_WHISPER_DEVICE=cpu`
+
+
+## Microphone Unavailable in Voice Mode
+
+**Error:** `Microphone unavailable. Reconnect or select a microphone in Voice settings, then check your operating-system microphone permissions.`
+
+**What it means:** AskRex could not initialize or continue using the microphone selected for voice mode. The Electron Voice page shows this message directly instead of only reporting a generic voice-pipeline failure.
+
+**Solution:**
+1. Open **Settings → Voice** and select an available microphone, or switch back to the system default.
+2. Reconnect the microphone if it was unplugged or disconnected.
+3. Confirm AskRex/Electron has microphone permission in your operating-system privacy settings.
+4. Close another application temporarily if it may be holding the microphone exclusively, then try voice mode again.
+5. Run `python -m rex doctor` if the device still cannot be opened.
+
+## Speaker Output Unavailable in Voice Mode
+
+**Error:** `Speaker output unavailable. Reconnect or select an output device in Voice settings, then check your operating-system sound output.`
+
+**What it means:** AskRex generated a response but the configured playback device could not be initialized or used. The Voice page shows the output-device error directly.
+
+**Solution:**
+1. Open **Settings → Voice** and select an available output device, or switch back to the system default.
+2. Reconnect or power on the selected speakers/headphones.
+3. Confirm the operating system is routing sound to that device and that it is not disabled.
+4. Close another application temporarily if it may be holding the output device exclusively, then try again.
+5. Run `python -m rex doctor` if output still cannot be opened.

--- a/gui/src/main/handlers/voice.ts
+++ b/gui/src/main/handlers/voice.ts
@@ -22,6 +22,8 @@ type VoiceBridgeEvent = {
   message?: string
   extra?: Record<string, unknown>
   traceback?: string
+  code?: string
+  device_kind?: string
 }
 type VoiceBridgeEventContext = {
   process: ChildProcess
@@ -157,6 +159,8 @@ function handleVoiceErrorEvent(event: VoiceBridgeEvent, context: VoiceBridgeEven
   appendElectronLog('ERROR', 'GUI voice bridge error event', {
     event: 'voice_bridge_error',
     error,
+    code: event.code,
+    device_kind: event.device_kind,
     traceback: event.traceback,
     pid: context.process.pid
   })

--- a/gui/src/pages/VoicePage.tsx
+++ b/gui/src/pages/VoicePage.tsx
@@ -940,7 +940,7 @@ export function VoicePage(): React.ReactElement {
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-full gap-4">
+      <div role="alert" aria-live="assertive" className="flex flex-col items-center justify-center h-full gap-4">
         <EmptyState
           icon={<MicOffIcon />}
           heading="Voice backend unavailable"

--- a/gui/tests/audioDiagnostics.test.ts
+++ b/gui/tests/audioDiagnostics.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('voice audio diagnostics', () => {
+  it('surfaces actionable bridge diagnostics through Electron to an alert', () => {
+    const bridge = readFileSync(join(__dirname, '../../bridge/rex_voice_bridge.py'), 'utf8')
+    const handler = readFileSync(join(__dirname, '../src/main/handlers/voice.ts'), 'utf8')
+    const preload = readFileSync(join(__dirname, '../src/preload/index.ts'), 'utf8')
+    const page = readFileSync(join(__dirname, '../src/pages/VoicePage.tsx'), 'utf8')
+
+    expect(bridge).toContain('diagnostic_callback=emit_audio_diagnostic')
+    expect(bridge).toContain('"error": user_message')
+    expect(handler).toContain("broadcastVoiceEvent('rex:voiceError', { error })")
+    expect(handler).toContain('context.failStartup(error)')
+    expect(preload).toContain("ipcRenderer.on('rex:voiceError'")
+    expect(page).toContain('role="alert"')
+    expect(page).toContain('subtext={error}')
+  })
+})

--- a/rex/audio_config.py
+++ b/rex/audio_config.py
@@ -60,6 +60,34 @@ def _normalize_device_name(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", " ", value.casefold()).strip()
 
 
+def build_audio_device_diagnostic(
+    device_kind: str,
+    error: BaseException | str,
+) -> dict[str, object]:
+    """Build a stable, user-actionable diagnostic for voice audio failures."""
+    normalized_kind = "speaker" if device_kind == "speaker" else "microphone"
+    detail = str(error).strip() or "audio device unavailable"
+    if normalized_kind == "speaker":
+        code = "speaker_unavailable"
+        user_message = (
+            "Speaker output unavailable. Reconnect or select an output device in Voice settings, "
+            "then check your operating-system sound output."
+        )
+    else:
+        code = "microphone_unavailable"
+        user_message = (
+            "Microphone unavailable. Reconnect or select a microphone in Voice settings, then "
+            "check your operating-system microphone permissions."
+        )
+    return {
+        "event": "audio_device_error",
+        "code": code,
+        "device_kind": normalized_kind,
+        "error": detail,
+        "user_message": user_message,
+    }
+
+
 _HOSTAPI_INPUT_PRIORITY = {
     # DirectSound/MME are the most reliable shared-mode choices for the
     # blocking ``sounddevice.rec`` path used by wake-word capture on

--- a/rex/voice/loop.py
+++ b/rex/voice/loop.py
@@ -13,6 +13,7 @@ from rex.assistant_errors import (
     SpeechToTextError,
     TextToSpeechError,
 )
+from rex.audio_config import build_audio_device_diagnostic
 from rex.voice._types import (
     AudioArray,
     IdentifySpeakerCallable,
@@ -70,6 +71,7 @@ class VoiceLoop:
         post_stt_acknowledge: Callable[[], Awaitable[None]] | None = None,
         identify_speaker: IdentifySpeakerCallable | None = None,
         state_callback: Callable[[str], None] | None = None,
+        diagnostic_callback: Callable[[dict[str, object]], None] | None = None,
         sample_rate: int = 16000,
         stt_timeout: float = 30.0,
         llm_timeout: float = 60.0,
@@ -117,6 +119,7 @@ class VoiceLoop:
         self._post_stt_acknowledge = post_stt_acknowledge
         self._identify_speaker = identify_speaker
         self._state_callback = state_callback
+        self._diagnostic_callback = diagnostic_callback
         self._identify_speaker_accepts_audio = self._resolve_identify_speaker_signature(
             identify_speaker
         )
@@ -155,6 +158,32 @@ class VoiceLoop:
     @staticmethod
     def _duration_ms(start_ns: int) -> float:
         return round((time.monotonic_ns() - start_ns) / 1_000_000, 3)
+
+    def _report_audio_device_error(
+        self,
+        device_kind: str,
+        exc: AudioDeviceError,
+        *,
+        interaction_id: int | None = None,
+    ) -> None:
+        diagnostic = build_audio_device_diagnostic(device_kind, exc)
+        extra: dict[str, object] = {
+            **diagnostic,
+            "session_id": self._session_id,
+        }
+        if interaction_id is not None:
+            extra["interaction_id"] = interaction_id
+        _vl().logger.error(
+            "Audio %s error: %s",
+            diagnostic["device_kind"],
+            exc,
+            extra=extra,
+        )
+        if self._diagnostic_callback is not None:
+            try:
+                self._diagnostic_callback(diagnostic)
+            except Exception:
+                _vl().logger.exception("Voice diagnostic callback failed")
 
     @staticmethod
     def _resolve_identify_speaker_signature(
@@ -469,6 +498,7 @@ class VoiceLoop:
                 try:
                     self._interaction_id += 1
                     interaction_id = self._interaction_id
+                    audio_device_kind = "microphone"
                     tracker = VoiceLatencyTracker()
                     wake_detected_ns = time.monotonic_ns()
                     self._log_pipeline_event(
@@ -631,12 +661,14 @@ class VoiceLoop:
                         _emit("thinking")
                         token = _VOICE_INTERACTION_ID.set(interaction_id)
                         try:
+                            audio_device_kind = "speaker"
                             await asyncio.wait_for(
                                 self._speak(_WEAK_TRANSCRIPT_RETRY_PROMPT),
                                 timeout=self._tts_timeout,
                             )
                         finally:
                             _VOICE_INTERACTION_ID.reset(token)
+                        audio_device_kind = "microphone"
                         transcript = await self._capture_followup_transcript(
                             interaction_id=interaction_id,
                             reason="weak_transcript_retry",
@@ -680,12 +712,14 @@ class VoiceLoop:
                         _emit("thinking")
                         token = _VOICE_INTERACTION_ID.set(interaction_id)
                         try:
+                            audio_device_kind = "speaker"
                             await asyncio.wait_for(
                                 self._speak(_SUSPICIOUS_TRANSCRIPT_RETRY_PROMPT),
                                 timeout=self._tts_timeout,
                             )
                         finally:
                             _VOICE_INTERACTION_ID.reset(token)
+                        audio_device_kind = "microphone"
                         transcript = await self._capture_followup_transcript(
                             interaction_id=interaction_id,
                             reason="suspicious_transcript_retry",
@@ -767,6 +801,7 @@ class VoiceLoop:
                         try:
                             token = _VOICE_INTERACTION_ID.set(interaction_id)
                             try:
+                                audio_device_kind = "speaker"
                                 await asyncio.wait_for(
                                     _speak_streaming(
                                         _sentence_buffer_stream(
@@ -850,6 +885,7 @@ class VoiceLoop:
                             )
                             token = _VOICE_INTERACTION_ID.set(interaction_id)
                             try:
+                                audio_device_kind = "speaker"
                                 await asyncio.wait_for(
                                     self._speak(llm_response), timeout=self._tts_timeout
                                 )
@@ -874,6 +910,7 @@ class VoiceLoop:
                             )
                             continue
                         if _looks_like_clarification_reply(llm_response, transcript):
+                            audio_device_kind = "microphone"
                             followup_transcript = await self._capture_followup_transcript(
                                 interaction_id=interaction_id,
                                 reason="assistant_clarification",
@@ -934,6 +971,7 @@ class VoiceLoop:
                                     token = _VOICE_INTERACTION_ID.set(interaction_id)
                                     try:
                                         try:
+                                            audio_device_kind = "speaker"
                                             await asyncio.wait_for(
                                                 self._speak(followup_response),
                                                 timeout=self._tts_timeout,
@@ -990,8 +1028,12 @@ class VoiceLoop:
                     _emit("error")
                     # Continue loop on TTS errors; text response preserved in log
                 except AudioDeviceError as exc:
-                    _vl().logger.error("Audio device error: %s", exc)
-                    _emit("error")
+                    self._report_audio_device_error(
+                        audio_device_kind,
+                        exc,
+                        interaction_id=interaction_id,
+                    )
+                    _emit("idle" if self._diagnostic_callback is not None else "error")
                     break
                 except Exception as exc:
                     _vl().logger.error("Unexpected error in voice loop: %s", exc)
@@ -1001,9 +1043,10 @@ class VoiceLoop:
                 if max_interactions is not None and interactions >= max_interactions:
                     break
         except AudioDeviceError as exc:
+            self._report_audio_device_error("microphone", exc)
             _vl().logger.error(
                 "Audio device error — pipeline halted: %s",
                 exc,
                 extra={"event": "pipeline_blocker", "stage": "audio_device", "error": str(exc)},
             )
-            _emit("error")
+            _emit("idle" if self._diagnostic_callback is not None else "error")

--- a/rex/voice/tts.py
+++ b/rex/voice/tts.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from rex.assistant_errors import (
+    AudioDeviceError,
     TextToSpeechError,
 )
 from rex.tts_utils import chunk_text_for_xtts
@@ -254,6 +255,8 @@ class TextToSpeech:
                 run_metrics["path_used"] = "stdout"
                 run_metrics["speech_start_delay_s"] = 0.0
                 print(f"Rex: {text}")
+        except AudioDeviceError:
+            raise
         except Exception as exc:
             if self._provider == "xtts" and self._xtts_init_error:
                 reason = f"XTTS not initialized ({self._xtts_init_error})"
@@ -495,14 +498,21 @@ class TextToSpeech:
 
             if Path(chunk_path).exists():
                 routed = await asyncio.to_thread(self._try_smart_speaker, chunk_path)
-                if not routed and _vl().sa is not None:
+                if not routed:
+                    if _vl().sa is None:
+                        raise AudioDeviceError(
+                            "Local speaker playback is unavailable because simpleaudio is not installed."
+                        )
 
                     def _play(_path=chunk_path) -> None:
                         wave_obj = _vl().sa.WaveObject.from_wave_file(_path)
                         play_obj = wave_obj.play()
                         play_obj.wait_done()
 
-                    await asyncio.to_thread(_play)
+                    try:
+                        await asyncio.to_thread(_play)
+                    except Exception as exc:
+                        raise AudioDeviceError(f"Speaker playback failed: {exc}") from exc
         finally:
             try:
                 os.unlink(chunk_path)
@@ -539,8 +549,12 @@ class TextToSpeech:
                     continue
                 try:
                     await self.speak(sentence, speaker_wav=speaker_wav)
+                except AudioDeviceError:
+                    raise
                 except Exception as exc:
                     _vl().logger.error("[TTS streaming] chunk failed: %s", exc)
+        except AudioDeviceError:
+            raise
         except Exception as exc:
             _vl().logger.error("[TTS streaming] failed: %s", exc)
 
@@ -673,18 +687,9 @@ class TextToSpeech:
         )
 
         if _vl().sa is None:
-            _vl().logger.error("LOCAL PLAYBACK ERROR: simpleaudio is not available in _speak_edge")
-            return {
-                "path_used": "edge",
-                "voice": voice,
-                "first_audio_chunk_s": first_audio_chunk_s,
-                "synthesis_ready_s": synthesis_ready_s,
-                "speech_start_delay_s": None,
-                "playback_duration_s": 0.0,
-                "audio_duration_s": audio_duration_s,
-                "used_streaming": used_streaming,
-                "playback_available": False,
-            }
+            raise AudioDeviceError(
+                "Local speaker playback is unavailable because simpleaudio is not installed."
+            )
 
         def _play(_pcm=pcm_data, _sample_rate=sample_rate, _channels=channel_count) -> None:
             play_obj = _vl().sa.play_buffer(
@@ -713,7 +718,10 @@ class TextToSpeech:
             channel_count,
             int(pcm_data.shape[0]),
         )
-        await asyncio.to_thread(_play)
+        try:
+            await asyncio.to_thread(_play)
+        except Exception as exc:
+            raise AudioDeviceError(f"Speaker playback failed: {exc}") from exc
         playback_duration_s = round(time.perf_counter() - playback_started_at, 3)
         _vl().logger.info(
             "[TTS:edge] Local playback finished",
@@ -791,7 +799,12 @@ class TextToSpeech:
                 if initialized:
                     pythoncom.CoUninitialize()
 
-        await asyncio.to_thread(_speak)
+        try:
+            await asyncio.to_thread(_speak)
+        except TextToSpeechError:
+            raise
+        except Exception as exc:
+            raise AudioDeviceError(f"Windows speaker output failed: {exc}") from exc
         _vl().logger.info(
             "[TTS:windows] Local SAPI playback finished",
             extra=_voice_log_extra(
@@ -838,7 +851,10 @@ class TextToSpeech:
             engine.runAndWait()
 
         started_at = time.perf_counter()
-        await asyncio.to_thread(_speak)
+        try:
+            await asyncio.to_thread(_speak)
+        except Exception as exc:
+            raise AudioDeviceError(f"Windows speaker output failed: {exc}") from exc
         return {
             "path_used": "pyttsx3",
             "speech_start_delay_s": speech_start_delay_s,

--- a/tests/test_audio_diagnostics.py
+++ b/tests/test_audio_diagnostics.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+from rex.assistant_errors import AudioDeviceError
+from rex.voice_loop import VoiceLoop
+
+
+class _OnceListener:
+    async def listen(self, _source):
+        yield b"wake"
+
+    def mark_listening_started(self, *, reason: str = "test") -> None:
+        return None
+
+    def reset(self, *, reason: str = "test") -> None:
+        return None
+
+
+def _assistant(reply: str = "Hello.") -> MagicMock:
+    assistant = MagicMock()
+    assistant.generate_reply = AsyncMock(return_value=reply)
+    del assistant.stream_reply
+    return assistant
+
+
+def _base_callbacks():
+    async def detection_source():
+        return b"wake"
+
+    async def transcribe(_audio):
+        return "hello rex"
+
+    return detection_source, transcribe
+
+
+def test_microphone_failure_emits_structured_actionable_diagnostic(caplog) -> None:
+    detection_source, transcribe = _base_callbacks()
+    diagnostics: list[dict[str, object]] = []
+
+    async def record_phrase():
+        raise AudioDeviceError("device busy")
+
+    async def speak(_text: str) -> None:
+        return None
+
+    loop = VoiceLoop(
+        _assistant(),
+        wake_listener=_OnceListener(),
+        detection_source=detection_source,
+        record_phrase=record_phrase,
+        transcribe=transcribe,
+        speak=speak,
+        diagnostic_callback=diagnostics.append,
+        post_interaction_cooldown=0,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="rex.voice_loop"):
+        asyncio.run(loop.run(max_interactions=1))
+
+    assert diagnostics
+    diagnostic = diagnostics[-1]
+    assert diagnostic["event"] == "audio_device_error"
+    assert diagnostic["code"] == "microphone_unavailable"
+    assert diagnostic["device_kind"] == "microphone"
+    assert "Voice settings" in str(diagnostic["user_message"])
+    assert "permission" in str(diagnostic["user_message"]).lower()
+    record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "audio_device_error"
+    )
+    assert record.device_kind == "microphone"
+    assert record.user_message == diagnostic["user_message"]
+
+
+def test_speaker_failure_emits_structured_actionable_diagnostic(caplog) -> None:
+    detection_source, transcribe = _base_callbacks()
+    diagnostics: list[dict[str, object]] = []
+
+    async def record_phrase():
+        return b"audio"
+
+    async def speak(_text: str) -> None:
+        raise AudioDeviceError("output device busy")
+
+    loop = VoiceLoop(
+        _assistant(),
+        wake_listener=_OnceListener(),
+        detection_source=detection_source,
+        record_phrase=record_phrase,
+        transcribe=transcribe,
+        speak=speak,
+        diagnostic_callback=diagnostics.append,
+        post_interaction_cooldown=0,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="rex.voice_loop"):
+        asyncio.run(loop.run(max_interactions=1))
+
+    assert diagnostics
+    diagnostic = diagnostics[-1]
+    assert diagnostic["event"] == "audio_device_error"
+    assert diagnostic["code"] == "speaker_unavailable"
+    assert diagnostic["device_kind"] == "speaker"
+    assert "Voice settings" in str(diagnostic["user_message"])
+    assert "output" in str(diagnostic["user_message"]).lower()
+    record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "audio_device_error"
+    )
+    assert record.device_kind == "speaker"
+    assert record.user_message == diagnostic["user_message"]
+
+
+def test_voice_bridge_preserves_actionable_audio_diagnostic(monkeypatch) -> None:
+    import rex_voice_bridge
+    from rex.audio_config import build_audio_device_diagnostic
+
+    events: list[dict[str, object]] = []
+    monkeypatch.setattr(rex_voice_bridge, "emit", events.append)
+
+    diagnostic = build_audio_device_diagnostic("microphone", "device busy")
+    rex_voice_bridge.emit_audio_diagnostic(diagnostic)
+
+    error_event = next(event for event in events if event.get("type") == "error")
+    assert error_event["code"] == "microphone_unavailable"
+    assert error_event["device_kind"] == "microphone"
+    assert error_event["error"] == diagnostic["user_message"]
+    assert "Voice settings" in str(error_event["error"])
+
+
+def test_tts_does_not_hide_speaker_device_failure(monkeypatch) -> None:
+    import pytest
+
+    import rex.voice_loop as voice_loop_module
+    from rex.voice.tts import TextToSpeech
+
+    monkeypatch.setattr(voice_loop_module.settings, "tts_provider", "windows")
+    tts = TextToSpeech(language="en")
+
+    async def fail_output(_text: str, *, request_started_at: float):
+        raise AudioDeviceError("speaker init failed")
+
+    monkeypatch.setattr(tts, "_speak_windows", fail_output)
+
+    with pytest.raises(AudioDeviceError, match="speaker init failed"):
+        asyncio.run(tts.speak("Hello"))

--- a/tests/test_voice_loop.py
+++ b/tests/test_voice_loop.py
@@ -766,7 +766,8 @@ def _make_tts(monkeypatch, tmp_path):
         return _orig_ntf(*args, **kwargs)
 
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", _patched_ntf)
-    monkeypatch.setattr(_rvl, "sa", None)  # skip audio playback
+    # Model a successful local playback path without requiring audio hardware.
+    monkeypatch.setattr(_rvl, "sa", MagicMock())
 
     tts = TextToSpeech.__new__(TextToSpeech)
     tts._language = "en"


### PR DESCRIPTION
## Summary
- add structured, user-actionable microphone and speaker diagnostics in the canonical VoiceLoop
- preserve real audio-device failures through TTS, the Python voice bridge, Electron IPC, and the Voice-page alert surface
- add Python + Electron regression coverage and troubleshooting guidance
- update US-045 tracker/progress evidence while leaving the GitHub-check criterion open

## Local validation
- `pytest tests/test_audio_diagnostics.py -q` — 4 passed
- voice/audio regression sweep — 91 passed
- TTS regression sweep — 90 passed
- GUI diagnostics + microphone routing Vitest — 2 passed
- GUI TypeScript typecheck + touched-file ESLint — pass
- Ruff, Black, mypy, skip-inventory, and `git diff --check` — pass

The final GitHub acceptance criterion will be closed only after this PR head is green.