### PR TITLE
feat(ha): preserve state verification evidence

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1698,7 +1698,7 @@ pytest tests/test_ha_confirmation_gate.py -q
 - [x] Return shape is `{ status, expected, actual, latency_ms }`; Electron maps `latency_ms` to `latencyMs` while preserving `expected` and `actual`.
 - [x] Tests cover happy path and the "state did not change" path.
 - [x] `docs/home_assistant.md` documents the verification model.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. *(PR #361 implementation head `a56fc79b85a995b6a69820b2f7b565af3c9cc918`; CI run `31257576337`, Commitlint run `31257576383`, and Windows Electron Artifact run `31257576346` all completed successfully.)*
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1694,10 +1694,10 @@ pytest tests/test_ha_confirmation_gate.py -q
 **Implementation notes:** After dispatching, poll the entity state up to a configurable timeout. Compare expected vs actual. Report `verified` when the state matches, `attempted` when dispatch returned but state did not yet change, `completed` when state changes were applied but verification is not applicable, `failed` on dispatch error.
 
 **Acceptance Criteria:**
-- [ ] Verification is run for switchable domains (`switch`, `light`, `lock`, `cover`).
-- [ ] Return shape is `{ status, expected, actual, latency_ms }`.
-- [ ] Tests cover happy path and the "state did not change" path.
-- [ ] `docs/home_assistant.md` documents the verification model.
+- [x] Verification is run for switchable domains (`switch`, `light`, `lock`, `cover`).
+- [x] Return shape is `{ status, expected, actual, latency_ms }`; Electron maps `latency_ms` to `latencyMs` while preserving `expected` and `actual`.
+- [x] Tests cover happy path and the "state did not change" path.
+- [x] `docs/home_assistant.md` documents the verification model.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1436,3 +1436,5 @@ Local evidence so far:
 - Ruff + Black on the new Python test: pass. Touched TypeScript ESLint: pass. Skip inventory: 127/127 current. `git diff --check`: pass.
 - Local npm 11.6.0 on Node 24.14.0 failed inside `electron-winstaller` install-script spawning; using the repo's previously validated npm 10.9.2 completed `npm ci` successfully. No repository change was required for that host-tooling issue.
 - Relevant GitHub checks remain pending the story PR.
+
+US-048 GitHub implementation gate: PASS. PR #361 head a56fc79b85a995b6a69820b2f7b565af3c9cc918 passed CI run 31257576337, Commitlint run 31257576383, and Windows Electron Artifact run 31257576346. The tracker is closed with this evidence; this closeout commit itself must also remain green before merge.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1421,3 +1421,18 @@ US-046 GitHub implementation-head gate: PASS. PR #358 head `c2978e938337e8b288c4
 US-047 local implementation gate: `script` and `scene` moved from prohibited to the canonical sensitive HA mutation class alongside `lock`, `cover`, and `alarm_control_panel`; `automation`, `hassio`, `homeassistant`, `python_script`, `shell_command`, `update`, and unknown domains remain fail-closed. New `tests/test_ha_confirmation_gate.py` covers all five sensitive domains and proves the first unconfirmed call returns `confirmation_required` with zero `call_service` side effects, while the signed confirmed replay dispatches exactly once. Focused acceptance tests passed 17/17; broader HA/OpenClaw/IPC/mobile regression passed 59/59. `docs/home_assistant.md` and `CLAUDE.md` document the gate. GitHub checks remain required before story closeout.
 
 US-047 GitHub gate: PASS. PR #359 head 9f269a2866f410a17063dfdf01a9b312d052d42a passed CI run 31242596301, Commitlint run 31242596359, and Windows Electron Artifact run 31242596280, then merged to master as 1de6d06f58cf26b425c861e74e97820172ffbab1. The production-readiness tracker is closed with that evidence.
+
+=== 2026-08-08 - US-048 Home Assistant post-control state verification ===
+
+Implementation:
+- Reconciled the already-present HAMutationService verifier against the US-048 contract and added direct acceptance coverage for switch, light, lock, and cover state verification.
+- Preserved `expected`, `actual`, and `latency_ms` evidence across the Electron mutation bridge; the TypeScript IPC contract exposes the latency as `latencyMs` while retaining the backend evidence objects.
+- Documented the four-attempt / 250 ms default state-polling model and the distinction between dispatch acceptance and independently observed state.
+
+Local evidence so far:
+- TDD red phase: `tests/test_ha_verification.py` initially failed because Electron `DeviceCommandResponse` omitted verification evidence even though Python produced it.
+- Focused acceptance/regression sweep: 35 passed across US-048, mutation-service, confirmation-gate, and US-007 IPC tests on Python 3.11.9.
+- GUI: TypeScript typecheck passed, production build passed, and 20 Vitest files / 100 tests passed.
+- Ruff + Black on the new Python test: pass. Touched TypeScript ESLint: pass. Skip inventory: 127/127 current. `git diff --check`: pass.
+- Local npm 11.6.0 on Node 24.14.0 failed inside `electron-winstaller` install-script spawning; using the repo's previously validated npm 10.9.2 completed `npm ci` successfully. No repository change was required for that host-tooling issue.
+- Relevant GitHub checks remain pending the story PR.

--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -43,13 +43,17 @@ The Electron renderer sends device commands via the `window.rex.sendDeviceComman
 // Renderer usage
 const result = await window.rex.sendDeviceCommand(entityId, command, payload?)
 // result: { status: 'verified' | 'attempted_unverified' |
-//   'confirmation_required' | 'denied' | 'failed', detail?: string }
+//   'confirmation_required' | 'denied' | 'failed', detail?: string,
+//   expected?: { state: string, attributes: object } | null,
+//   actual?: object | null, latencyMs?: number }
 ```
 
 The main-process handler delegates to `bridge/rex_ha_mutation_bridge.py`. That bridge and the
 OpenClaw HA tool both use `rex.ha.mutation_service.HAMutationService`; renderer code cannot bypass
 the policy service. The service validates the immutable Electron user, classifies risk, dispatches,
 then reads entity state independently. An HTTP 2xx response is never treated as proof.
+
+For switchable domains (`switch`, `light`, `lock`, and `cover`), the default verifier polls up to four state reads with 250 ms between successful reads. This gives Home Assistant a short settling window without treating dispatch acceptance as success. Each HTTP request remains bounded by the configured Home Assistant request timeout; `latency_ms` records the complete dispatch-and-verification duration.
 
 **Status semantics:**
 

--- a/gui/src/main/homeAssistant.ts
+++ b/gui/src/main/homeAssistant.ts
@@ -123,6 +123,9 @@ export type DeviceCommandStatus =
 export interface DeviceCommandResponse {
   status: DeviceCommandStatus
   detail?: string
+  expected?: { state: string; attributes: Record<string, unknown> } | null
+  actual?: Record<string, unknown> | null
+  latencyMs?: number
   confirmationToken?: string
   requestId?: string
 }
@@ -186,6 +189,9 @@ export function callDeviceCommand(
           ok: boolean
           status?: DeviceCommandStatus
           detail?: string
+          expected?: { state: string; attributes: Record<string, unknown> } | null
+          actual?: Record<string, unknown> | null
+          latency_ms?: number
           confirmation_token?: string
           request_id?: string
           error?: string
@@ -194,6 +200,9 @@ export function callDeviceCommand(
           resolve({
             status: result.status,
             detail: result.detail,
+            expected: result.expected,
+            actual: result.actual,
+            latencyMs: result.latency_ms,
             confirmationToken: result.confirmation_token,
             requestId: result.request_id
           })

--- a/gui/src/types/ipc.ts
+++ b/gui/src/types/ipc.ts
@@ -404,6 +404,9 @@ export type DeviceCommandStatus =
 export interface DeviceCommandResponse {
   status: DeviceCommandStatus
   detail?: string
+  expected?: { state: string; attributes: Record<string, unknown> } | null
+  actual?: Record<string, unknown> | null
+  latencyMs?: number
   confirmationToken?: string
   requestId?: string
 }

--- a/tests/test_ha_verification.py
+++ b/tests/test_ha_verification.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from rex.ha.mutation_service import HAMutation, HAMutationService, HAOutcome
+
+
+class FakeHAClient:
+    def __init__(self, states: list[dict[str, Any] | None]) -> None:
+        self.states = list(states)
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def call_service(self, domain: str, service: str, data: dict[str, Any]) -> None:
+        self.calls.append((domain, service, data))
+
+    def get_state(self, entity_id: str) -> dict[str, Any] | None:
+        return self.states.pop(0) if self.states else None
+
+
+def _service(tmp_path: Path, client: FakeHAClient) -> HAMutationService:
+    return HAMutationService(
+        client,
+        confirmation_secret=b"us048-confirmation-secret",
+        state_db=tmp_path / "ha.db",
+        audit_path=tmp_path / "audit.jsonl",
+        verification_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+
+def _execute(
+    tmp_path: Path,
+    *,
+    domain: str,
+    service: str,
+    entity_id: str,
+    observed_state: str,
+) -> tuple[dict[str, Any], FakeHAClient]:
+    client = FakeHAClient([{"state": observed_state, "attributes": {}}])
+    mutation = HAMutation(
+        user_id="james",
+        entity_id=entity_id,
+        domain=domain,
+        service=service,
+        parameters={},
+        request_id=f"us048-{domain}-{service}",
+    )
+    svc = _service(tmp_path, client)
+    result = svc.execute(mutation)
+    if result.status == HAOutcome.CONFIRMATION_REQUIRED:
+        result = svc.execute(replace(mutation, confirmation_token=result.confirmation_token))
+    return result.to_dict(), client
+
+
+@pytest.mark.parametrize(
+    ("domain", "service", "entity_id", "observed_state", "expected_state"),
+    [
+        ("switch", "turn_on", "switch.fan", "on", "on"),
+        ("light", "turn_off", "light.kitchen", "off", "off"),
+        ("lock", "lock", "lock.front", "locked", "locked"),
+        ("cover", "open_cover", "cover.garage", "open", "open"),
+    ],
+)
+def test_switchable_domains_return_verified_state_evidence(
+    tmp_path: Path,
+    domain: str,
+    service: str,
+    entity_id: str,
+    observed_state: str,
+    expected_state: str,
+) -> None:
+    result, client = _execute(
+        tmp_path,
+        domain=domain,
+        service=service,
+        entity_id=entity_id,
+        observed_state=observed_state,
+    )
+
+    assert result["status"] == "verified"
+    assert result["expected"] == {"state": expected_state, "attributes": {}}
+    assert result["actual"] == {"state": observed_state, "attributes": {}}
+    assert isinstance(result["latency_ms"], float)
+    assert result["latency_ms"] >= 0
+    assert len(client.calls) == 1
+
+
+def test_state_did_not_change_returns_attempted_with_evidence(tmp_path: Path) -> None:
+    client = FakeHAClient([{"state": "off", "attributes": {}}] * 4)
+    svc = _service(tmp_path, client)
+    result = svc.execute(
+        HAMutation(
+            user_id="james",
+            entity_id="switch.fan",
+            domain="switch",
+            service="turn_on",
+            parameters={},
+            request_id="us048-stale-switch",
+        )
+    ).to_dict()
+
+    assert result["status"] == "attempted_unverified"
+    assert result["expected"] == {"state": "on", "attributes": {}}
+    assert result["actual"] == {"state": "off", "attributes": {}}
+    assert result["latency_ms"] >= 0
+
+
+def test_electron_device_command_contract_preserves_verification_evidence() -> None:
+    home_assistant = Path("gui/src/main/homeAssistant.ts").read_text(encoding="utf-8")
+    ipc_types = Path("gui/src/types/ipc.ts").read_text(encoding="utf-8")
+
+    for source in (home_assistant, ipc_types):
+        assert "expected?:" in source
+        assert "actual?:" in source
+        assert "latencyMs?: number" in source
+
+    assert "expected: result.expected" in home_assistant
+    assert "actual: result.actual" in home_assistant
+    assert "latencyMs: result.latency_ms" in home_assistant


### PR DESCRIPTION
Implements US-048 post-control Home Assistant verification acceptance coverage and fixes the remaining Electron evidence gap.

Changes:
- add direct verification coverage for switch, light, lock, and cover
- cover the state-did-not-change attempted_unverified path
- preserve expected/actual/latency evidence through the Electron IPC response
- document the verification polling/evidence model
- update production-readiness local evidence while leaving the GitHub gate open

Local verification:
- Python 3.11.9 focused HA/IPC sweep: 35 passed
- Ruff + Black: pass
- skip inventory: 127/127 current
- touched TypeScript ESLint: pass
- GUI TypeScript typecheck: pass
- GUI production build: pass
- GUI Vitest: 20 files / 100 tests passed
- git diff --check: pass

Note: this branch is stacked on the US-047 tracker-closeout commit from PR #360. Do not merge until #360 lands; after that, the net diff is US-048 only.