### PR TITLE
feat(ha): use truthful verification language

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1722,10 +1722,10 @@ pytest tests/test_ha_verification.py -q
 - `tests/test_response_verification_language.py` (new)
 
 **Acceptance Criteria:**
-- [ ] A response builder helper maps `{ status }` to user-facing text per the documented vocabulary.
-- [ ] Tests assert each status produces the correct phrase ("I tried…", "I asked HA to…", "Confirmed the light is on", "That failed because…").
-- [ ] No code path produces a confident success message when `status != "verified"` and verification was applicable.
-- [ ] `README.md` mentions the verification language.
+- [x] A response builder helper maps `{ status }` to user-facing text per the documented vocabulary.
+- [x] Tests assert each status produces the correct phrase ("I tried…", "I asked HA to…", "Confirmed the light is on", "That failed because…").
+- [x] No code path produces a confident success message when `status != "verified"` and verification was applicable.
+- [x] `README.md` mentions the verification language.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1726,7 +1726,7 @@ pytest tests/test_ha_verification.py -q
 - [x] Tests assert each status produces the correct phrase ("I tried…", "I asked HA to…", "Confirmed the light is on", "That failed because…").
 - [x] No code path produces a confident success message when `status != "verified"` and verification was applicable.
 - [x] `README.md` mentions the verification language.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. *(PR #362 implementation head `b380778a9a01e922d86be5d5e3e083b139e25a06`; CI runs `31259723604`/`31259313682`, Commitlint runs `31259723610`/`31259313656`, and Windows Electron Artifact runs `31259723591`/`31259313652` all completed successfully.)*
 
 **Validation commands:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ The Electron app under `gui/` is the current primary GUI. `rex-gui` remains usef
 | WordPress/WooCommerce | WordPress health checks and WooCommerce order/product reads are implemented; WooCommerce order status and coupon writes are approval-gated. |
 | OpenClaw | Optional experimental HTTP gateway/client adapters and a standalone Rex tool server are present; feature flags under `openclaw` control gateway-backed paths. Configuration does not prove gateway reachability. |
 
+Home Assistant result wording mirrors the verification evidence. `attempted_unverified` uses **"I tried..."**, `completed` uses **"I asked HA to..."** without claiming state proof, `verified` alone may use **"Confirmed..."**, and a definite dispatch failure uses **"That failed because..."**. See [docs/home_assistant.md](docs/home_assistant.md) for the status and evidence contract.
+
 ## Requirements
 
 | Component | Requirement |

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1452,3 +1452,5 @@ Local evidence so far:
 - `tests/test_response_verification_language.py`: 11 passed after implementation and documentation.
 - Broader HA/OpenClaw/mobile verification-language sweep: 38 passed; only two unrelated pre-existing `AppConfig.llm_provider` deprecation warnings were emitted.
 - Relevant GitHub checks remain pending the story PR.
+
+US-049 GitHub implementation gate: PASS. PR #362 head b380778a9a01e922d86be5d5e3e083b139e25a06 passed CI, Commitlint, and Windows Electron Artifact twice after rebase/reopen (runs 31259723604/31259313682, 31259723610/31259313656, 31259723591/31259313652). The tracker is closed with that evidence; the docs-only closeout head will be retriggered before merge.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1438,3 +1438,17 @@ Local evidence so far:
 - Relevant GitHub checks remain pending the story PR.
 
 US-048 GitHub implementation gate: PASS. PR #361 head a56fc79b85a995b6a69820b2f7b565af3c9cc918 passed CI run 31257576337, Commitlint run 31257576383, and Windows Electron Artifact run 31257576346. The tracker is closed with this evidence; this closeout commit itself must also remain green before merge.
+
+=== 2026-08-08 - US-049 truthful Home Assistant response language ===
+
+Implementation:
+- Extended the canonical Home Assistant response helper to distinguish `attempted_unverified`, `completed`, `verified`, and `failed` without upgrading uncertain outcomes into success claims.
+- Verified responses can name the independently observed target state (`Confirmed light kitchen is on.`); completed-but-not-verified responses say `I asked HA to...`; attempted-unverified responses say `I tried...` and disclose the missing verification; definite failures say `That failed because...`.
+- The OpenClaw HA adapter now passes the verifier's `expected` evidence into the response helper so confirmed wording is grounded in the actual verification contract.
+- README documents the exact status vocabulary and links to the Home Assistant evidence contract.
+
+Local evidence so far:
+- TDD red phase: the new tests failed because the helper had no `completed` mapping, no expected-state input, and failure wording did not follow the documented vocabulary; the README vocabulary test also failed before documentation was added.
+- `tests/test_response_verification_language.py`: 11 passed after implementation and documentation.
+- Broader HA/OpenClaw/mobile verification-language sweep: 38 passed; only two unrelated pre-existing `AppConfig.llm_provider` deprecation warnings were emitted.
+- Relevant GitHub checks remain pending the story PR.

--- a/rex/openclaw/tools/ha_tool.py
+++ b/rex/openclaw/tools/ha_tool.py
@@ -126,6 +126,9 @@ def ha_call_service(
     return {
         **result.to_dict(),
         "message": home_assistant_status_message(
-            result.status.value, entity_id=result.entity_id, detail=result.detail
+            result.status.value,
+            entity_id=result.entity_id,
+            detail=result.detail,
+            expected=result.expected,
         ),
     }

--- a/rex/response/builder.py
+++ b/rex/response/builder.py
@@ -16,18 +16,29 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def home_assistant_status_message(status: str, *, entity_id: str, detail: str | None = None) -> str:
-    """Render Home Assistant outcomes without overstating an unverified mutation."""
+def home_assistant_status_message(
+    status: str,
+    *,
+    entity_id: str,
+    detail: str | None = None,
+    expected: dict[str, Any] | None = None,
+) -> str:
+    """Render Home Assistant outcomes without overstating verification evidence."""
     friendly = entity_id.replace("_", " ").replace(".", " ")
     if status == "verified":
+        expected_state = expected.get("state") if isinstance(expected, dict) else None
+        if isinstance(expected_state, str) and expected_state:
+            return f"Confirmed {friendly} is {expected_state.replace('_', ' ')}."
         return f"Confirmed the requested state for {friendly}."
     if status == "attempted_unverified":
         return f"I tried to update {friendly}, but I could not verify the result."
+    if status == "completed":
+        return f"I asked HA to update {friendly}."
     if status == "confirmation_required":
         return detail or f"Please confirm the requested change to {friendly}."
     if status == "denied":
         return f"I did not change {friendly}. {detail or 'The action was denied.'}"
-    return f"That failed for {friendly}. {detail or 'Home Assistant reported an error.'}"
+    return f"That failed because {detail or 'Home Assistant reported an error.'}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_response_verification_language.py
+++ b/tests/test_response_verification_language.py
@@ -1,25 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
 from rex.response.builder import home_assistant_status_message
 
 
-def test_verified_language_is_confident() -> None:
-    assert home_assistant_status_message("verified", entity_id="light.kitchen").startswith(
-        "Confirmed"
+def test_verified_language_names_observed_state_confidently() -> None:
+    message = home_assistant_status_message(
+        "verified",
+        entity_id="light.kitchen",
+        expected={"state": "on", "attributes": {}},
     )
+    assert message == "Confirmed light kitchen is on."
 
 
-def test_unverified_language_discloses_uncertainty() -> None:
+def test_attempted_unverified_language_discloses_uncertainty() -> None:
     message = home_assistant_status_message("attempted_unverified", entity_id="light.kitchen")
-    assert "tried" in message
+    assert message.startswith("I tried")
     assert "could not verify" in message
 
 
-def test_denied_and_failed_language_do_not_claim_completion() -> None:
-    denied = home_assistant_status_message(
-        "denied", entity_id="lock.front_door", detail="Confirmation expired."
-    )
-    failed = home_assistant_status_message(
+def test_completed_language_reports_dispatch_without_claiming_verification() -> None:
+    message = home_assistant_status_message("completed", entity_id="scene.movie_night")
+    assert message == "I asked HA to update scene movie night."
+    assert "Confirmed" not in message
+
+
+def test_failed_language_explains_failure_without_claiming_success() -> None:
+    message = home_assistant_status_message(
         "failed", entity_id="switch.garage", detail="Connection timed out."
     )
-    assert "did not change" in denied
-    assert "failed" in failed
-    assert "Confirmed" not in denied + failed
+    assert message == "That failed because Connection timed out."
+    assert "Confirmed" not in message
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["attempted_unverified", "completed", "confirmation_required", "denied", "failed"],
+)
+def test_only_verified_status_uses_confirmed_language(status: str) -> None:
+    message = home_assistant_status_message(
+        status,
+        entity_id="lock.front_door",
+        detail="The operation did not produce verified state evidence.",
+    )
+    assert "Confirmed" not in message
+
+
+def test_denied_language_states_that_no_change_was_made() -> None:
+    message = home_assistant_status_message(
+        "denied", entity_id="lock.front_door", detail="Confirmation expired."
+    )
+    assert message.startswith("I did not change")
+
+
+def test_readme_documents_home_assistant_verification_vocabulary() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    for phrase in ("I tried", "I asked HA to", "Confirmed", "That failed because"):
+        assert phrase in readme


### PR DESCRIPTION
Implements US-049 truthful Home Assistant response language.

Changes:
- map attempted_unverified, completed, verified, denied, confirmation-required, and failed outcomes to distinct user-facing wording
- allow verified responses to name the independently observed target state
- pass HA expected-state evidence into the canonical response helper
- document the exact verification vocabulary in README
- expand response-language tests, including a guard that only verified may use confirmed wording
- update production-readiness local evidence while leaving the GitHub gate open

Local verification:
- focused HA/OpenClaw/mobile sweep: 38 passed
- Ruff: pass
- Black: pass
- mypy on changed source files: 0 issues
- skip inventory: 127/127 current
- git diff --check: pass

This branch is stacked on PR #361 (which is stacked on merged #360). Merge only after dependencies land.