### PR TITLE
fix(openclaw): fail closed on incomplete config

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1748,11 +1748,11 @@ pytest tests/test_response_verification_language.py -q
 - `SURFACE-CLASSIFICATION.md`
 
 **Acceptance Criteria:**
-- [ ] Defaults for both OpenClaw flags are False.
-- [ ] Enabling either flag without a valid gateway URL+token raises a clear error at startup.
-- [ ] `SURFACE-CLASSIFICATION.md` classifies OpenClaw surfaces as `experimental`.
-- [ ] GUI settings label OpenClaw as "Experimental — off by default".
-- [ ] A test asserts defaults and the fail-closed startup behavior.
+- [x] Defaults for both OpenClaw flags are False.
+- [x] Enabling either flag without a valid gateway URL+token raises a clear error at startup.
+- [x] `SURFACE-CLASSIFICATION.md` classifies OpenClaw surfaces as `experimental`.
+- [x] GUI settings label OpenClaw as "Experimental — off by default".
+- [x] A test asserts defaults and the fail-closed startup behavior.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1753,7 +1753,7 @@ pytest tests/test_response_verification_language.py -q
 - [x] `SURFACE-CLASSIFICATION.md` classifies OpenClaw surfaces as `experimental`.
 - [x] GUI settings label OpenClaw as "Experimental — off by default".
 - [x] A test asserts defaults and the fail-closed startup behavior.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. *(PR #363, head `74f699a`: CI, Commitlint, Windows Electron Artifact, CodeFactor, and GitGuardian all green on 2026-08-08/09.)*
 
 **Validation commands:**
 ```bash

--- a/SURFACE-CLASSIFICATION.md
+++ b/SURFACE-CLASSIFICATION.md
@@ -14,6 +14,7 @@ here first, then propagated to docs, packaging config, and CI.
 |----------------|---------|
 | `shippable` | Supported, user-facing surface included in or required by a release artifact. Security fixes and regressions are P0. |
 | `developer-only` | Supported for developer and operator use but not exposed to end users in the packaged app. Not in the packaged Electron installer. |
+| `experimental` | Optional pre-release surface. Disabled by default and not part of the supported end-user contract until explicit promotion criteria pass. |
 | `deprecated` | Still present for backward compatibility. Emits `DeprecationWarning` on use. Will be removed in a future release. No new features. Security fixes only. |
 | `archived` | Not maintained. Entry points removed. Kept in `archived/` for reference. May be permanently deleted in a future major version. |
 | `removed` | Deleted from the repo. Listed here as a historical record only. |
@@ -29,7 +30,7 @@ here first, then propagated to docs, packaging config, and CI.
 | `rex-config` | `rex.config:cli` | `developer-only` | Config inspection and migration utility. Operator/developer use only. |
 | `rex-speak-api` | `rex_speak_api:main` | `developer-only` | Standalone TTS API with auth and rate limiting. Backend service; not user-facing. |
 | `rex-agent` | `rex.computers.agent_server:main` | `developer-only` | Optional remote PC control API. Not enabled by default; requires explicit configuration. |
-| `rex-tool-server` | `rex.openclaw.tool_server:main` | `developer-only` | OpenClaw tool adapter backend at `/rex/tools/{tool_name}`. Backend service; not user-facing. |
+| `rex-tool-server` | `rex.openclaw.tool_server:main` | `experimental` | OpenClaw tool adapter backend at `/rex/tools/{tool_name}`. Disabled by default; requires explicit gateway configuration and is not part of the supported end-user contract. |
 
 The mobile API gateway is a CLI subcommand, not a `[project.scripts]` console script:
 
@@ -133,7 +134,8 @@ These modules implement user-facing capabilities invoked by the assistant pipeli
 | Classification | Count |
 |----------------|-------|
 | `shippable` | 2 |
-| `developer-only` | 29 |
+| `developer-only` | 28 |
+| `experimental` | 1 |
 | `deprecated` | 5 |
 | `archived` | 15 |
 | `removed` | 0 |

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1472,3 +1472,5 @@ Local evidence so far:
 - SettingsPage ESLint: 0 errors (2 pre-existing hook warnings); GUI typecheck and 20-file/100-test Vitest suite pass.
 - Skip inventory: 127/127 current; git diff --check: pass.
 - Relevant GitHub checks remain pending the story PR.
+
+US-050 GitHub implementation gate: PASS. PR #363 head `74f699a380215a000b0c263ffaaeccb1e8b7e20a` passed all 18 reported checks after rebase onto merged US-049, including Python 3.11 Tests & Coverage (9m49s), Installed Windows Electron artifact (10m42s), CI quality/security jobs, Commitlint, CodeFactor, and GitGuardian. The tracker is closed with that evidence.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1454,3 +1454,21 @@ Local evidence so far:
 - Relevant GitHub checks remain pending the story PR.
 
 US-049 GitHub implementation gate: PASS. PR #362 head b380778a9a01e922d86be5d5e3e083b139e25a06 passed CI, Commitlint, and Windows Electron Artifact twice after rebase/reopen (runs 31259723604/31259313682, 31259723610/31259313656, 31259723591/31259313652). The tracker is closed with that evidence; the docs-only closeout head will be retriggered before merge.
+
+=== 2026-08-08 - US-050 OpenClaw defaults and fail-closed configuration ===
+
+Implementation:
+- Confirmed both OpenClaw feature flags already defaulted to false and preserved those defaults.
+- Added central config validation: when tools or voice are enabled, both a non-empty credential-vault token and a syntactically valid HTTP(S) gateway URL are mandatory; incomplete configuration raises a clear ConfigurationError during load_config validation.
+- Reclassified the OpenClaw `rex-tool-server` surface as experimental and added the experimental classification definition/count.
+- Added an AI Settings truth card: `OpenClaw` / `Experimental - off by default`; no new activation control was introduced.
+- Added a release-status banner to the OpenClaw migration status doc.
+
+Local evidence so far:
+- TDD red phase: 5/7 focused tests failed before implementation (missing validation, classification, and GUI label).
+- Focused acceptance: 7/7 passed after implementation.
+- Broad config/OpenClaw selection: 682 passed, 7865 deselected. Warnings are existing deprecation debt outside this story.
+- Ruff + Black on changed Python: pass; mypy on rex/config.py: 0 issues.
+- SettingsPage ESLint: 0 errors (2 pre-existing hook warnings); GUI typecheck and 20-file/100-test Vitest suite pass.
+- Skip inventory: 127/127 current; git diff --check: pass.
+- Relevant GitHub checks remain pending the story PR.

--- a/docs/openclaw-migration-status.md
+++ b/docs/openclaw-migration-status.md
@@ -1,5 +1,7 @@
 # OpenClaw Migration Status
 
+> **Release status:** Experimental and off by default. Enabling OpenClaw tools or voice requires both a valid HTTP(S) gateway URL and a credential-vault token; incomplete configuration fails closed during config validation.
+
 Tracks every Rex module's migration state as Rex pivots to an OpenClaw-based architecture.
 
 **Classifications:**

--- a/gui/src/pages/SettingsPage.tsx
+++ b/gui/src/pages/SettingsPage.tsx
@@ -2261,6 +2261,14 @@ function AiPanel(): React.ReactElement {
     <div className="p-6 max-w-lg">
       <h2 className="text-lg font-semibold text-text-primary mb-6">AI</h2>
 
+      <div className="mb-6 rounded-xl border border-warning/40 bg-warning/5 p-4">
+        <div className="text-sm font-semibold text-text-primary">OpenClaw</div>
+        <div className="mt-1 text-xs font-medium text-warning">Experimental - off by default</div>
+        <p className="mt-2 text-xs text-text-secondary">
+          Gateway-backed tools and voice stay disabled unless an operator explicitly configures both a gateway URL and credential token.
+        </p>
+      </div>
+
       {/* Personality */}
       <div className="mb-6">
         <div className="flex items-center justify-between mb-2">

--- a/rex/config.py
+++ b/rex/config.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 from dataclasses import asdict, dataclass, field
+from urllib.parse import urlparse
 
 from rex.exception_handler import wrap_entrypoint
 from pathlib import Path
@@ -1484,6 +1485,21 @@ def validate_config(config: AppConfig) -> None:
         raise ConfigurationError("llm_temperature must be between 0 and 5.")
     if config.memory_max_turns <= 0:
         raise ConfigurationError("memory_max_turns must be positive.")
+    if config.use_openclaw_tools or config.use_openclaw_voice_backend:
+        integrations = config.integrations
+        if integrations is None:
+            raise ConfigurationError("OpenClaw integration settings are unavailable.")
+        gateway_url = integrations.openclaw_gateway_url.strip()
+        gateway_token = (config.openclaw_gateway_token or "").strip()
+        if not gateway_url or not gateway_token:
+            raise ConfigurationError(
+                "OpenClaw features are enabled but a gateway URL and token are not both configured."
+            )
+        parsed_gateway = urlparse(gateway_url)
+        if parsed_gateway.scheme not in {"http", "https"} or not parsed_gateway.hostname:
+            raise ConfigurationError(
+                "OpenClaw features require a valid HTTP(S) gateway URL and token."
+            )
 
 
 def reload_settings(

--- a/tests/test_openclaw_defaults.py
+++ b/tests/test_openclaw_defaults.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rex.config import AppConfig, ConfigurationError, validate_config
+
+
+def test_openclaw_feature_flags_default_off() -> None:
+    config = AppConfig()
+    assert config.use_openclaw_tools is False
+    assert config.use_openclaw_voice_backend is False
+
+
+@pytest.mark.parametrize("flag", ["use_openclaw_tools", "use_openclaw_voice_backend"])
+def test_enabled_openclaw_requires_gateway_url_and_token(flag: str) -> None:
+    config = AppConfig()
+    setattr(config, flag, True)
+    with pytest.raises(ConfigurationError, match="OpenClaw.*gateway URL.*token"):
+        validate_config(config)
+
+
+def test_enabled_openclaw_rejects_invalid_gateway_url() -> None:
+    config = AppConfig(
+        use_openclaw_tools=True,
+        openclaw_gateway_url="not-a-url",
+        openclaw_gateway_token="test-token",
+    )
+    with pytest.raises(ConfigurationError, match=r"HTTP\(S\) gateway URL"):
+        validate_config(config)
+
+
+def test_enabled_openclaw_accepts_complete_gateway_configuration() -> None:
+    config = AppConfig(
+        use_openclaw_tools=True,
+        openclaw_gateway_url="http://127.0.0.1:18789",
+        openclaw_gateway_token="test-token",
+    )
+    validate_config(config)
+
+
+def test_openclaw_surfaces_are_classified_experimental() -> None:
+    text = Path("SURFACE-CLASSIFICATION.md").read_text(encoding="utf-8")
+    assert "`experimental`" in text
+    assert "`rex-tool-server` | `rex.openclaw.tool_server:main` | `experimental`" in text
+
+
+def test_gui_labels_openclaw_experimental_and_off_by_default() -> None:
+    source = Path("gui/src/pages/SettingsPage.tsx").read_text(encoding="utf-8")
+    assert "OpenClaw" in source
+    assert "Experimental - off by default" in source


### PR DESCRIPTION
Implements US-050 OpenClaw default-off / fail-closed configuration behavior.

Changes:
- preserve both OpenClaw feature flags defaulting to false
- reject enabled OpenClaw tools/voice unless both a non-empty token and valid HTTP(S) gateway URL are configured
- classify the OpenClaw tool-server surface as experimental
- label OpenClaw in AI Settings as `Experimental - off by default` without adding an activation control
- add release-status truth to the OpenClaw migration doc
- add focused acceptance coverage for defaults, fail-closed validation, classification, and GUI label
- update production-readiness local evidence while leaving the GitHub gate open

Local verification:
- broad config/OpenClaw selection: 682 passed
- focused final OpenClaw regression: 28 passed
- Ruff + Black: pass
- mypy rex/config.py: 0 issues
- GUI typecheck and 20-file/100-test Vitest suite: pass
- SettingsPage ESLint: 0 errors, 2 pre-existing hook warnings
- skip inventory: 127/127 current
- git diff --check: pass

This branch is stacked on #362 -> #361. Merge only after dependencies land.