### PR TITLE
feat(openclaw): add gateway health fallback

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1774,11 +1774,11 @@ pytest tests/test_openclaw_defaults.py -q
 - `tests/test_openclaw_health.py` (new)
 
 **Acceptance Criteria:**
-- [ ] `GET /healthz` (or equivalent) detects gateway availability.
-- [ ] On gateway failure, tool dispatch falls back to local execution AND emits a structured warning; it does not silently succeed.
-- [ ] Reconnect attempts are bounded by config.
-- [ ] Tests cover up/down/recovery paths.
-- [ ] `docs/openclaw-migration-status.md` documents the model.
+- [x] `GET /healthz` (or equivalent) detects gateway availability.
+- [x] On gateway failure, tool dispatch falls back to local execution AND emits a structured warning; it does not silently succeed.
+- [x] Reconnect attempts are bounded by config.
+- [x] Tests cover up/down/recovery paths.
+- [x] `docs/openclaw-migration-status.md` documents the model.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1779,7 +1779,7 @@ pytest tests/test_openclaw_defaults.py -q
 - [x] Reconnect attempts are bounded by config.
 - [x] Tests cover up/down/recovery paths.
 - [x] `docs/openclaw-migration-status.md` documents the model.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:**
 ```bash

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1490,4 +1490,3 @@ Local evidence so far:
 - Relevant GitHub checks remain pending the story PR.
 
 US-051 broad regression evidence: 638 OpenClaw-selected tests passed (7914 deselected); existing deprecation warnings only. Final changed-surface gates: 36 focused HTTP/bridge/health tests passed, Ruff/Black pass, mypy 0 issues in both changed source files, skip inventory 127/127 current, and git diff --check pass.
-

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1474,3 +1474,20 @@ Local evidence so far:
 - Relevant GitHub checks remain pending the story PR.
 
 US-050 GitHub implementation gate: PASS. PR #363 head `74f699a380215a000b0c263ffaaeccb1e8b7e20a` passed all 18 reported checks after rebase onto merged US-049, including Python 3.11 Tests & Coverage (9m49s), Installed Windows Electron artifact (10m42s), CI quality/security jobs, Commitlint, CodeFactor, and GitGuardian. The tracker is closed with that evidence.
+=== 2026-08-08 - US-051 OpenClaw health, retry bounds, and graceful degradation ===
+
+Implementation:
+- Added `OpenClawClient.health()` using `GET /healthz`, returning explicit availability/status, latency, details on success, and sanitized error type/message on failure.
+- Connection and timeout errors now retry with the same configured `max_retries` bound used for retryable HTTP failures (initial attempt plus at most `max_retries` retries).
+- Exhausted connection/auth/429/5xx tool-gateway failures emit a structured `openclaw.tool_fallback` warning and fall back to the canonical local executor. 403 remains a hard policy denial; other non-retryable API errors still surface.
+- No sticky circuit breaker was added: the next tool call tries OpenClaw again, so recovery returns automatically to remote dispatch.
+- Documented the health, retry, fallback, policy-denial, and recovery model.
+
+Local evidence so far:
+- TDD red phase: all 5 new acceptance tests failed before implementation (no health method, no connection retry bound, no structured event metadata, and exhausted 5xx escaped instead of degrading locally).
+- Focused US-051 acceptance: 5 passed after implementation.
+- HTTP client + tool-bridge + health regression set: 36 passed after updating one stale 5xx expectation to the new graceful-degradation contract.
+- Relevant GitHub checks remain pending the story PR.
+
+US-051 broad regression evidence: 638 OpenClaw-selected tests passed (7914 deselected); existing deprecation warnings only. Final changed-surface gates: 36 focused HTTP/bridge/health tests passed, Ruff/Black pass, mypy 0 issues in both changed source files, skip inventory 127/127 current, and git diff --check pass.
+

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1490,3 +1490,5 @@ Local evidence so far:
 - Relevant GitHub checks remain pending the story PR.
 
 US-051 broad regression evidence: 638 OpenClaw-selected tests passed (7914 deselected); existing deprecation warnings only. Final changed-surface gates: 36 focused HTTP/bridge/health tests passed, Ruff/Black pass, mypy 0 issues in both changed source files, skip inventory 127/127 current, and git diff --check pass.
+
+US-051 GitHub implementation gate: PASS. PR #364 head `2597394d1757cbb36fce2a50a3fdcd201d606cdc` passed all 18 reported checks after rebase onto merged US-050, including Python 3.11 Tests & Coverage (9m31s), Installed Windows Electron artifact (10m08s), CI quality/security jobs, Commitlint, CodeFactor, and GitGuardian. The tracker is closed with that evidence; this docs-only closeout head must also remain green before merge.

--- a/docs/openclaw-migration-status.md
+++ b/docs/openclaw-migration-status.md
@@ -2,6 +2,14 @@
 
 > **Release status:** Experimental and off by default. Enabling OpenClaw tools or voice requires both a valid HTTP(S) gateway URL and a credential-vault token; incomplete configuration fails closed during config validation.
 
+## Gateway health and graceful degradation
+
+`OpenClawClient.health()` probes `GET /healthz` and returns explicit `up`/`down` evidence with request latency. Transport, authentication, and API failures are represented as a down result rather than being mistaken for gateway availability.
+
+Normal OpenClaw requests use the configured `openclaw_gateway_max_retries` as a retry bound: the initial attempt plus at most that many retries. Connection/timeout failures and retryable HTTP 429/5xx responses back off within that bound. For tool execution, an exhausted connection/auth/429/5xx gateway failure emits a structured `openclaw.tool_fallback` warning and then runs the canonical local Rex tool path. A 403 remains a policy denial and never falls back around policy; a 404 means that specific tool is absent remotely and uses the existing local-tool fallback.
+
+There is no sticky circuit breaker. A fallback applies only to the failed call, so a later request probes/uses the gateway again and automatically resumes remote execution when it has recovered.
+
 Tracks every Rex module's migration state as Rex pivots to an OpenClaw-based architecture.
 
 **Classifications:**

--- a/rex/openclaw/http_client.py
+++ b/rex/openclaw/http_client.py
@@ -99,8 +99,28 @@ class OpenClawClient:
                     timeout=self.timeout,
                 )
             except (RequestsConnectionError, Timeout) as exc:
-                logger.warning("OpenClaw connection error on %s %s: %s", method.upper(), url, exc)
-                raise OpenClawConnectionError(url, exc) from exc
+                if attempt > self.max_retries:
+                    logger.warning(
+                        "OpenClaw connection error on %s %s after %d attempts: %s",
+                        method.upper(),
+                        url,
+                        attempt,
+                        exc,
+                    )
+                    raise OpenClawConnectionError(url, exc) from exc
+
+                wait = 2 ** (attempt - 1)
+                logger.warning(
+                    "OpenClaw connection error on %s %s; retrying in %.1fs (attempt %d/%d): %s",
+                    method.upper(),
+                    url,
+                    wait,
+                    attempt,
+                    self.max_retries,
+                    exc,
+                )
+                time.sleep(wait)
+                continue
 
             status = response.status_code
             logger.debug("%s %s -> %d", method.upper(), path, status)
@@ -205,6 +225,26 @@ class OpenClawClient:
     def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Send a GET request and return the parsed JSON response."""
         return self._request("GET", path, params=params)
+
+    def health(self) -> dict[str, Any]:
+        """Probe the gateway health endpoint without raising transport errors."""
+        started = time.perf_counter()
+        try:
+            details = self.get("/healthz")
+        except (OpenClawConnectionError, OpenClawAuthError, OpenClawAPIError) as exc:
+            return {
+                "available": False,
+                "status": "down",
+                "latency_ms": (time.perf_counter() - started) * 1000.0,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            }
+        return {
+            "available": True,
+            "status": "up",
+            "latency_ms": (time.perf_counter() - started) * 1000.0,
+            "details": details,
+        }
 
     def patch(self, path: str, json: dict[str, Any] | None = None) -> dict[str, Any]:
         """Send a PATCH request and return the parsed JSON response."""

--- a/rex/openclaw/tool_bridge.py
+++ b/rex/openclaw/tool_bridge.py
@@ -60,6 +60,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _warn_gateway_fallback(tool_name: str, exc: Exception, *, failure: str | None = None) -> None:
+    """Emit a machine-readable warning before local fallback."""
+    failure_name = failure or type(exc).__name__
+    logger.warning(
+        "OpenClaw gateway unavailable for tool=%s; falling back to local execution: %s",
+        tool_name,
+        exc,
+        extra={
+            "event": "openclaw.tool_fallback",
+            "tool_name": tool_name,
+            "failure": failure_name,
+        },
+    )
+
+
 class ToolBridge:
     """Adapter that presents Rex's tool executor as an OpenClaw tool provider.
 
@@ -167,14 +182,17 @@ class ToolBridge:
                         tool_name,
                     )
                     # fall through to local execution below
+                elif exc.status == 429 or exc.status >= 500:
+                    _warn_gateway_fallback(
+                        tool_name,
+                        exc,
+                        failure=f"OpenClawAPIError:{exc.status}",
+                    )
+                    # fall through to local execution below
                 else:
                     raise
             except (OpenClawConnectionError, OpenClawAuthError) as exc:
-                logger.warning(
-                    "OpenClaw tool dispatch error for tool=%s, falling back to local: %s",
-                    tool_name,
-                    exc,
-                )
+                _warn_gateway_fallback(tool_name, exc)
                 # fall through to local execution below
 
         return _execute_tool(

--- a/tests/test_openclaw_health.py
+++ b/tests/test_openclaw_health.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from requests.exceptions import ConnectionError as RequestsConnectionError
+
+from rex.openclaw.errors import OpenClawAPIError, OpenClawConnectionError
+from rex.openclaw.http_client import OpenClawClient
+from rex.openclaw.tool_bridge import ToolBridge
+
+
+def _response(status: int, payload: dict | None = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status
+    response.headers = {}
+    response.text = "service unavailable" if status >= 500 else ""
+    response.content = b"..." if payload is not None else b""
+    response.json.return_value = payload or {}
+    return response
+
+
+def test_healthz_reports_gateway_up() -> None:
+    client = OpenClawClient("http://openclaw.test:18789", "token", max_retries=0)
+    with patch.object(
+        client._session,
+        "request",
+        return_value=_response(200, {"status": "ok"}),
+    ) as request:
+        health = client.health()
+
+    assert health["available"] is True
+    assert health["status"] == "up"
+    assert health["details"] == {"status": "ok"}
+    assert health["latency_ms"] >= 0
+    assert request.call_args.args[:2] == ("GET", "http://openclaw.test:18789/healthz")
+
+
+def test_healthz_retries_connection_failure_only_to_configured_bound() -> None:
+    client = OpenClawClient("http://openclaw.test:18789", "token", max_retries=2)
+    with patch.object(
+        client._session,
+        "request",
+        side_effect=RequestsConnectionError("refused"),
+    ) as request:
+        with patch("rex.openclaw.http_client.time.sleep") as sleep:
+            health = client.health()
+
+    assert health["available"] is False
+    assert health["status"] == "down"
+    assert health["error_type"] == "OpenClawConnectionError"
+    assert request.call_count == 3
+    assert sleep.call_count == 2
+
+
+def test_healthz_recovers_on_later_probe() -> None:
+    client = OpenClawClient("http://openclaw.test:18789", "token", max_retries=0)
+    with patch.object(
+        client._session,
+        "request",
+        side_effect=[
+            RequestsConnectionError("refused"),
+            _response(200, {"status": "ok"}),
+        ],
+    ):
+        first = client.health()
+        second = client.health()
+
+    assert first["available"] is False
+    assert second["available"] is True
+
+
+def test_tool_gateway_failure_falls_back_with_structured_warning_and_recovers(caplog) -> None:
+    config = SimpleNamespace(use_openclaw_tools=True)
+    client = MagicMock()
+    client.post.side_effect = [
+        OpenClawConnectionError("http://openclaw.test:18789", Exception("refused")),
+        {"status": "success", "result": "remote"},
+    ]
+    bridge = ToolBridge(config=config)
+    local = {"status": "ok", "result": "local"}
+
+    with patch("rex.openclaw.tool_bridge.get_openclaw_client", return_value=client):
+        with patch("rex.openclaw.tool_bridge._execute_tool", return_value=local) as local_execute:
+            with caplog.at_level(logging.WARNING, logger="rex.openclaw.tool_bridge"):
+                first = bridge.execute_tool({"tool": "time_now", "args": {}}, {})
+                second = bridge.execute_tool({"tool": "time_now", "args": {}}, {})
+
+    assert first == local
+    assert second == {"status": "success", "result": "remote"}
+    local_execute.assert_called_once()
+    fallback = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "openclaw.tool_fallback"
+    )
+    assert fallback.tool_name == "time_now"
+    assert fallback.failure == "OpenClawConnectionError"
+
+
+def test_exhausted_server_retries_fall_back_locally_with_warning(caplog) -> None:
+    config = SimpleNamespace(use_openclaw_tools=True)
+    client = MagicMock()
+    client.post.side_effect = OpenClawAPIError(503, "service unavailable")
+    bridge = ToolBridge(config=config)
+    local = {"status": "ok", "result": "local"}
+
+    with patch("rex.openclaw.tool_bridge.get_openclaw_client", return_value=client):
+        with patch("rex.openclaw.tool_bridge._execute_tool", return_value=local):
+            with caplog.at_level(logging.WARNING, logger="rex.openclaw.tool_bridge"):
+                result = bridge.execute_tool({"tool": "weather_now", "args": {}}, {})
+
+    assert result == local
+    fallback = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "openclaw.tool_fallback"
+    )
+    assert fallback.tool_name == "weather_now"
+    assert fallback.failure == "OpenClawAPIError:503"

--- a/tests/test_openclaw_tool_bridge_http.py
+++ b/tests/test_openclaw_tool_bridge_http.py
@@ -102,16 +102,24 @@ class TestExecuteToolHTTPPath:
         mock_local.assert_called_once()
         assert result == local_result
 
-    def test_5xx_raises_after_retries(self):
+    def test_5xx_falls_back_to_local_after_remote_retries(self, caplog):
         cfg = _make_config()
         client = _make_client(post_side_effect=OpenClawAPIError(500, "server error"))
         bridge = ToolBridge(config=cfg)
+        local_result = {"status": "ok", "result": "local"}
 
         with patch("rex.openclaw.tool_bridge.get_openclaw_client", return_value=client):
-            with pytest.raises(OpenClawAPIError) as exc_info:
-                bridge.execute_tool({"tool": "time_now", "args": {}}, {})
+            with patch("rex.openclaw.tool_bridge._execute_tool", return_value=local_result):
+                with caplog.at_level("WARNING", logger="rex.openclaw.tool_bridge"):
+                    result = bridge.execute_tool({"tool": "time_now", "args": {}}, {})
 
-        assert exc_info.value.status == 500
+        assert result == local_result
+        fallback = next(
+            record
+            for record in caplog.records
+            if getattr(record, "event", None) == "openclaw.tool_fallback"
+        )
+        assert fallback.failure == "OpenClawAPIError:500"
 
     def test_connection_error_falls_back_to_local(self):
         cfg = _make_config()


### PR DESCRIPTION
Implements US-051 OpenClaw gateway health, bounded reconnect, and graceful degradation.

Changes:
- add `OpenClawClient.health()` using `GET /healthz` with explicit up/down, latency, and error evidence
- retry connection/timeouts within the configured `max_retries` bound, matching existing retryable HTTP behavior
- after exhausted connection/auth/429/5xx gateway failures, emit structured `openclaw.tool_fallback` warnings and execute through the canonical local Rex tool path
- preserve 403 as a hard policy denial and existing tool-specific 404 fallback
- do not add a sticky circuit breaker, so later calls automatically return to remote dispatch when the gateway recovers
- document the health/retry/fallback/recovery model
- update stale 5xx bridge expectation to the new graceful-degradation contract
- update production-readiness local evidence while leaving the GitHub gate open

Verification:
- focused health TDD acceptance: 5 passed
- HTTP client/tool bridge/health regression: 36 passed
- broad OpenClaw-selected suite: 638 passed
- Ruff + Black: pass
- mypy changed source files: 0 issues
- skip inventory: 127/127 current
- git diff --check: pass

This branch is stacked on #363 -> #362 -> #361. Merge only after dependencies land.