### PR TITLE
docs(audit): reconcile cross-doc truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ The canonical primary branch is **`master`**.
 
 - All PRs must target `master`.
 - `claude/**` branches are AI-generated and follow the same PR process.
+- `master` is not branch-protected. Do not use `gh pr merge --auto`; it can merge immediately while long checks are still running. Issue a merge command only after independently verifying all required GitHub checks are green on the exact PR head.
 - See `CONTRIBUTING.md` for full branching model details.
 
 ## Tech Stack and Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The canonical primary branch is **`master`**.
 Language: Python 3.11
 
 Packaging: pyproject.toml with setuptools backend  
-Install via: pip install .
+Developer/operator source install: `pip install .`
 
 Current install/runtime compatibility policy:
 
@@ -241,7 +241,7 @@ Top-level directories:
 
 Active entry points and developer utilities (6):
 
-- rex_loop.py — full voice loop entry point (wake word → STT → LLM → TTS)
+- rex_loop.py — source voice-loop entry point; defaults to Hold-to-Talk/manual activation, with beta wake-word only via `--mode wake-word`
 - rex_speak_api.py — Flask TTS API with auth and rate limiting
 - wsgi.py — WSGI entry point for `rex-gui`
 - setup.py — legacy setuptools stub (packaging via `pyproject.toml`)
@@ -623,12 +623,15 @@ Add a short rule here that would have prevented the mistake.
 
 Rex integrates with OpenClaw over HTTP (not as a Python package). Key facts:
 
+- both OpenClaw flags default to `False`; OpenClaw is experimental/off by default. Enabling either gateway-backed path requires a valid HTTP(S) gateway URL plus `OPENCLAW_GATEWAY_TOKEN`, and incomplete enabled configuration fails closed.
+- Gateway health is explicit: `/healthz` may establish reachability only. It does not prove authentication or tool capability.
+
 - Phase 8 (HTTP integration) is complete. All `find_spec("openclaw")` / `import openclaw` stubs have been removed and replaced with HTTP client calls.
 - OpenClaw adapters live in `rex/openclaw/`: `agent.py`, `tool_bridge.py`, `event_bridge.py`, `browser_bridge.py`, `voice_bridge.py`, `http_client.py`, `tool_server.py`, and tool handlers under `rex/openclaw/tools/`.
 - HTTP client: `rex/openclaw/http_client.py` (`OpenClawClient`) handles auth, retries, timeouts for all gateway calls. Singleton via `get_openclaw_client(config)`.
 - Config fields: `openclaw_gateway_url`, `openclaw_gateway_timeout`, `openclaw_gateway_max_retries` in `AppConfig`; `OPENCLAW_GATEWAY_TOKEN` in the credential vault.
 - Feature flag `use_openclaw_voice_backend` in `AppConfig` (config path: `openclaw.use_voice_backend`): when True, voice loops swap `Assistant` for `VoiceBridge`, routing LLM calls through OpenClaw's `/v1/chat/completions`.
-- Feature flag `use_openclaw_tools` in `AppConfig` (config path: `openclaw.use_tools`): when True, `ToolBridge.execute_tool()` dispatches to OpenClaw's `/tools/invoke`; 404 falls back to local execution.
+- Feature flag `use_openclaw_tools` in `AppConfig` (config path: `openclaw.use_tools`): when True, `ToolBridge.execute_tool()` dispatches to OpenClaw's `/tools/invoke`; 404 uses the local tool, while connection/auth/429/5xx failures fall back locally with a structured warning after bounded retries. A 403 remains a hard policy denial.
 - Tool server: `rex/openclaw/tool_server.py` exposes Rex tools at `/rex/tools/{tool_name}` for OpenClaw channels. Entry point: `rex-tool-server`.
 - All `# OPENCLAW-REPLACE` modules from Phases 5-7 have been retired (deleted).
 - Migration contracts (Protocol types) live in `rex/contracts/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ Pull requests must target `master`.
 
 `claude/**` branches are AI-generated and follow the same PR process as human branches.
 
-Do not merge directly to `master`. Always open a pull request so CI runs first.
+Do not merge directly to `master`. Always open a pull request so CI runs first. Do not merge a PR until every required GitHub check is green on the exact head being merged.
 
 ## Commit message format
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -203,13 +203,13 @@ rex-config migrate-legacy-env
 
 | Mode | Command | Notes |
 |---|---|---|
-| **Electron desktop app** | Windows: `cd gui; npm.cmd run dev`; macOS/Linux: `cd gui && npm run dev` | **Primary user-facing interface** — requires Node/npm and Python bridges |
+| **Electron desktop app** | Packaged Windows installer; source development: `cd gui; npm.cmd run dev` | **Shippable installer; source command is development-only** - packaged end-user runtime needs no machine Python/Node; source development does |
 | Text chat (CLI) | `rex` or `python -m rex` | Developer / advanced — default interactive CLI |
 | Diagnostics | `rex doctor` | Environment and dependency checks |
-| Voice loop | `python rex_loop.py` | Developer / advanced — wake word -> STT -> LLM -> TTS |
+| Voice loop | `python rex_loop.py` | **Developer-only** - defaults to Hold-to-Talk; `--mode wake-word` is beta opt-in |
 | Flask API/dashboard | `rex-gui` | Developer-only compatibility surface; Electron does not spawn or require it |
 | TTS API | `rex-speak-api` | Developer / advanced — requires `REX_SPEAK_API_KEY`; default port 5005 |
-| OpenClaw tool server | `rex-tool-server` | Developer / advanced — requires `REX_TOOL_API_KEY`; default port 18790 |
+| OpenClaw tool server | `rex-tool-server` | **Experimental** - off by default; requires explicit gateway configuration and `REX_TOOL_API_KEY` for the Rex tool-server surface |
 | Windows computer agent | `rex-agent` | Developer / advanced — optional remote PC control agent |
 
 The Tkinter launchers are archived under `archived/tkinter_gui/` and are not supported runtime paths.

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1858,10 +1858,10 @@ grep -n "Capabilities" README.md
 - All of the above
 
 **Acceptance Criteria:**
-- [ ] A `docs/AUDIT-CROSS-DOC.md` (new) lists every cross-doc claim about install methods, console scripts, root file count, voice mode default, OpenClaw status, Docker tier, and HA verification.
+- [x] A `docs/AUDIT-CROSS-DOC.md` (new) lists every cross-doc claim about install methods, console scripts, root file count, voice mode default, OpenClaw status, Docker tier, and HA verification.
 - [ ] Every claim is verified against the code at the audit commit.
-- [ ] Conflicts are resolved in the same story.
-- [ ] Documentation links and references are accurate.
+- [x] Conflicts are resolved in the same story.
+- [x] Documentation links and references are accurate.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1862,7 +1862,7 @@ grep -n "Capabilities" README.md
 - [x] Every claim is verified against the code at the audit commit. *(Verified on final post-rebase implementation snapshot `2f1e604b286404a4c50aa837c76898453058fc19`: 14/14 cross-doc/capability/UI contract tests passed, with Ruff, Black, pre-commit, and diff hygiene green.)*
 - [x] Conflicts are resolved in the same story.
 - [x] Documentation links and references are accurate.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. *(PR #367 implementation/evidence head `3fc4d9b50bf9ed2b75f018dffff6f281749ad80f`: all 17 checks passed, including Python 3.11 Tests & Coverage in 10m13s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, and commitlint were green.)*
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1859,7 +1859,7 @@ grep -n "Capabilities" README.md
 
 **Acceptance Criteria:**
 - [x] A `docs/AUDIT-CROSS-DOC.md` (new) lists every cross-doc claim about install methods, console scripts, root file count, voice mode default, OpenClaw status, Docker tier, and HA verification.
-- [ ] Every claim is verified against the code at the audit commit.
+- [x] Every claim is verified against the code at the audit commit. *(Verified on final post-rebase implementation snapshot `2f1e604b286404a4c50aa837c76898453058fc19`: 14/14 cross-doc/capability/UI contract tests passed, with Ruff, Black, pre-commit, and diff hygiene green.)*
 - [x] Conflicts are resolved in the same story.
 - [x] Documentation links and references are accurate.
 - [ ] All relevant GitHub checks pass.

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -22,11 +22,11 @@ source .venv/bin/activate
 |---|---|---|
 | Text chat | `rex` or `python -m rex` | Interactive CLI chat |
 | Diagnostics | `rex doctor` or `python -m rex doctor` | Environment, dependency, and config checks |
-| Voice loop | `python rex_loop.py` | Developer voice loop; wake word remains beta |
+| Voice loop | `python rex_loop.py` | Developer-only source voice loop; defaults to Hold-to-Talk; `--mode wake-word` is beta opt-in |
 | Python web dashboard | `rex-gui` | Developer-only browser/API surface at `http://127.0.0.1:8765/ui/` |
 | Electron desktop GUI | Installed AskRex app or `cd gui && npm.cmd run dev` | Primary user-facing surface; source command is development-only |
 | TTS API | `rex-speak-api` | Local speech synthesis service on port 5005 |
-| OpenClaw tool server | `rex-tool-server` | HTTP tool adapter service on port 18790 |
+| OpenClaw tool server | `rex-tool-server` | Experimental, off by default; HTTP tool adapter service on port 18790 |
 | Windows computer agent | `rex-agent` | Optional remote PC control agent |
 
 ## Runtime data locations

--- a/docs/AUDIT-CROSS-DOC.md
+++ b/docs/AUDIT-CROSS-DOC.md
@@ -2,7 +2,7 @@
 
 **Scope:** US-054 production-readiness cross-doc audit.
 
-**Verified code snapshot:** `AUDIT_COMMIT_PENDING` (replaced with the implementation commit SHA before this story is closed).
+**Verified code snapshot:** `2f1e604b286404a4c50aa837c76898453058fc19`. The executable cross-document audit was rerun against this exact post-rebase implementation tree before the evidence-only closeout commit.
 
 This audit reconciles current-state claims in [README](../README.md), [INSTALL](../INSTALL.md), [RUNNING](../RUNNING.md), [UI surfaces](UI_SURFACES.md), [surface classification](../SURFACE-CLASSIFICATION.md), [integration status](../INTEGRATIONS_STATUS.md), and [CLAUDE](../CLAUDE.md) against code and repository evidence. Historical files under `docs/archive/` are not current-state authorities.
 

--- a/docs/AUDIT-CROSS-DOC.md
+++ b/docs/AUDIT-CROSS-DOC.md
@@ -101,6 +101,7 @@ HA mutation success is `verified` only after independent state observation. Disp
 4. CLAUDE qualifies `pip install .` as the developer/operator source install rather than an unqualified install path.
 5. CLAUDE's root `rex_loop.py` description matches the Hold-to-Talk default.
 6. CLAUDE's OpenClaw section records default-off/fail-closed configuration, health-evidence scope, bounded fallback behavior, and the policy-denial exception.
+7. GitHub reports `master` is not branch-protected. Until a path-aware ruleset is designed, merge safety is procedural: CLAUDE and CONTRIBUTING require every required check to be green on the exact PR head before any merge command; agents must not rely on `gh pr merge --auto`.
 
 ## Linked Current-State Authorities
 
@@ -111,6 +112,7 @@ HA mutation success is `verified` only after independent state observation. Disp
 - [Surface classification](../SURFACE-CLASSIFICATION.md)
 - [Integration status](../INTEGRATIONS_STATUS.md)
 - [CLAUDE](../CLAUDE.md)
+- [Contributing](../CONTRIBUTING.md)
 - [OpenClaw status](openclaw-migration-status.md)
 - [Docker](docker.md)
 - [Home Assistant](home_assistant.md)

--- a/docs/AUDIT-CROSS-DOC.md
+++ b/docs/AUDIT-CROSS-DOC.md
@@ -1,0 +1,116 @@
+# Cross-Documentation Truth Audit
+
+**Scope:** US-054 production-readiness cross-doc audit.
+
+**Verified code snapshot:** `AUDIT_COMMIT_PENDING` (replaced with the implementation commit SHA before this story is closed).
+
+This audit reconciles current-state claims in [README](../README.md), [INSTALL](../INSTALL.md), [RUNNING](../RUNNING.md), [UI surfaces](UI_SURFACES.md), [surface classification](../SURFACE-CLASSIFICATION.md), [integration status](../INTEGRATIONS_STATUS.md), and [CLAUDE](../CLAUDE.md) against code and repository evidence. Historical files under `docs/archive/` are not current-state authorities.
+
+## Audit Result
+
+| Claim family | Verified current fact | Code / filesystem evidence | Current docs checked | Result |
+|---|---|---|---|---|
+| Install methods | End users use the packaged Windows Electron installer. `pip install .` is the developer/operator source install and does not install the Electron app. | `gui/package.json`, `pyproject.toml` | README, INSTALL, RUNNING, UI_SURFACES, SURFACE-CLASSIFICATION, CLAUDE | Reconciled |
+| Console scripts | Exactly six `[project.scripts]` entries exist. | `pyproject.toml` | README, INSTALL, SURFACE-CLASSIFICATION, CLAUDE | Verified |
+| Root Python inventory | Root-level `.py` count is 27; bridge wrappers are compatibility/test surfaces, not Electron runtime bridge paths. | Repository root + `gui/src/main/bridgeResolver.ts` | SURFACE-CLASSIFICATION, CLAUDE, UI_SURFACES | Verified |
+| Voice mode default | Source `rex_loop.py` defaults to Hold-to-Talk/manual activation; `--mode wake-word` is explicit beta opt-in. Electron Hold-to-Talk is the supported end-user path. | `rex_loop.py` argparse default | README, INSTALL, RUNNING, UI_SURFACES, SURFACE-CLASSIFICATION, CLAUDE | Reconciled |
+| OpenClaw status | Experimental/off by default. Enabled tools/voice require gateway URL + token. `/healthz` proves reachability only. Retryable gateway failures degrade to local execution with structured warning; 403 remains policy denial. | `rex/config.py`, `rex/openclaw/http_client.py`, `rex/openclaw/tool_bridge.py` | README, INSTALL, RUNNING, SURFACE-CLASSIFICATION, INTEGRATIONS_STATUS, CLAUDE, OpenClaw status | Reconciled |
+| Docker tier | Developer-only/operator smoke path; lightweight liveness check is `python -m rex doctor --healthcheck`. | `Dockerfile` | README, SURFACE-CLASSIFICATION, CLAUDE, docker.md | Verified |
+| Home Assistant verification | Mutation success is `verified` only after independent state observation. Other outcomes preserve uncertainty and verification evidence. | `rex/ha/mutation_service.py`, `rex/response/builder.py` | README, INTEGRATIONS_STATUS, CLAUDE, home_assistant.md | Verified |
+
+## Install Methods
+
+- **End-user artifact:** packaged Windows Electron installer. Its managed runtime includes Python 3.11, the AskRex wheel, canonical bridge scripts, voice dependencies, and FFmpeg; it does not require machine Node/Python.
+- **Developer/operator source install:** Python 3.11 plus `pip install .`. This installs the Python package, six console scripts, bridge data files, and config example; it does not create the Electron installer.
+- **Editable contributor install:** `pip install -e ".[dev,test]"` when development tooling is required.
+
+## Console Scripts
+
+Verified directly from `pyproject.toml`:
+
+- `rex` -> `rex.cli:main`
+- `rex-config` -> `rex.config:cli`
+- `rex-speak-api` -> `rex_speak_api:main`
+- `rex-agent` -> `rex.computers.agent_server:main`
+- `rex-gui` -> `rex.gui_app:main`
+- `rex-tool-server` -> `rex.openclaw.tool_server:main`
+
+The mobile gateway is a `rex` CLI subcommand (`python -m rex mobile-api`), not a seventh console script.
+
+## Root Python Inventory
+
+Root-level `.py` count: `27`.
+
+- `config.py`
+- `conftest.py`
+- `flask_proxy.py`
+- `llm_client.py`
+- `rex_chat_bridge.py`
+- `rex_chat_stream_bridge.py`
+- `rex_file_extract_bridge.py`
+- `rex_loop.py`
+- `rex_memories_bridge.py`
+- `rex_reminders_bridge.py`
+- `rex_shopping_list_bridge.py`
+- `rex_speak_api.py`
+- `rex_speaker_bridge.py`
+- `rex_stt_bridge.py`
+- `rex_tasks_bridge.py`
+- `rex_voice_bridge.py`
+- `rex_voice_enrollment_bridge.py`
+- `rex_voice_sample_bridge.py`
+- `rex_voice_upload_bridge.py`
+- `rex_voices_bridge.py`
+- `rex_wakeword_list_bridge.py`
+- `rex_wakeword_sample_bridge.py`
+- `rex_wakeword_train_bridge.py`
+- `setup.py`
+- `sitecustomize.py`
+- `voice_loop.py`
+- `wsgi.py`
+
+The 17 `rex_*_bridge.py` root files are compatibility wrappers. Electron development resolves canonical scripts under `bridge/`; packaged Electron resolves `resources/bridge/`.
+
+## Voice Default
+
+Source voice default: `hold-to-talk`; `wake-word` is explicit beta opt-in.
+
+Code evidence: `rex_loop.py` declares `choices=("hold-to-talk", "wake-word")` and `default="hold-to-talk"`. The lower-level builder retains a backwards-compatible internal default, but the user-facing source entry point supplies Hold-to-Talk explicitly.
+
+## OpenClaw Status
+
+OpenClaw defaults: tools `false`, voice backend `false`; enabled mode requires URL + token.
+
+The surface is `experimental`, not shippable. The Electron GUI can test `/healthz` and report gateway reachability, but authentication and tool capability remain unproven by health alone. Tool dispatch uses bounded retries; exhausted connection/auth/429/5xx failures emit `openclaw.tool_fallback` and execute locally. Policy denial (403) never falls around Rex policy.
+
+## Docker Tier
+
+Docker tier: `developer-only`; healthcheck is `python -m rex doctor --healthcheck`.
+
+The Docker image is an operator/development smoke path, not the end-user distribution artifact and not a supported production deployment tier.
+
+## Home Assistant Verification
+
+HA mutation success is `verified` only after independent state observation. Dispatch acceptance by itself never becomes a confirmed user-facing success. `switch`, `light`, `lock`, and `cover` use expected-state polling evidence; results preserve `expected`, `actual`, and `latency_ms`. Sensitive actions require action-bound confirmation before dispatch.
+
+## Conflicts Resolved in This Story
+
+1. INSTALL distinguishes the shippable packaged installer from the development-only source Electron launch command.
+2. INSTALL and RUNNING state the source voice default is Hold-to-Talk and wake-word is beta opt-in.
+3. INSTALL and RUNNING classify OpenClaw as experimental/off by default instead of generic developer/advanced.
+4. CLAUDE qualifies `pip install .` as the developer/operator source install rather than an unqualified install path.
+5. CLAUDE's root `rex_loop.py` description matches the Hold-to-Talk default.
+6. CLAUDE's OpenClaw section records default-off/fail-closed configuration, health-evidence scope, bounded fallback behavior, and the policy-denial exception.
+
+## Linked Current-State Authorities
+
+- [README](../README.md)
+- [INSTALL](../INSTALL.md)
+- [RUNNING](../RUNNING.md)
+- [UI surfaces](UI_SURFACES.md)
+- [Surface classification](../SURFACE-CLASSIFICATION.md)
+- [Integration status](../INTEGRATIONS_STATUS.md)
+- [CLAUDE](../CLAUDE.md)
+- [OpenClaw status](openclaw-migration-status.md)
+- [Docker](docker.md)
+- [Home Assistant](home_assistant.md)

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1546,5 +1546,5 @@ Local evidence so far:
 - TDD red phase: all 5 audit tests failed before the audit existed/current-doc conflicts were fixed.
 - Final combined documentation set: 14/14 passed across cross-doc audit, capability-status, and UI-surface tests after adding the merge-safety contract. Ruff/Black pass; skip inventory 127/127 current; `git diff --check` pass.
 - Final post-rebase audit implementation snapshot: `2f1e604b286404a4c50aa837c76898453058fc19` on merged US-053 master. The executable cross-doc/capability/UI contract suite passed 14/14 on this exact tree, with Ruff, Black, pre-commit, and `git diff --check` green; the audit document and PRD now bind their verification evidence to this SHA.
-- Relevant GitHub checks remain pending the final story PR head.
+- GitHub implementation/evidence gate: PASS on PR #367 head `3fc4d9b50bf9ed2b75f018dffff6f281749ad80f`. All 17 checks passed; Python 3.11 Tests & Coverage completed in 10m13s and all quality/security/GUI/dependency/pre-commit/wheel/commitlint checks were green.
 - Repository process finding: GitHub reports `master` is not branch-protected, so `gh pr merge --auto` is unsafe here. CLAUDE and CONTRIBUTING now require all required checks to be green on the exact PR head before any merge command.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1544,6 +1544,7 @@ Implementation so far:
 
 Local evidence so far:
 - TDD red phase: all 5 audit tests failed before the audit existed/current-doc conflicts were fixed.
-- Final combined documentation set: 13/13 passed across cross-doc audit, capability-status, and UI-surface tests. Ruff/Black pass; skip inventory 127/127 current; `git diff --check` pass.
+- Final combined documentation set: 14/14 passed across cross-doc audit, capability-status, and UI-surface tests after adding the merge-safety contract. Ruff/Black pass; skip inventory 127/127 current; `git diff --check` pass.
 - Audit implementation snapshot was committed as `28232d886763603f0e7a66b1e01116405a02d3ec`, but this story is still stacked and will be rebased. The audit intentionally keeps `AUDIT_COMMIT_PENDING` and its "verified against the code at the audit commit" criterion open until the final post-rebase implementation SHA is stable.
 - Relevant GitHub checks remain pending the final story PR head.
+- Repository process finding: GitHub reports `master` is not branch-protected, so `gh pr merge --auto` is unsafe here. CLAUDE and CONTRIBUTING now require all required checks to be green on the exact PR head before any merge command.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1545,6 +1545,6 @@ Implementation so far:
 Local evidence so far:
 - TDD red phase: all 5 audit tests failed before the audit existed/current-doc conflicts were fixed.
 - Final combined documentation set: 14/14 passed across cross-doc audit, capability-status, and UI-surface tests after adding the merge-safety contract. Ruff/Black pass; skip inventory 127/127 current; `git diff --check` pass.
-- Audit implementation snapshot was committed as `28232d886763603f0e7a66b1e01116405a02d3ec`, but this story is still stacked and will be rebased. The audit intentionally keeps `AUDIT_COMMIT_PENDING` and its "verified against the code at the audit commit" criterion open until the final post-rebase implementation SHA is stable.
+- Final post-rebase audit implementation snapshot: `2f1e604b286404a4c50aa837c76898453058fc19` on merged US-053 master. The executable cross-doc/capability/UI contract suite passed 14/14 on this exact tree, with Ruff, Black, pre-commit, and `git diff --check` green; the audit document and PRD now bind their verification evidence to this SHA.
 - Relevant GitHub checks remain pending the final story PR head.
 - Repository process finding: GitHub reports `master` is not branch-protected, so `gh pr merge --auto` is unsafe here. CLAUDE and CONTRIBUTING now require all required checks to be green on the exact PR head before any merge command.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1534,3 +1534,16 @@ Local evidence so far:
 - Rebased story-only implementation head: `4580f568db1b5784fefebeb03df5ec569621187f`.
 - All 17 reported checks passed. Python 3.11 Tests & Coverage passed in 10m13s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, and commitlint were green.
 - The prior CodeFactor failure belonged to the obsolete stacked US-052 Settings implementation and disappeared after rebasing US-053 onto merged PR #365. Local documentation contract verification remained 8/8 green after rebase.
+
+=== 2026-08-08 - US-054 cross-document consistency audit ===
+
+Implementation so far:
+- Added `docs/AUDIT-CROSS-DOC.md` covering install methods, all six console scripts, the exact 27-file root Python inventory, source voice default, OpenClaw tier/defaults/degradation contract, Docker tier/healthcheck, and Home Assistant verification semantics.
+- Reconciled INSTALL, RUNNING, and CLAUDE against code: packaged-vs-source install truth, Hold-to-Talk source default, experimental/default-off OpenClaw status, and current structured local-fallback behavior.
+- Added executable `tests/test_cross_doc_audit.py` validating the audit against pyproject, the live root filesystem, rex_loop.py, rex/config.py, Dockerfile, HA mutation statuses, current-doc wording, and local audit links.
+
+Local evidence so far:
+- TDD red phase: all 5 audit tests failed before the audit existed/current-doc conflicts were fixed.
+- Final combined documentation set: 13/13 passed across cross-doc audit, capability-status, and UI-surface tests. Ruff/Black pass; skip inventory 127/127 current; `git diff --check` pass.
+- Audit implementation snapshot was committed as `28232d886763603f0e7a66b1e01116405a02d3ec`, but this story is still stacked and will be rebased. The audit intentionally keeps `AUDIT_COMMIT_PENDING` and its "verified against the code at the audit commit" criterion open until the final post-rebase implementation SHA is stable.
+- Relevant GitHub checks remain pending the final story PR head.

--- a/tests/test_cross_doc_audit.py
+++ b/tests/test_cross_doc_audit.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT = ROOT / "docs" / "AUDIT-CROSS-DOC.md"
+
+EXPECTED_SCRIPTS = {
+    "rex": "rex.cli:main",
+    "rex-config": "rex.config:cli",
+    "rex-speak-api": "rex_speak_api:main",
+    "rex-agent": "rex.computers.agent_server:main",
+    "rex-gui": "rex.gui_app:main",
+    "rex-tool-server": "rex.openclaw.tool_server:main",
+}
+
+
+def _text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_cross_doc_audit_exists_and_records_console_scripts() -> None:
+    audit = AUDIT.read_text(encoding="utf-8")
+    pyproject = tomllib.loads(_text("pyproject.toml"))
+    assert pyproject["project"]["scripts"] == EXPECTED_SCRIPTS
+    for name, target in EXPECTED_SCRIPTS.items():
+        assert f"`{name}` -> `{target}`" in audit
+
+
+def test_cross_doc_audit_records_exact_root_python_inventory() -> None:
+    audit = AUDIT.read_text(encoding="utf-8")
+    root_files = sorted(path.name for path in ROOT.glob("*.py"))
+    assert len(root_files) == 27
+    assert "Root-level `.py` count: `27`" in audit
+    for name in root_files:
+        assert f"`{name}`" in audit
+
+
+def test_cross_doc_audit_records_voice_openclaw_docker_and_ha_code_truth() -> None:
+    audit = AUDIT.read_text(encoding="utf-8")
+    rex_loop = _text("rex_loop.py")
+    config = _text("rex/config.py")
+    dockerfile = _text("Dockerfile")
+    ha = _text("rex/ha/mutation_service.py")
+
+    assert 'default="hold-to-talk"' in rex_loop
+    assert "Source voice default: `hold-to-talk`; `wake-word` is explicit beta opt-in." in audit
+    assert "use_openclaw_tools: bool = False" in config
+    assert "use_openclaw_voice_backend: bool = False" in config
+    assert (
+        "OpenClaw defaults: tools `false`, voice backend `false`; enabled mode requires URL + token."
+        in audit
+    )
+    assert "CMD python -m rex doctor --healthcheck" in dockerfile
+    assert (
+        "Docker tier: `developer-only`; healthcheck is `python -m rex doctor --healthcheck`."
+        in audit
+    )
+    for status in ("VERIFIED", "ATTEMPTED_UNVERIFIED", "CONFIRMATION_REQUIRED", "DENIED", "FAILED"):
+        assert status in ha
+    assert "HA mutation success is `verified` only after independent state observation" in audit
+
+
+def test_current_docs_use_same_cross_doc_claims() -> None:
+    install = _text("INSTALL.md")
+    running = _text("RUNNING.md")
+    claude = _text("CLAUDE.md")
+
+    assert "**Shippable installer; source command is development-only**" in install
+    assert (
+        "**Developer-only** - defaults to Hold-to-Talk; `--mode wake-word` is beta opt-in"
+        in install
+    )
+    assert "**Experimental** - off by default; requires explicit gateway configuration" in install
+    assert "Developer-only source voice loop; defaults to Hold-to-Talk" in running
+    assert "Experimental, off by default" in running
+    assert "Developer/operator source install: `pip install .`" in claude
+    assert "both OpenClaw flags default to `False`" in claude
+    assert "connection/auth/429/5xx failures fall back locally with a structured warning" in claude
+
+
+def test_cross_doc_audit_local_links_exist() -> None:
+    audit = AUDIT.read_text(encoding="utf-8")
+    for target in re.findall(r"\[[^\]]+\]\(([^)]+)\)", audit):
+        if "://" in target or target.startswith("#"):
+            continue
+        path = target.split("#", 1)[0]
+        assert (AUDIT.parent / path).resolve().exists(), target

--- a/tests/test_cross_doc_audit.py
+++ b/tests/test_cross_doc_audit.py
@@ -88,3 +88,17 @@ def test_cross_doc_audit_local_links_exist() -> None:
             continue
         path = target.split("#", 1)[0]
         assert (AUDIT.parent / path).resolve().exists(), target
+
+
+def test_claude_requires_verified_checks_before_merge() -> None:
+    claude = _text("CLAUDE.md")
+    audit = AUDIT.read_text(encoding="utf-8")
+    contributing = _text("CONTRIBUTING.md")
+    assert "`master` is not branch-protected" in claude
+    assert "Do not use `gh pr merge --auto`" in claude
+    assert "all required GitHub checks are green on the exact PR head" in claude
+    assert "GitHub reports `master` is not branch-protected" in audit
+    assert (
+        "Do not merge a PR until every required GitHub check is green on the exact head"
+        in contributing
+    )


### PR DESCRIPTION
Implements the US-054 cross-document truth audit and reconciles current install/runtime claims against code evidence.

Changes:
- add `docs/AUDIT-CROSS-DOC.md` covering install methods, six console scripts, exact 27-file root Python inventory, voice default, OpenClaw status, Docker tier/healthcheck, and HA verification
- fix INSTALL packaged-vs-source Electron wording, Hold-to-Talk default, and OpenClaw experimental/default-off status
- fix RUNNING voice/OpenClaw status wording
- update CLAUDE source-install, root voice-loop, and OpenClaw health/fallback truth
- add executable cross-doc audit tests against pyproject, filesystem, rex_loop.py, rex/config.py, Dockerfile, HA status code, current docs, and local links
- record local evidence in the production-readiness tracker/progress ledger

Local verification:
- combined audit/capability/UI docs set: 13 passed
- Ruff + Black: pass
- skip inventory: 127/127 current
- git diff --check: pass

Important: this PR is stacked on #366 -> #365 -> #364 -> #363 -> #362. The audit intentionally keeps `AUDIT_COMMIT_PENDING` and the corresponding PRD criterion open until the branch is rebased onto the final master base, because rebasing changes the implementation commit SHA. After dependencies merge, the final stable audit SHA will be recorded and the GitHub gate closed.