### PR TITLE
test(docs): enforce CLAUDE truth contract

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1883,12 +1883,12 @@ grep -n "rex-gui\|rex_loop\|wake word\|OpenClaw\|Docker" README.md INSTALL.md RU
 - `CLAUDE.md`
 
 **Acceptance Criteria:**
-- [ ] Root `.py` file count and list are accurate.
-- [ ] Console-script list matches `pyproject.toml`.
-- [ ] Voice-mode default matches US-042.
-- [ ] OpenClaw status matches US-050.
-- [ ] Docker tier matches US-041.
-- [ ] Documentation links and references are accurate.
+- [x] Root `.py` file count and list are accurate.
+- [x] Console-script list matches `pyproject.toml`.
+- [x] Voice-mode default matches US-042.
+- [x] OpenClaw status matches US-050.
+- [x] Docker tier matches US-041.
+- [x] Documentation links and references are accurate.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1889,7 +1889,7 @@ grep -n "rex-gui\|rex_loop\|wake word\|OpenClaw\|Docker" README.md INSTALL.md RU
 - [x] OpenClaw status matches US-050.
 - [x] Docker tier matches US-041.
 - [x] Documentation links and references are accurate.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:**
 ```bash

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1556,3 +1556,8 @@ Verification:
 - Verified the exact 27 root Python files, all six console scripts, source Hold-to-Talk default/beta wake opt-in, experimental/default-off OpenClaw fail-closed/health/fallback contract, developer-only Docker healthcheck tier, packaged-vs-source install distinction, primary Electron GUI, and current referenced documentation paths.
 - The focused contract passed 5/5 on its first run because US-054 had already corrected the substantive CLAUDE drift. No additional production/document prose change was necessary in this story.
 - Relevant GitHub checks remain pending the story PR.
+
+2026-08-09 - US-055 GitHub implementation gate (PR #368)
+- Final master-based implementation head: `be3c8e0d2d3140b8d5ee981b905ad4aa07a3bb37`.
+- All 17 reported checks passed on that exact head. Python 3.11 Tests & Coverage passed in 10m04s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, and commitlint were green.
+- Local CLAUDE/cross-document/status verification remained 19/19 green after the final rebase, with Ruff, Black, pre-commit, and diff hygiene passing.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1548,3 +1548,11 @@ Local evidence so far:
 - Final post-rebase audit implementation snapshot: `2f1e604b286404a4c50aa837c76898453058fc19` on merged US-053 master. The executable cross-doc/capability/UI contract suite passed 14/14 on this exact tree, with Ruff, Black, pre-commit, and `git diff --check` green; the audit document and PRD now bind their verification evidence to this SHA.
 - GitHub implementation/evidence gate: PASS on PR #367 head `3fc4d9b50bf9ed2b75f018dffff6f281749ad80f`. All 17 checks passed; Python 3.11 Tests & Coverage completed in 10m13s and all quality/security/GUI/dependency/pre-commit/wheel/commitlint checks were green.
 - Repository process finding: GitHub reports `master` is not branch-protected, so `gh pr merge --auto` is unsafe here. CLAUDE and CONTRIBUTING now require all required checks to be green on the exact PR head before any merge command.
+
+=== 2026-08-08 - US-055 CLAUDE.md truth pass ===
+
+Verification:
+- Added `tests/test_claude_truth.py`, grounding CLAUDE against the live root filesystem and `pyproject.toml` instead of duplicating another prose audit.
+- Verified the exact 27 root Python files, all six console scripts, source Hold-to-Talk default/beta wake opt-in, experimental/default-off OpenClaw fail-closed/health/fallback contract, developer-only Docker healthcheck tier, packaged-vs-source install distinction, primary Electron GUI, and current referenced documentation paths.
+- The focused contract passed 5/5 on its first run because US-054 had already corrected the substantive CLAUDE drift. No additional production/document prose change was necessary in this story.
+- Relevant GitHub checks remain pending the story PR.

--- a/tests/test_claude_truth.py
+++ b/tests/test_claude_truth.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLAUDE = ROOT / "CLAUDE.md"
+
+
+def _claude() -> str:
+    return CLAUDE.read_text(encoding="utf-8")
+
+
+def test_claude_root_python_inventory_matches_filesystem() -> None:
+    text = _claude()
+    root_files = sorted(path.name for path in ROOT.glob("*.py"))
+    assert len(root_files) == 27
+    assert "### Root-level `.py` files (27 total)" in text
+    assert "9 active root-level" not in text
+    for name in root_files:
+        assert f"- {name}" in text
+
+
+def test_claude_console_scripts_match_pyproject() -> None:
+    text = _claude()
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    scripts = pyproject["project"]["scripts"]
+    assert len(scripts) == 6
+    for name, target in scripts.items():
+        assert f"- {name} -> {target}" in text
+
+
+def test_claude_voice_openclaw_and_docker_truth_matches_current_contract() -> None:
+    text = _claude()
+    assert "The source CLI defaults to Hold-to-Talk/manual activation" in text
+    assert "`--mode wake-word` is explicitly selected" in text
+    assert "both OpenClaw flags default to `False`" in text
+    assert "OpenClaw is experimental/off by default" in text
+    assert "valid HTTP(S) gateway URL plus `OPENCLAW_GATEWAY_TOKEN`" in text
+    assert "`/healthz` may establish reachability only" in text
+    assert "connection/auth/429/5xx failures fall back locally with a structured warning" in text
+    assert "A 403 remains a hard policy denial" in text
+    assert "Docker is developer/operator-only" in text
+    assert "python -m rex doctor --healthcheck" in text
+
+
+def test_claude_install_and_primary_gui_truth() -> None:
+    text = _claude()
+    assert "Developer/operator source install: `pip install .`" in text
+    assert "End-user install path: packaged Windows Electron installer" in text
+    assert "React + Electron under `gui/` is the primary packaged interface" in text
+    assert "`rex.gui_app` is a developer-only Flask API/dashboard" in text
+
+
+def test_claude_current_document_references_exist() -> None:
+    expected = [
+        "docs/BRANDING.md",
+        "SURFACE-CLASSIFICATION.md",
+        "docs/claude/COMMANDS_AND_ENTRYPOINTS.md",
+        "docs/claude/CONFIG_AND_SECURITY.md",
+        "INTEGRATIONS_STATUS.md",
+        "docs/claude/TESTING_AND_QUALITY.md",
+        "CONTRIBUTING.md",
+        "archived/ARCHIVED.md",
+        "docs/voice_pipeline.md",
+        "docs/testing/SKIPPED-TESTS-INVENTORY.md",
+        "INSTALL.md",
+        "README.md",
+        "docs/mobile/MOBILE_API_SETUP_WINDOWS.md",
+        "docs/planning/source-of-truth/REX_Unified_Build_Spec_UPDATED.md",
+        "docs/planning/source-of-truth/REX_ACTIVE_CHECKLIST.md",
+        "docs/planning/TEAM_LEAD_OPERATING_RULES.md",
+        "docs/mobile/DEVICE_PAIRING.md",
+        "docs/mobile/STRONG_AUTH.md",
+    ]
+    text = _claude()
+    for path in expected:
+        assert path in text
+        assert (ROOT / path).exists(), path


### PR DESCRIPTION
Implements US-055 as a live `CLAUDE.md` truth contract after US-054 reconciled the underlying prose.

Changes:
- add `tests/test_claude_truth.py`
- verify the exact 27 root Python files against the live filesystem
- verify all six console scripts against `pyproject.toml`
- verify source Hold-to-Talk default / beta wake opt-in
- verify OpenClaw experimental/default-off, URL+token, health-evidence, structured fallback, and 403 policy-denial truth
- verify developer-only Docker healthcheck tier
- verify packaged-vs-source install and primary Electron GUI truth
- verify current CLAUDE documentation references exist
- update production-readiness local evidence while leaving the GitHub gate open

Local verification:
- CLAUDE + cross-doc audit contracts: 10 passed
- Ruff + Black: pass
- skip inventory: 127/127 current
- git diff --check: pass

This PR is stacked on #367 -> #366 -> #365 -> #364 -> #363 -> #362. Merge only after dependencies land and the branch is rebased onto the resulting master.