### PR TITLE
fix(time): use aware UTC timestamps

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1911,7 +1911,7 @@ grep -nE "Active root-level|Entry points|OpenClaw|Docker|wake word" CLAUDE.md
 **Acceptance Criteria:**
 - [x] `grep -rn "datetime.utcnow" rex/` returns no results.
 - [x] Tests assert the timestamps are timezone-aware (`tzinfo is not None`).
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1909,8 +1909,8 @@ grep -nE "Active root-level|Entry points|OpenClaw|Docker|wake word" CLAUDE.md
 - Any other call sites discovered by grep
 
 **Acceptance Criteria:**
-- [ ] `grep -rn "datetime.utcnow" rex/` returns no results.
-- [ ] Tests assert the timestamps are timezone-aware (`tzinfo is not None`).
+- [x] `grep -rn "datetime.utcnow" rex/` returns no results.
+- [x] Tests assert the timestamps are timezone-aware (`tzinfo is not None`).
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1573,3 +1573,8 @@ Local evidence so far:
 - Final assistant/history regression set: 116 passed.
 - `rg datetime.utcnow rex` returns no matches. Ruff/Black pass; mypy on `rex/assistant.py` reports 0 issues; skip inventory current; `git diff --check` pass.
 - Relevant GitHub checks remain pending the story PR.
+
+2026-08-09 - US-056 GitHub implementation gate (PR #369)
+- Final master-based implementation head: `f3835b096eddc202b24b61ee0968429c04e5a190`.
+- All 18 reported checks passed on that exact head. Python 3.11 Tests & Coverage passed in 9m20s and Installed Windows Electron artifact passed in 11m57s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, raw-API guard, and commitlint were green.
+- Final local verification found no `datetime.utcnow()` under `rex/`; 50/50 assistant/timestamp tests plus Ruff, Black, mypy, pre-commit, and diff hygiene passed after the final rebase.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1561,3 +1561,15 @@ Verification:
 - Final master-based implementation head: `be3c8e0d2d3140b8d5ee981b905ad4aa07a3bb37`.
 - All 17 reported checks passed on that exact head. Python 3.11 Tests & Coverage passed in 10m04s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, and commitlint were green.
 - Local CLAUDE/cross-document/status verification remained 19/19 green after the final rebase, with Ruff, Black, pre-commit, and diff hygiene passing.
+
+=== 2026-08-08 - US-056 timezone-aware assistant UTC timestamps ===
+
+Implementation:
+- Replaced both remaining `datetime.utcnow()` calls in `rex/assistant.py` with timezone-aware `datetime.now(UTC)`. The repo's Ruff UP017 rule requires the Python 3.11 `UTC` alias rather than spelling `timezone.utc`; semantics are equivalent.
+- Added `tests/test_assistant_utc_timestamps.py`, including a behavioral capture of the timestamp passed into persisted history and a source guard against reintroducing `datetime.utcnow()` in Assistant.
+
+Local evidence so far:
+- TDD red phase: both tests failed before implementation because persisted timestamps were naive and source still contained `utcnow()`.
+- Final assistant/history regression set: 116 passed.
+- `rg datetime.utcnow rex` returns no matches. Ruff/Black pass; mypy on `rex/assistant.py` reports 0 issues; skip inventory current; `git diff --check` pass.
+- Relevant GitHub checks remain pending the story PR.

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -8,7 +8,7 @@ import re
 import threading
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -590,7 +590,7 @@ class Assistant:
         # Never write history, transcripts, or in-memory windows under an
         # unvalidated key (issue #303).
         uid = validate_user_id(uid)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         history_store = getattr(self, "_history_store", None)
         if history_store is not None:
             try:
@@ -1072,7 +1072,7 @@ class Assistant:
             self._transcripts_dir.mkdir(parents=True, exist_ok=True)
             user_dir = self._transcripts_dir / uid
             user_dir.mkdir(parents=True, exist_ok=True)
-            timestamp = datetime.utcnow()
+            timestamp = datetime.now(UTC)
             file_path = user_dir / f"{timestamp:%Y-%m-%d}.txt"
             with file_path.open("a", encoding="utf-8") as handle:
                 handle.write(f"{timestamp:%H:%M:%S} user: {transcript.strip()}\n")

--- a/tests/test_assistant_utc_timestamps.py
+++ b/tests/test_assistant_utc_timestamps.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+from rex.assistant import Assistant
+
+
+class CapturingHistoryStore:
+    def __init__(self) -> None:
+        self.timestamps = []
+
+    def save_turn(self, user_id, role, content, timestamp) -> None:
+        self.timestamps.append(timestamp)
+
+
+def test_record_completion_persists_timezone_aware_utc_timestamp() -> None:
+    assistant = Assistant.__new__(Assistant)
+    assistant._user_id = "james"
+    assistant._history_store = CapturingHistoryStore()
+    assistant._histories = {"james": []}
+    assistant._history_limit = 10
+    assistant._log_turn = lambda *args, **kwargs: None
+
+    Assistant._record_completion(assistant, "hello", "hi", user_id="james")
+
+    assert len(assistant._history_store.timestamps) == 2
+    for timestamp in assistant._history_store.timestamps:
+        assert timestamp.tzinfo is not None
+        assert timestamp.utcoffset() == timedelta(0)
+
+
+def test_assistant_source_has_no_naive_utcnow_calls() -> None:
+    source = Path("rex/assistant.py").read_text(encoding="utf-8")
+    assert "datetime.utcnow(" not in source


### PR DESCRIPTION
Implements US-056 timezone-aware UTC cleanup.

Changes:
- replace both remaining `datetime.utcnow()` calls in `rex/assistant.py` with timezone-aware `datetime.now(UTC)` (Ruff UP017 requires the Python 3.11 UTC alias)
- add behavioral coverage proving persisted completion timestamps are timezone-aware UTC
- add a source guard against reintroducing `datetime.utcnow()` in Assistant
- update production-readiness local evidence while leaving the GitHub gate open

Local verification:
- assistant/history regression set: 116 passed
- no `datetime.utcnow()` remains under `rex/`
- Ruff + Black: pass
- mypy rex/assistant.py: 0 issues
- skip inventory: current
- git diff --check: pass

This PR is stacked on #368 -> #367 -> #366 -> #365 -> #364 -> #363 -> #362. Merge only after dependencies land and the branch is rebased onto the resulting master.