### PR TITLE
fix(asyncio): modernize loop access

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1933,8 +1933,8 @@ pytest -q
 - `rex/tts_voices.py` lines 192, 244
 
 **Acceptance Criteria:**
-- [ ] `grep -rn "asyncio.get_event_loop" rex/` returns no results.
-- [ ] Tests cover the replaced call sites.
+- [x] `grep -rn "asyncio.get_event_loop" rex/` returns no results.
+- [x] Tests cover the replaced call sites.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1935,7 +1935,7 @@ pytest -q
 **Acceptance Criteria:**
 - [x] `grep -rn "asyncio.get_event_loop" rex/` returns no results.
 - [x] Tests cover the replaced call sites.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:**
 ```bash

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1578,3 +1578,16 @@ Local evidence so far:
 - Final master-based implementation head: `f3835b096eddc202b24b61ee0968429c04e5a190`.
 - All 18 reported checks passed on that exact head. Python 3.11 Tests & Coverage passed in 9m20s and Installed Windows Electron artifact passed in 11m57s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, raw-API guard, and commitlint were green.
 - Final local verification found no `datetime.utcnow()` under `rex/`; 50/50 assistant/timestamp tests plus Ruff, Black, mypy, pre-commit, and diff hygiene passed after the final rebase.
+
+=== 2026-08-08 - US-057 asyncio event-loop modernization ===
+
+Implementation:
+- Replaced async-context `asyncio.get_event_loop()` calls in geolocation and XTTS/pyttsx3 synthesis with `asyncio.get_running_loop()`.
+- Replaced the broken weather sync/async fallback in `rex/openclaw/tool_executor.py`. If the synchronous tool is called while no loop is running, it uses `asyncio.run()` directly; if a loop is already running in the caller thread, one worker thread owns a separate `asyncio.run()` lifecycle. This avoids the previous impossible `run_until_complete()` call on an already-running loop and prevents leaked/unawaited coroutines.
+- Added `tests/test_asyncio_loop_cleanup.py` with a repo source guard and an actual weather invocation from inside a running event loop.
+
+Local evidence so far:
+- TDD red phase: both new tests failed; the weather case also emitted an unawaited-coroutine warning under the old fallback.
+- Geolocation/TTS/tool-router/time-weather/OpenClaw-weather regression set: 84 passed.
+- No `asyncio.get_event_loop()` calls remain under `rex/`. Ruff/Black pass; mypy reports 0 issues in the 3 changed source files; skip inventory 127/127 current; `git diff --check` pass.
+- Relevant GitHub checks remain pending the story PR.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1591,3 +1591,8 @@ Local evidence so far:
 - Geolocation/TTS/tool-router/time-weather/OpenClaw-weather regression set: 84 passed.
 - No `asyncio.get_event_loop()` calls remain under `rex/`. Ruff/Black pass; mypy reports 0 issues in the 3 changed source files; skip inventory 127/127 current; `git diff --check` pass.
 - Relevant GitHub checks remain pending the story PR.
+
+2026-08-09 - US-057 GitHub implementation gate (PR #370)
+- Final master-based implementation head: `627b3201a094c8e5a56d4b0df504ebf0a472cfa8`.
+- All 18 reported checks passed on that exact head. Python 3.11 Tests & Coverage passed in 9m03s and Installed Windows Electron artifact passed in 11m54s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, raw-API guard, and commitlint were green.
+- Final local verification found no `asyncio.get_event_loop()` under `rex/`; 30/30 focused async/geolocation/TTS tests plus Ruff, Black, mypy, pre-commit, and diff hygiene passed after the final rebase.

--- a/rex/geolocation.py
+++ b/rex/geolocation.py
@@ -38,7 +38,7 @@ async def detect_location() -> dict[str, object] | None:
 
     try:
         result = await asyncio.wait_for(
-            asyncio.get_event_loop().run_in_executor(None, _fetch_location),
+            asyncio.get_running_loop().run_in_executor(None, _fetch_location),
             timeout=_TIMEOUT_SECONDS,
         )
         if result is not None:

--- a/rex/openclaw/tool_executor.py
+++ b/rex/openclaw/tool_executor.py
@@ -20,6 +20,7 @@ import os
 import time
 import uuid
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -579,13 +580,19 @@ def _execute_weather_now(args: dict[str, Any], default_context: dict[str, Any]) 
             "OPENWEATHERMAP_API_KEY is not configured", tool="weather_now", args=args
         )
 
+    def _run_weather() -> dict[str, Any]:
+        return asyncio.run(get_weather(location, api_key))
+
     try:
-        coro = get_weather(location, api_key)
         try:
-            weather = asyncio.run(coro)
+            asyncio.get_running_loop()
         except RuntimeError:
-            loop = asyncio.get_event_loop()
-            weather = loop.run_until_complete(coro)
+            weather = _run_weather()
+        else:
+            # This executor is synchronous API code. A nested event loop cannot
+            # run in the same thread, so isolate the coroutine in one worker.
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                weather = pool.submit(_run_weather).result()
     except Exception as exc:
         return _error_result(str(exc), tool="weather_now", args=args)
 

--- a/rex/tts_voices.py
+++ b/rex/tts_voices.py
@@ -195,7 +195,7 @@ async def _synthesize_xtts(voice_id: str, text: str) -> bytes:
             if os.path.exists(tmpfile):
                 os.unlink(tmpfile)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, _run)
 
 
@@ -248,7 +248,7 @@ async def _synthesize_pyttsx3(voice_id: str, text: str) -> bytes:
             if os.path.exists(tmpfile):
                 os.unlink(tmpfile)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, _run)
 
 

--- a/tests/test_asyncio_loop_cleanup.py
+++ b/tests/test_asyncio_loop_cleanup.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from rex.openclaw import tool_executor
+
+
+def test_rex_source_has_no_deprecated_get_event_loop_calls() -> None:
+    offenders = []
+    for path in Path("rex").rglob("*.py"):
+        if "asyncio.get_event_loop(" in path.read_text(encoding="utf-8"):
+            offenders.append(str(path))
+    assert offenders == []
+
+
+def test_sync_weather_executor_works_when_called_inside_running_loop(monkeypatch) -> None:
+    async def fake_get_weather(location: str, api_key: str):
+        await asyncio.sleep(0)
+        return {"city": location, "temp_f": 75.0, "description": "clear"}
+
+    monkeypatch.setattr("rex.weather.get_weather", fake_get_weather)
+    monkeypatch.setenv("OPENWEATHERMAP_API_KEY", "test-key")
+    monkeypatch.setattr("rex.credentials.legacy_plaintext_fallback_enabled", lambda: True)
+
+    async def invoke():
+        return tool_executor._execute_weather_now({"location": "Dallas"}, {})
+
+    result = asyncio.run(invoke())
+    assert result["city"] == "Dallas"
+    assert result["temp_f"] == 75.0
+    assert "error" not in result


### PR DESCRIPTION
Implements US-057 asyncio event-loop modernization.

Changes:
- replace async-context `asyncio.get_event_loop()` calls in geolocation and XTTS/pyttsx3 synthesis with `get_running_loop()`
- replace the broken weather sync/async fallback: direct `asyncio.run()` when no loop exists; isolated worker-thread loop when the synchronous tool is invoked inside an already-running event loop
- add source guard against deprecated `get_event_loop()` under `rex/`
- add behavioral coverage for weather execution inside a running event loop
- update production-readiness local evidence while leaving the GitHub gate open

Local verification:
- geolocation/TTS/tool-router/time-weather/OpenClaw-weather regression set: 84 passed
- no `asyncio.get_event_loop()` remains under `rex/`
- Ruff + Black: pass
- mypy changed source files: 0 issues
- skip inventory: 127/127 current
- git diff --check: pass

This PR is stacked on #369 -> #368 -> #367 -> #366 -> #365 -> #364 -> #363 -> #362. Merge only after dependencies land and the branch is rebased onto the resulting master.