### PR TITLE
ci(quality): block deprecated Python APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: 🗑️ Check no generated artifacts are committed
         run: python scripts/check_no_generated_artifacts.py
 
+      - name: Check deprecated Python APIs
+        run: python scripts/check_deprecated_apis.py
+
       - name: Validate skipped-test inventory
         run: python scripts/check_skip_inventory.py
 

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1961,7 +1961,7 @@ pytest -q
 **Acceptance Criteria:**
 - [x] Ruff rule or check script fails on `datetime.utcnow()` and `asyncio.get_event_loop()` outside `archived/`.
 - [x] CI runs the check.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -1959,8 +1959,8 @@ pytest -q
 - `.github/workflows/ci.yml`
 
 **Acceptance Criteria:**
-- [ ] Ruff rule or check script fails on `datetime.utcnow()` and `asyncio.get_event_loop()` outside `archived/`.
-- [ ] CI runs the check.
+- [x] Ruff rule or check script fails on `datetime.utcnow()` and `asyncio.get_event_loop()` outside `archived/`.
+- [x] CI runs the check.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1610,3 +1610,8 @@ Local evidence so far:
 - Final deprecation guard + US-056/057 source-behavior guards: 9/9 passed.
 - `python scripts/check_deprecated_apis.py` passes on tracked current Python. Ruff/Black pass; compileall pass; skip inventory 127/127 current; `git diff --check` pass.
 - Relevant GitHub checks remain pending the story PR.
+
+2026-08-09 - US-058 GitHub implementation gate (PR #371)
+- Final master-based implementation head: `0d65f97232ff8caa69f067389e42bd032aa5abe3`.
+- All 17 reported checks passed on that exact head. Python 3.11 Tests & Coverage passed in 10m05s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, raw-API guard, and commitlint were green. This CI-only story did not trigger the installed Windows Electron artifact workflow.
+- Final local verification: 9/9 deprecation/source-behavior guard tests passed; `python scripts/check_deprecated_apis.py`, compileall, CI wiring, Ruff, Black, pre-commit/secrets, and diff hygiene passed after the final rebase.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1596,3 +1596,17 @@ Local evidence so far:
 - Final master-based implementation head: `627b3201a094c8e5a56d4b0df504ebf0a472cfa8`.
 - All 18 reported checks passed on that exact head. Python 3.11 Tests & Coverage passed in 9m03s and Installed Windows Electron artifact passed in 11m54s; CodeFactor, GitGuardian, lint/format, mypy, GUI Vitest/typecheck/build/ESLint, dependency/security scans, pre-commit, wheel smoke, raw-API guard, and commitlint were green.
 - Final local verification found no `asyncio.get_event_loop()` under `rex/`; 30/30 focused async/geolocation/TTS tests plus Ruff, Black, mypy, pre-commit, and diff hygiene passed after the final rebase.
+
+=== 2026-08-08 - US-058 deprecated Python API CI guard ===
+
+Implementation:
+- Added dependency-free `scripts/check_deprecated_apis.py`, using the stdlib AST over tracked Python files so comments/strings do not create false positives and historical `archived/` code is excluded.
+- The guard fails on live `datetime.utcnow()` or `asyncio.get_event_loop()` calls and fails closed on parse/git errors. UTF-8 BOM source files are supported via `utf-8-sig`.
+- Wired the guard into the lightweight CI lint job.
+- Added tests for both banned calls, string/comment false-positive resistance, archived exclusion, BOM handling, and CI wiring.
+
+Local evidence so far:
+- TDD red phase: 4/4 initial tests failed because the guard/CI step did not exist. A real repo scan then exposed a BOM parse edge case, added as a fifth regression test before the scanner was made BOM-aware.
+- Final deprecation guard + US-056/057 source-behavior guards: 9/9 passed.
+- `python scripts/check_deprecated_apis.py` passes on tracked current Python. Ruff/Black pass; compileall pass; skip inventory 127/127 current; `git diff --check` pass.
+- Relevant GitHub checks remain pending the story PR.

--- a/scripts/check_deprecated_apis.py
+++ b/scripts/check_deprecated_apis.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Fail CI if deprecated datetime/asyncio call patterns return.
+
+The guard parses tracked Python source with the stdlib AST so references inside
+comments, docs, and string-based regression tests do not create false positives.
+Historical code under archived/ is intentionally excluded.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    path: Path
+    line: int
+    column: int
+    api: str
+    replacement: str
+
+
+_BANNED = {
+    "datetime.utcnow": "use timezone-aware datetime.now(UTC)",
+    "asyncio.get_event_loop": "use get_running_loop() in async code or an explicit loop lifecycle",
+}
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def scan_file(path: Path) -> list[Finding]:
+    source = path.read_text(encoding="utf-8-sig")
+    tree = ast.parse(source, filename=str(path))
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        api = _call_name(node.func)
+        replacement = _BANNED.get(api)
+        if replacement is None:
+            continue
+        findings.append(
+            Finding(
+                path=path,
+                line=node.lineno,
+                column=node.col_offset + 1,
+                api=api,
+                replacement=replacement,
+            )
+        )
+    return sorted(findings)
+
+
+def _is_archived(path: Path, root: Path) -> bool:
+    try:
+        relative = path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return bool(relative.parts and relative.parts[0].lower() == "archived")
+
+
+def scan_paths(paths: Iterable[Path], *, root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in paths:
+        if _is_archived(path, root):
+            continue
+        findings.extend(scan_file(path))
+    return sorted(findings)
+
+
+def tracked_python_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "*.py"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    return [root / item.decode("utf-8") for item in result.stdout.split(b"\0") if item]
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    try:
+        findings = scan_paths(tracked_python_files(root), root=root)
+    except (OSError, SyntaxError, subprocess.CalledProcessError) as exc:
+        print(f"Deprecated-API guard failed closed: {exc}", file=sys.stderr)
+        return 2
+
+    if findings:
+        print("Deprecated API calls are not allowed outside archived/:", file=sys.stderr)
+        for finding in findings:
+            try:
+                display = finding.path.relative_to(root)
+            except ValueError:
+                display = finding.path
+            print(
+                f"  {display}:{finding.line}:{finding.column}: {finding.api}() - {finding.replacement}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(
+        "OK: no banned datetime.utcnow() or asyncio.get_event_loop() calls in tracked current Python."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deprecated_api_guard.py
+++ b/tests/test_deprecated_api_guard.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_deprecated_api_guard_detects_banned_calls(tmp_path: Path) -> None:
+    from scripts.check_deprecated_apis import scan_file
+
+    source = tmp_path / "bad.py"
+    source.write_text(
+        "import asyncio\nfrom datetime import datetime\n"
+        "datetime.utcnow()\nasyncio.get_event_loop()\n",
+        encoding="utf-8",
+    )
+    findings = scan_file(source)
+    assert [finding.api for finding in findings] == [
+        "datetime.utcnow",
+        "asyncio.get_event_loop",
+    ]
+
+
+def test_deprecated_api_guard_ignores_strings_and_comments(tmp_path: Path) -> None:
+    from scripts.check_deprecated_apis import scan_file
+
+    source = tmp_path / "good.py"
+    source.write_text(
+        "# datetime.utcnow() and asyncio.get_event_loop() are banned\n"
+        'TEXT = "datetime.utcnow() asyncio.get_event_loop()"\n',
+        encoding="utf-8",
+    )
+    assert scan_file(source) == []
+
+
+def test_deprecated_api_guard_excludes_archived_paths(tmp_path: Path) -> None:
+    from scripts.check_deprecated_apis import scan_paths
+
+    current = tmp_path / "rex" / "current.py"
+    archived = tmp_path / "archived" / "old.py"
+    current.parent.mkdir(parents=True)
+    archived.parent.mkdir(parents=True)
+    current.write_text("from datetime import datetime\ndatetime.utcnow()\n", encoding="utf-8")
+    archived.write_text("import asyncio\nasyncio.get_event_loop()\n", encoding="utf-8")
+
+    findings = scan_paths([current, archived], root=tmp_path)
+    assert len(findings) == 1
+    assert findings[0].path == current
+
+
+def test_deprecated_api_guard_handles_utf8_bom(tmp_path: Path) -> None:
+    from scripts.check_deprecated_apis import scan_file
+
+    source = tmp_path / "bom.py"
+    source.write_bytes(b"\xef\xbb\xbfimport asyncio\nasyncio.get_event_loop()\n")
+    findings = scan_file(source)
+    assert [finding.api for finding in findings] == ["asyncio.get_event_loop"]
+
+
+def test_ci_runs_deprecated_api_guard() -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "python scripts/check_deprecated_apis.py" in workflow


### PR DESCRIPTION
Implements US-058 CI guard against reintroducing deprecated Python APIs.

Changes:
- add dependency-free AST scanner over tracked current Python files
- fail on live `datetime.utcnow()` and `asyncio.get_event_loop()` calls
- ignore historical `archived/` code and avoid string/comment false positives
- support UTF-8 BOM source files
- fail closed on parse/git errors
- run the guard in the lightweight CI lint job
- add tests for banned calls, false-positive resistance, archived exclusion, BOM handling, and CI wiring
- update production-readiness local evidence while leaving the GitHub gate open

Local verification:
- deprecation + US-056/057 guards: 9 passed
- `python scripts/check_deprecated_apis.py`: pass
- Ruff + Black: pass
- compileall: pass
- skip inventory: 127/127 current
- git diff --check: pass

This PR is stacked on #370 -> #369 -> #368 -> #367 -> #366 -> #365 -> #364 -> #363 -> #362. Merge only after dependencies land and the branch is rebased onto the resulting master.