### PR TITLE
perf(latency): add RexBench instrumentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,8 @@ Bridge compatibility wrappers (17) — exec canonical `bridge/<name>.py` in thei
 - rex/commands/ — CLI command modules, one per domain (US-REM-027); `rex/cli.py` keeps parser registration, `main()`, and re-exports, and `rex.cli.<name>` remains the import/monkeypatch surface for handlers and service getters
 - rex/voice/ — voice pipeline modules, one per concern (US-REM-028); `rex/voice_loop.py` is the facade and `rex.voice_loop.<name>` remains the import/monkeypatch surface (settings, lazy importers, sa/sd, pipeline classes)
 - rex/tools/execution.py — canonical typed tool lifecycle; all registered dispatch must pass availability, argument, identity, permission, risk, confirmation, execution, normalization, independent verification, truthful response, and redacted audit stages. Read-only success is `completed`; mutation success is `verified` only.
-- gui/src/main/ — Electron main-process modules, one per concern (US-REM-029); `index.ts` is a thin entrypoint (app lifecycle wiring only), `ipc.ts` aggregates handler registration, IPC handlers live in `gui/src/main/handlers/`, integration credential persistence/rollback lives in `integrationSettingsStorage.ts`, and settings/integration/HA logic lives in `configStore.ts`, `aiSettings.ts`, `voiceSettings.ts`, `settingsDefaults.ts`, `settingsMirror.ts`, `homeAssistant.ts`, `integrationStatus.ts`, `integrationInventory.ts`, `window.ts`
+- `rex/latency.py` / `rex/rexbench.py` - privacy-safe request timing and p50/p95 aggregation. Timing telemetry must never include prompts, transcripts, user IDs, memory contents, credentials, or tool payloads; see `docs/performance.md`.
+- gui/src/main/ - Electron main-process modules, one per concern (US-REM-029); `index.ts` is a thin entrypoint (app lifecycle wiring only), `ipc.ts` aggregates handler registration, IPC handlers live in `gui/src/main/handlers/`, integration credential persistence/rollback lives in `integrationSettingsStorage.ts`, and settings/integration/HA logic lives in `configStore.ts`, `aiSettings.ts`, `voiceSettings.ts`, `settingsDefaults.ts`, `settingsMirror.ts`, `homeAssistant.ts`, `integrationStatus.ts`, `integrationInventory.ts`, `window.ts`
 - `gui/src/pages/settings/integrations/` owns the Settings > Integrations controller and focused UI components; keep OpenClaw token handling renderer-blind and route all secret persistence through the main-process vault helpers.
 - `gui/src/types/settingsRouting.ts` is the shared parser for Settings deep links such as `#/settings?section=integrations`; invalid or missing sections fail safely to General.
 - Installed Electron artifact smoke may override Electron `userData` only when `ASKREX_ARTIFACT_SMOKE=1` and `ASKREX_ARTIFACT_SMOKE_RUNTIME_ROOT` is set; the PowerShell harness must point Python `ASKREX_RUNTIME_DIR` and Electron userData at the same isolated temp runtime root.
@@ -375,6 +376,14 @@ Release health gate:
 
 python -m rex doctor --release-gate
 python scripts/security_audit.py --release-gate
+
+Deterministic latency baseline (instrumentation/framework evidence only):
+
+```powershell
+python scripts/rexbench.py --profile baseline --iterations 20 --output docs/performance/rexbench-baseline.json
+```
+
+`deterministic_mock` RexBench results never prove live provider, model, network, audio, or hardware latency is within budget. Use `docs/performance.md` and the final live RexBench release gate for production claims.
 
 Electron identity (required before launch):
 

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2620,27 +2620,28 @@ cd gui && npm run typecheck && npm run build
 **Implementation notes:** Add structured timings before optimization. Define target budgets for typed chat, hold-to-talk, wake-word response, STT, LLM token-to-first, TTS start, and playback.
 
 **Acceptance Criteria:**
-- [ ] Chat response path records IPC, routing, LLM, tool, and total timings.
-- [ ] Voice path records wake, capture, STT, LLM, TTS, playback, and total timings.
-- [ ] Logs include provider/model/settings identifiers needed for diagnosis without leaking secrets.
-- [ ] Target budgets are documented.
-- [ ] A profiling command or harness summarizes timings.
-- [ ] Optimization stories are opened or blockers documented for any stage over budget.
-- [ ] Tests cover timing event emission with mocked stages.
+- [x] Chat response path records IPC, routing, LLM, tool, and total timings.
+- [x] Voice path records wake, capture, STT, LLM, TTS, playback, and total timings.
+- [x] Logs include provider/model/settings identifiers needed for diagnosis without leaking secrets.
+- [x] Target budgets are documented.
+- [x] A profiling command or harness summarizes timings.
+- [x] Optimization stories are opened or blockers documented for any stage over budget.
+- [x] Tests cover timing event emission with mocked stages.
 - [ ] All relevant GitHub checks pass.
 
-- [ ] A checked-in RexBench baseline reports cold and warm p50/p95 for typed chat, voice, read-only tool, mutating tool, and unavailable-capability request classes.
-- [ ] Baseline stages separately report routing, first token, tool execution, STT, first audio, completion, and total latency where applicable.
-- [ ] Deterministic fixtures/mocks are the default benchmark evidence; live-provider and physical-hardware evidence is stored/labeled separately and never conflated with mock/local measurements.
-- [ ] Benchmark output contains no prompts, transcripts, memory contents, credentials, or user IDs.
+- [x] A checked-in RexBench baseline reports cold and warm p50/p95 for typed chat, voice, read-only tool, mutating tool, and unavailable-capability request classes.
+- [x] Baseline stages separately report routing, first token, tool execution, STT, first audio, completion, and total latency where applicable.
+- [x] Deterministic fixtures/mocks are the default benchmark evidence; live-provider and physical-hardware evidence is stored/labeled separately and never conflated with mock/local measurements.
+- [x] Benchmark output contains no prompts, transcripts, memory contents, credentials, or user IDs.
 
 **Validation commands:**
 ```bash
-pytest -q tests/test_voice_latency.py tests/test_tool_pipeline.py
+pytest -q tests/test_assistant_latency.py tests/test_voice_latency_budget.py tests/test_voice_pipeline_logs.py tests/test_tool_pipeline.py tests/test_rexbench.py
+cd gui && npx vitest run tests/chatLatency.test.ts && npm run typecheck
+python scripts/rexbench.py --profile baseline --iterations 20 --output docs/performance/rexbench-baseline.json
 ```
 
 **Risk notes:** Do not add synchronous timing work that increases latency materially. Use monotonic clocks.
-
 ---
 
 ### US-076: Add incoherent model output validation and fail-safe handling

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1656,3 +1656,18 @@ Planning/reconciliation only; no runtime behavior changed in this entry.
 - Architecture invariants remain unchanged: Rex is local-first and remains the brain/orchestrator/verifier/permission/memory layer; OpenClaw is optional; James/Cole isolation is fail-closed; mobile keeps desktop-owned secure pairing/strong auth; SMS backend/direct route remains while primary navigation stays hidden; no new paid service is required.
 - Design and execution documents were added under `docs/superpowers/specs/` and `docs/superpowers/plans/`.
 - A Claude Code docs-only attempt was stopped after the repository's active Ralph hook caused uncontrolled iteration; all unintended child-process edits were reverted. This preserves the established cost-efficiency rule: agents are used only while they add value.
+
+2026-08-09 - US-075 chat/voice latency instrumentation and RexBench baseline
+
+Implementation:
+- Added privacy-safe monotonic `LatencyTrace` instrumentation for chat/tool dispatch and stream-first-token timing, Electron IPC/first-token timing, and voice stage evidence.
+- Added deterministic RexBench cold/warm p50/p95 coverage for typed chat, voice, read-only tool, mutating tool, and unavailable-capability classes; typed chat now measures the first user-visible streamed token instead of inferring it from non-streaming LLM duration.
+- Added performance budgets, evidence-class rules, privacy constraints, and explicit follow-on latency owners in `docs/performance.md`; refreshed the checked-in 20-iteration baseline.
+- Preserved fail-closed identity ordering while instrumenting Assistant paths and switched latency metadata to canonical nested LLM config when available, avoiding new deprecated-config warnings.
+
+Local evidence:
+- TDD red phase proved the missing `chat_stream_latency` event and missing checked-in `first_token` baseline stage before implementation; both new contracts are green.
+- Broad stream/chat/mobile/voice regression: 208 passed. Focused identity/latency regression: 57 passed. Core assistant: 48 passed with `DeprecationWarning` promoted to errors.
+- Final acceptance sweep: 64 latency/voice/tool/RexBench tests passed; Electron chat latency: 2 passed; full GUI TypeScript typecheck passed.
+- Deprecated-API guard, compileall, Ruff, Black, mypy, and `git diff --check` all passed.
+- Relevant GitHub checks remain pending the US-075 story PR; that final checkbox intentionally remains open.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,105 @@
+# AskRex Performance and RexBench
+
+## Purpose
+
+AskRex records latency before optimizing it. Timing evidence must distinguish
+framework overhead from live provider, model, network, audio, and device costs.
+A synthetic or mocked benchmark is never evidence that real user latency is fixed.
+
+US-075 establishes the baseline instrumentation used by later TurnEngine and
+release-readiness work. Final production acceptance belongs to US-118.
+
+## Privacy contract
+
+Latency telemetry may contain only:
+- trace/request timing identifiers,
+- channel or transport mode,
+- provider/model identifiers,
+- non-secret settings/mode identifiers,
+- stage durations and success/error outcome.
+
+It must not contain prompts, transcripts, memory contents, user IDs, credentials,
+tool payloads, email/message bodies, or other request content.
+
+## Timing surfaces
+
+Typed chat records two layers:
+1. Electron main-process timing: IPC/bridge total and streaming first-token time.
+2. Python Assistant timing: `generate_reply()` emits `chat_latency` for routing, LLM,
+   tool execution/resolution, completion, and total; `stream_reply()` emits
+   `chat_stream_latency` with routing, first user-visible token, LLM, completion, and total.
+
+Voice records wake acceptance, capture, STT, LLM, TTS start, playback completion,
+and total pipeline timing. Provider TTS implementations also emit provider-specific
+synthesis/playback timing where that boundary is observable. A combined TTS/playback
+scope must not be presented as separate synthesis and playback evidence.
+
+All new generic request timings use `time.perf_counter_ns()` so short Windows stages
+are not quantized by a lower-resolution wall-clock source.
+
+## Diagnostic target budgets
+
+These are product targets, not claims about the current live system:
+| Path/stage | Target |
+|---|---:|
+| Typed chat first token, warm p50 | <= 1.5 s |
+| Typed chat first token, warm p95 | <= 3.0 s |
+| Simple typed chat total, warm p95 | <= 8.0 s |
+| Read-only tool total, warm p95 | <= 5.0 s |
+| Verified mutating tool total, warm p95 | <= 7.0 s |
+| Unavailable capability response, warm p95 | <= 1.0 s |
+| Wake accepted -> capture start | <= 250 ms |
+| STT after capture completes, p95 | <= 2.0 s |
+| LLM first token for voice, warm p95 | <= 3.0 s |
+| TTS request -> playback start, warm p95 | <= 1.0 s |
+| End of utterance -> first spoken audio, warm p95 | <= 4.0 s |
+
+Playback duration scales with spoken answer length, so it is recorded but does not
+have a single fixed duration budget. Voice capture duration is user-controlled;
+only capture/endpointing overhead should be optimized independently of speech length.
+
+## RexBench baseline profile
+
+Run the deterministic baseline with:
+
+```bash
+python scripts/rexbench.py --profile baseline --iterations 20 \
+  --output docs/performance/rexbench-baseline.json
+```
+
+The baseline exercises the real current Assistant/ActionDispatcher and VoiceLoop
+orchestration while mocking external provider, model, network, audio, and hardware
+work. Typed-chat samples consume the real `Assistant.stream_reply()` latency event so
+`first_token` is measured at the first user-visible emitted chunk rather than inferred
+from non-streaming LLM duration. It reports cold/warm p50 and p95 for:
+- typed chat,
+- voice,
+- read-only tools,
+- mutating tools,
+- unavailable capabilities.
+
+Its evidence class is `deterministic_mock`. It validates instrumentation and framework
+overhead only. It must not be used to claim that live provider or physical-device
+latency meets the target budgets.
+
+## Known latency work after the baseline
+
+Manual desktop testing has observed responses taking roughly 30-60+ seconds in some
+real sessions. The deterministic baseline does not reproduce external model/audio
+costs, so that observation remains unresolved until live RexBench evidence exists.
+
+The integrated production-readiness plan already assigns the likely bottlenecks:
+- US-094 through US-097: one canonical TurnEngine for streamed and non-streamed paths.
+- US-099: managed warm local runtime/model lifetime.
+- US-100: streaming ASR and semantic endpointing.
+- US-101: safe speculative read-only prefetch.
+- US-102: clause/sentence TTS streaming.
+- US-103: barge-in through canonical cancellation.
+- US-104: progressive status events while work is still running.
+- US-105: identity-safe context caching.
+- US-110/US-111: fast/deep model routing and provider reliability evidence.
+- US-118: final live RexBench release gate.
+
+A stage that exceeds budget in live evidence is a release blocker until the owning
+story fixes it or the production-readiness tracker documents an explicit, justified
+budget change.

--- a/docs/performance/rexbench-baseline.json
+++ b/docs/performance/rexbench-baseline.json
@@ -1,0 +1,321 @@
+{
+  "privacy": "timings_and_nonsecret_runtime_identifiers_only",
+  "profile": "baseline",
+  "results": {
+    "mutating_tool": {
+      "cold": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "completion": {
+            "p50": 0.657,
+            "p95": 0.823
+          },
+          "llm": {
+            "p50": 2.458,
+            "p95": 2.703
+          },
+          "postprocess": {
+            "p50": 0.166,
+            "p95": 0.366
+          },
+          "routing": {
+            "p50": 0.157,
+            "p95": 0.195
+          },
+          "startup": {
+            "p50": 0.492,
+            "p95": 0.589
+          },
+          "tool": {
+            "p50": 2.668,
+            "p95": 2.845
+          },
+          "total": {
+            "p50": 13.531,
+            "p95": 14.58
+          }
+        }
+      },
+      "warm": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "completion": {
+            "p50": 0.72,
+            "p95": 0.925
+          },
+          "llm": {
+            "p50": 2.489,
+            "p95": 2.701
+          },
+          "postprocess": {
+            "p50": 0.175,
+            "p95": 0.333
+          },
+          "routing": {
+            "p50": 0.135,
+            "p95": 0.189
+          },
+          "tool": {
+            "p50": 2.61,
+            "p95": 2.892
+          },
+          "total": {
+            "p50": 12.796,
+            "p95": 13.989
+          }
+        }
+      }
+    },
+    "read_only_tool": {
+      "cold": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "completion": {
+            "p50": 0.692,
+            "p95": 0.783
+          },
+          "llm": {
+            "p50": 2.374,
+            "p95": 2.629
+          },
+          "postprocess": {
+            "p50": 0.157,
+            "p95": 0.351
+          },
+          "routing": {
+            "p50": 0.118,
+            "p95": 0.49
+          },
+          "startup": {
+            "p50": 0.456,
+            "p95": 0.598
+          },
+          "tool": {
+            "p50": 2.667,
+            "p95": 3.235
+          },
+          "total": {
+            "p50": 12.077,
+            "p95": 14.828
+          }
+        }
+      },
+      "warm": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "completion": {
+            "p50": 0.72,
+            "p95": 0.877
+          },
+          "llm": {
+            "p50": 2.518,
+            "p95": 2.696
+          },
+          "postprocess": {
+            "p50": 0.143,
+            "p95": 0.304
+          },
+          "routing": {
+            "p50": 0.108,
+            "p95": 0.131
+          },
+          "tool": {
+            "p50": 2.671,
+            "p95": 2.875
+          },
+          "total": {
+            "p50": 11.754,
+            "p95": 12.726
+          }
+        }
+      }
+    },
+    "typed_chat": {
+      "cold": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "completion": {
+            "p50": 1.075,
+            "p95": 1.228
+          },
+          "first_token": {
+            "p50": 5.913,
+            "p95": 7.565
+          },
+          "llm": {
+            "p50": 2.813,
+            "p95": 3.367
+          },
+          "routing": {
+            "p50": 0.021,
+            "p95": 0.03
+          },
+          "startup": {
+            "p50": 0.559,
+            "p95": 0.685
+          },
+          "total": {
+            "p50": 7.643,
+            "p95": 9.201
+          }
+        }
+      },
+      "warm": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "completion": {
+            "p50": 0.962,
+            "p95": 1.229
+          },
+          "first_token": {
+            "p50": 5.886,
+            "p95": 6.934
+          },
+          "llm": {
+            "p50": 2.858,
+            "p95": 3.354
+          },
+          "routing": {
+            "p50": 0.025,
+            "p95": 0.035
+          },
+          "total": {
+            "p50": 6.802,
+            "p95": 8.214
+          }
+        }
+      }
+    },
+    "unavailable_capability": {
+      "cold": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "completion": {
+            "p50": 0.883,
+            "p95": 0.961
+          },
+          "llm": {
+            "p50": 2.694,
+            "p95": 2.889
+          },
+          "postprocess": {
+            "p50": 0.283,
+            "p95": 0.407
+          },
+          "routing": {
+            "p50": 0.173,
+            "p95": 0.221
+          },
+          "startup": {
+            "p50": 0.567,
+            "p95": 0.66
+          },
+          "total": {
+            "p50": 8.364,
+            "p95": 9.05
+          }
+        }
+      },
+      "warm": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "completion": {
+            "p50": 0.863,
+            "p95": 0.974
+          },
+          "llm": {
+            "p50": 2.736,
+            "p95": 2.904
+          },
+          "postprocess": {
+            "p50": 0.266,
+            "p95": 0.392
+          },
+          "routing": {
+            "p50": 0.186,
+            "p95": 0.232
+          },
+          "total": {
+            "p50": 7.896,
+            "p95": 8.714
+          }
+        }
+      }
+    },
+    "voice": {
+      "cold": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "capture": {
+            "p50": 1.102,
+            "p95": 1.449
+          },
+          "completion": {
+            "p50": 28.84,
+            "p95": 29.517
+          },
+          "first_audio": {
+            "p50": 13.548,
+            "p95": 14.072
+          },
+          "llm": {
+            "p50": 0.116,
+            "p95": 0.195
+          },
+          "startup": {
+            "p50": 0.018,
+            "p95": 0.035
+          },
+          "stt": {
+            "p50": 11.861,
+            "p95": 12.597
+          },
+          "total": {
+            "p50": 28.857,
+            "p95": 29.531
+          }
+        }
+      },
+      "warm": {
+        "evidence_class": "deterministic_mock",
+        "sample_count": 20,
+        "stages_ms": {
+          "capture": {
+            "p50": 1.305,
+            "p95": 1.493
+          },
+          "completion": {
+            "p50": 28.703,
+            "p95": 29.433
+          },
+          "first_audio": {
+            "p50": 13.466,
+            "p95": 13.919
+          },
+          "llm": {
+            "p50": 0.131,
+            "p95": 0.205
+          },
+          "stt": {
+            "p50": 11.616,
+            "p95": 12.173
+          },
+          "total": {
+            "p50": 28.703,
+            "p95": 29.433
+          }
+        }
+      }
+    }
+  },
+  "schema_version": 1
+}

--- a/docs/voice_pipeline.md
+++ b/docs/voice_pipeline.md
@@ -43,7 +43,7 @@ A completion event is emitted only when that stage completes successfully. Exist
 non-hardware callbacks. The budgets below are regression guards for AskRex orchestration and
 stage hand-offs; they are not end-user hardware, network, or model-provider SLAs. Real Whisper,
 LLM, TTS, audio-driver, and speaker latency is tracked separately by runtime telemetry and the
-performance baseline.
+[performance baseline](performance.md).
 
 The first release uses intentionally wide margins so shared CI runners do not create false
 failures while still catching accidental blocking calls, sleeps, or serial regressions.

--- a/gui/src/main/chatLatency.ts
+++ b/gui/src/main/chatLatency.ts
@@ -1,0 +1,15 @@
+export type ChatLatencyOutcome = 'ok' | 'error' | 'cancelled'
+
+export function logChatLatency(
+  event: string,
+  mode: 'single' | 'stream',
+  durationMs: number,
+  outcome: ChatLatencyOutcome
+): void {
+  console.info('[latency]', {
+    event,
+    mode,
+    durationMs: Number(durationMs.toFixed(3)),
+    outcome
+  })
+}

--- a/gui/src/main/handlers/chat.ts
+++ b/gui/src/main/handlers/chat.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import { spawn, ChildProcess } from 'child_process'
 import { bridgeSpawnOptions, resolveBridgePath, resolvePythonCommand } from '../bridgeResolver'
+import { logChatLatency } from '../chatLatency'
 import { privateSessionPayload, type ElectronSessionIdentity } from '../sessionIdentity'
 
 /**
@@ -176,7 +177,15 @@ async function transcribeAudio(audioBase64: string): Promise<string> {
 
 export function registerChatHandlers(session: ElectronSessionIdentity): void {
   ipcMain.handle('rex:sendChat', async (_event, message: string): Promise<string> => {
-    return callRexBackend(message, session)
+    const startedAt = performance.now()
+    try {
+      const reply = await callRexBackend(message, session)
+      logChatLatency('chat_ipc_complete', 'single', performance.now() - startedAt, 'ok')
+      return reply
+    } catch (error) {
+      logChatLatency('chat_ipc_complete', 'single', performance.now() - startedAt, 'error')
+      throw error
+    }
   })
 
   ipcMain.handle('rex:startChatStream', async (event, { message, streamId }: { message: string; streamId: string }): Promise<{ ok: boolean }> => {
@@ -188,25 +197,37 @@ export function registerChatHandlers(session: ElectronSessionIdentity): void {
     })
     chatStreamProcesses.set(streamId, py)
 
+    const streamStartedAt = performance.now()
+    let firstTokenLogged = false
     let sentFinal = false
 
     function sendToken(token: string): void {
+      if (!firstTokenLogged) {
+        firstTokenLogged = true
+        logChatLatency('chat_first_token', 'stream', performance.now() - streamStartedAt, 'ok')
+      }
       if (!event.sender.isDestroyed()) {
         event.sender.send('rex:chatToken', { streamId, token })
       }
     }
 
     function sendDone(): void {
-      if (!sentFinal && !event.sender.isDestroyed()) {
+      if (!sentFinal) {
         sentFinal = true
-        event.sender.send('rex:chatDone', { streamId })
+        logChatLatency('chat_ipc_complete', 'stream', performance.now() - streamStartedAt, 'ok')
+        if (!event.sender.isDestroyed()) {
+          event.sender.send('rex:chatDone', { streamId })
+        }
       }
     }
 
     function sendError(error: string): void {
-      if (!sentFinal && !event.sender.isDestroyed()) {
+      if (!sentFinal) {
         sentFinal = true
-        event.sender.send('rex:chatError', { streamId, error })
+        logChatLatency('chat_ipc_complete', 'stream', performance.now() - streamStartedAt, 'error')
+        if (!event.sender.isDestroyed()) {
+          event.sender.send('rex:chatError', { streamId, error })
+        }
       }
     }
 

--- a/gui/tests/chatLatency.test.ts
+++ b/gui/tests/chatLatency.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { logChatLatency } from '../src/main/chatLatency'
+
+describe('chat latency logging', () => {
+  it('logs only safe transport timing metadata', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    try {
+      logChatLatency('chat_ipc_complete', 'stream', 12.345, 'ok')
+      expect(spy).toHaveBeenCalledTimes(1)
+      const [, fields] = spy.mock.calls[0]
+      expect(fields).toEqual({
+        event: 'chat_ipc_complete',
+        mode: 'stream',
+        durationMs: 12.345,
+        outcome: 'ok'
+      })
+      expect(fields).not.toHaveProperty('transcript')
+      expect(fields).not.toHaveProperty('prompt')
+      expect(fields).not.toHaveProperty('userId')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('is wired into single and streaming chat handlers', () => {
+    const source = readFileSync(new URL('../src/main/handlers/chat.ts', import.meta.url), 'utf8')
+    expect(source).toContain("logChatLatency('chat_ipc_complete', 'single'")
+    expect(source).toContain("logChatLatency('chat_first_token', 'stream'")
+    expect(source).toContain("logChatLatency('chat_ipc_complete', 'stream'")
+  })
+})

--- a/rex/actions/dispatcher.py
+++ b/rex/actions/dispatcher.py
@@ -17,6 +17,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from rex.latency import LatencyTrace
+
 logger = logging.getLogger(__name__)
 
 _UNDO_PATTERN = re.compile(r"^\s*undo\s*(?:that)?\s*$", re.IGNORECASE)
@@ -129,6 +131,7 @@ class ActionDispatcher:
         active_user_id: str | None = None,
         user_id: str | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
+        latency_trace: LatencyTrace | None = None,
     ) -> ActionResult:
         """Dispatch *transcript* through all action layers and return an :class:`ActionResult`.
 
@@ -245,15 +248,21 @@ class ActionDispatcher:
                     tool for tool in _selected_tools if getattr(tool, "operation", "read") == "read"
                 ]
             if _selected_tools:
-                _tool_results = await run_in_executor_with_mobile_context(
-                    _loop,
-                    functools.partial(
-                        self._tool_dispatcher.execute_tools,
-                        _selected_tools,
-                        transcript,
-                        user_id=effective_user,
-                    ),
-                )
+                if latency_trace is not None:
+                    latency_trace.start("tool")
+                try:
+                    _tool_results = await run_in_executor_with_mobile_context(
+                        _loop,
+                        functools.partial(
+                            self._tool_dispatcher.execute_tools,
+                            _selected_tools,
+                            transcript,
+                            user_id=effective_user,
+                        ),
+                    )
+                finally:
+                    if latency_trace is not None:
+                        latency_trace.end("tool")
                 _tool_context = self._tool_dispatcher.format_tool_context(_tool_results) or None
 
         completion: str | None = None
@@ -265,6 +274,8 @@ class ActionDispatcher:
             and not mobile_action_context_active()
             and mobile_scope_granted("home.control")
         ):
+            if latency_trace is not None:
+                latency_trace.start("tool")
             if _UNDO_PATTERN.match(transcript):
                 completion = await run_in_executor_with_mobile_context(
                     _loop,
@@ -308,6 +319,8 @@ class ActionDispatcher:
                                 completion = f"{completion} {_spoken}"
                         except Exception:
                             pass
+            if latency_trace is not None:
+                latency_trace.end("tool")
 
         # 8. LLM call (if no pre-LLM handler produced a completion)
         if completion is None:
@@ -324,16 +337,22 @@ class ActionDispatcher:
 
             messages = ctx.messages
             prompt = ctx.prompt
+            if latency_trace is not None:
+                latency_trace.start("llm")
             try:
-                completion = await run_in_executor_with_mobile_context(
-                    _loop,
-                    lambda: self._llm.generate(messages=messages),
-                )
-            except TypeError:
-                completion = await run_in_executor_with_mobile_context(
-                    _loop,
-                    lambda: self._llm.generate(prompt),
-                )
+                try:
+                    completion = await run_in_executor_with_mobile_context(
+                        _loop,
+                        lambda: self._llm.generate(messages=messages),
+                    )
+                except TypeError:
+                    completion = await run_in_executor_with_mobile_context(
+                        _loop,
+                        lambda: self._llm.generate(prompt),
+                    )
+            finally:
+                if latency_trace is not None:
+                    latency_trace.end("llm")
 
             # 9. Post-process LLM output (TOOL_REQUEST resolution, OpenClaw bridge)
             plugin_enrichments: list[str] = []
@@ -351,13 +370,19 @@ class ActionDispatcher:
                     model_call_fn = self._model_call_fn_builder(transcript, user_id=effective_user)
                 except TypeError:
                     model_call_fn = self._model_call_fn_builder(transcript)
-            completion = await self._result_handler.process(
-                transcript,
-                completion,
-                tool_context=tool_context_dict,
-                model_call_fn=model_call_fn,
-                plugin_enrichments=plugin_enrichments,
-            )
+            if latency_trace is not None:
+                latency_trace.start("postprocess")
+            try:
+                completion = await self._result_handler.process(
+                    transcript,
+                    completion,
+                    tool_context=tool_context_dict,
+                    model_call_fn=model_call_fn,
+                    plugin_enrichments=plugin_enrichments,
+                )
+            finally:
+                if latency_trace is not None:
+                    latency_trace.end("postprocess")
 
         return ActionResult(
             success=True,

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -6,11 +6,12 @@ import asyncio
 import logging
 import re
 import threading
+import time
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .actions.dispatcher import _UNDO_PATTERN
 from .assistant_errors import IdentityRequiredError
@@ -20,6 +21,7 @@ from .followup_engine import FollowupEngine
 from .ha_bridge import HABridge
 from .history_store import HistoryStore
 from .identity import validate_user_id
+from .latency import LatencyTrace
 from .llm_client import LanguageModel
 from .memory import trim_history
 from .model_router import ModelRouter
@@ -544,6 +546,19 @@ class Assistant:
         )
         return prompt
 
+    def _latency_provider_model(self) -> tuple[str, str]:
+        """Return latency-safe provider/model identifiers without deprecated config access."""
+        settings_obj = getattr(self, "_settings", None)
+        llm_config = getattr(settings_obj, "llm", None)
+        provider = getattr(llm_config, "llm_provider", None)
+        if provider is None:
+            provider = getattr(settings_obj, "llm_provider", "unknown")
+        llm_obj = getattr(self, "_llm", None)
+        model = getattr(llm_obj, "model_name", None) or getattr(llm_config, "model_name", None)
+        if model is None:
+            model = getattr(settings_obj, "llm_model", "unknown")
+        return str(provider or "unknown"), str(model or "unknown")
+
     def _generate_model_reply(self, prompt: str, messages: list[dict[str, str]]) -> str:
         try:
             return self._llm.generate(messages=messages)
@@ -632,14 +647,44 @@ class Assistant:
             return "pending"
         return "text"
 
+    async def _stream_home_assistant_completion(
+        self,
+        transcript: str,
+        *,
+        loop: asyncio.AbstractEventLoop,
+        latency_trace: LatencyTrace,
+    ) -> str | None:
+        from rex.mobile_api.action_context import (  # noqa: PLC0415
+            mobile_action_context_active,
+            mobile_scope_granted,
+            run_in_executor_with_mobile_context,
+        )
+
+        if not (
+            self._ha_bridge
+            and self._ha_bridge.enabled
+            and not mobile_action_context_active()
+            and mobile_scope_granted("home.control")
+        ):
+            return None
+
+        latency_trace.start("tool")
+        try:
+            return cast(
+                str | None,
+                await run_in_executor_with_mobile_context(
+                    loop, self._ha_bridge.process_transcript, transcript
+                ),
+            )
+        finally:
+            latency_trace.end("tool")
+
     async def stream_reply(
         self, transcript: str, *, voice_mode: bool = False, active_user_id: str | None = None
     ) -> AsyncIterator[str]:
         loop = asyncio.get_running_loop()
         completion: str | None = None
         from rex.mobile_api.action_context import (  # noqa: PLC0415
-            mobile_action_context_active,
-            mobile_scope_granted,
             run_in_executor_with_mobile_context,
         )
 
@@ -648,30 +693,54 @@ class Assistant:
         effective_user_id = self._resolve_request_user_id(active_user_id)
         self._ensure_followup_session(effective_user_id)
 
+        latency_provider, latency_model = self._latency_provider_model()
+        latency_trace = LatencyTrace(
+            channel="voice" if voice_mode else "chat",
+            provider=latency_provider,
+            model=latency_model,
+            settings_id="voice_stream" if voice_mode else "text_stream",
+        )
+        stream_started_ns = time.perf_counter_ns()
+        first_token_recorded = False
+
+        def _mark_first_token() -> None:
+            nonlocal first_token_recorded
+            if first_token_recorded:
+                return
+            latency_trace.add_duration_ms(
+                "first_token", (time.perf_counter_ns() - stream_started_ns) / 1_000_000
+            )
+            first_token_recorded = True
+
+        latency_trace.start("routing")
+
         # Intent routing: time/date, greetings, recipes (US-015)
         _intent = self._get_or_create_intent_router().route(transcript)
+        latency_trace.end("routing")
         if _intent.handled:
+            latency_trace.start("completion")
             self._record_completion(transcript, _intent.response, user_id=effective_user_id)
+            latency_trace.end("completion")
+            _mark_first_token()
+            latency_trace.finish()
+            latency_trace.log_summary(logger, event="chat_stream_latency")
             yield _intent.response
             return
 
-        if (
-            self._ha_bridge
-            and self._ha_bridge.enabled
-            and not mobile_action_context_active()
-            and mobile_scope_granted("home.control")
-        ):
-            completion = await run_in_executor_with_mobile_context(
-                loop,
-                self._ha_bridge.process_transcript,
-                transcript,
-            )
+        completion = await self._stream_home_assistant_completion(
+            transcript, loop=loop, latency_trace=latency_trace
+        )
 
         if completion is not None:
+            latency_trace.start("completion")
             completion = await self._post_process_completion(
                 transcript, completion, user_id=effective_user_id
             )
             self._record_completion(transcript, completion, user_id=effective_user_id)
+            latency_trace.end("completion")
+            _mark_first_token()
+            latency_trace.finish()
+            latency_trace.log_summary(logger, event="chat_stream_latency")
             yield completion
             return
 
@@ -679,16 +748,23 @@ class Assistant:
             transcript, voice_mode=voice_mode, active_user_id=active_user_id
         )
 
+        latency_trace.start("llm")
         try:
             token_iterator = self._stream_model_reply(prompt, messages)
         except NotImplementedError:
             completion = await run_in_executor_with_mobile_context(
                 loop, self._generate_model_reply, prompt, messages
             )
+            latency_trace.end("llm")
+            latency_trace.start("completion")
             completion = await self._post_process_completion(
                 transcript, completion, user_id=effective_user_id
             )
             self._record_completion(transcript, completion, user_id=effective_user_id)
+            latency_trace.end("completion")
+            _mark_first_token()
+            latency_trace.finish()
+            latency_trace.log_summary(logger, event="chat_stream_latency")
             yield completion
             return
 
@@ -719,6 +795,7 @@ class Assistant:
                 token = str(item)
                 collected_tokens.append(token)
                 if stream_released:
+                    _mark_first_token()
                     yield token
                     continue
 
@@ -726,16 +803,24 @@ class Assistant:
                 prefix_state = self._stream_tool_prefix_state(pending_stream_text)
                 if prefix_state == "text":
                     stream_released = True
+                    _mark_first_token()
                     yield pending_stream_text
                     pending_stream_text = ""
         finally:
             await pump_task
 
+        latency_trace.end("llm")
+        latency_trace.start("completion")
         completion = "".join(collected_tokens).strip() or "(silence)"
         completion = await self._post_process_completion(
             transcript, completion, user_id=effective_user_id
         )
         self._record_completion(transcript, completion, user_id=effective_user_id)
+        latency_trace.end("completion")
+        if not stream_released:
+            _mark_first_token()
+        latency_trace.finish()
+        latency_trace.log_summary(logger, event="chat_stream_latency")
         if not stream_released:
             yield completion
 
@@ -748,13 +833,21 @@ class Assistant:
     ) -> str:
         """Orchestrate a full reply: identity → intent → cache → context → dispatch → response."""
         loop = asyncio.get_running_loop()
-
         # The user this turn belongs to: an explicit validated request
         # identity, otherwise the explicit constructor identity.  Missing
         # identity fails closed before intent routing, cache lookup, early
         # returns, history, context, and tool dispatch (issue #303).
         effective_user_id = self._resolve_request_user_id(active_user_id)
         self._ensure_followup_session(effective_user_id)
+
+        latency_provider, latency_model = self._latency_provider_model()
+        latency_trace = LatencyTrace(
+            channel="voice" if voice_mode else "chat",
+            provider=latency_provider,
+            model=latency_model,
+            settings_id="voice" if voice_mode else "text",
+        )
+        latency_trace.start("routing")
 
         # Route intent: capability queries, pending suggestions, time/date, greetings, recipes
         _intent = self._get_or_create_intent_router().route(
@@ -766,7 +859,12 @@ class Assistant:
         if _intent.handled:
             # Greeting shortcuts are suppressed in multi-user voice sessions
             if not (_intent.intent_type == "greeting" and active_user_id is not None):
+                latency_trace.end("routing")
+                latency_trace.start("completion")
                 self._record_completion(transcript, _intent.response, user_id=effective_user_id)
+                latency_trace.end("completion")
+                latency_trace.finish()
+                latency_trace.log_summary(logger, event="chat_latency")
                 return _intent.response  # type: ignore[no-any-return]
 
         # Fast path: return cached response without hitting the LLM.
@@ -775,13 +873,20 @@ class Assistant:
             transcript, user_id=effective_user_id
         )
         if _cached is not None:
+            latency_trace.end("routing")
+            latency_trace.start("completion")
             self._record_completion(transcript, _cached, user_id=effective_user_id)
+            latency_trace.end("completion")
+            latency_trace.finish()
+            latency_trace.log_summary(logger, event="chat_latency")
             return _cached  # type: ignore[no-any-return]
 
         # Apply per-request model routing; restore in finally.  The request
         # identity is propagated explicitly (never via self._user_id, which
         # would race across overlapping requests for different users).
         prev_model = self._begin_request(transcript)
+        latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
+        latency_trace.end("routing")
         try:
             _ctx = self._get_or_create_context_builder().build(
                 transcript, voice_mode=voice_mode, active_user_id=active_user_id
@@ -794,15 +899,24 @@ class Assistant:
                 active_user_id=active_user_id,
                 user_id=effective_user_id,
                 loop=loop,
+                latency_trace=latency_trace,
             )
+            latency_trace.start("completion")
             final = self._get_or_create_response_builder().build(
                 result, _ctx, transcript=transcript, user_id=effective_user_id
             )
             completion = final.text
+        except Exception:
+            latency_trace.finish()
+            latency_trace.log_summary(logger, event="chat_latency")
+            raise
         finally:
             self._end_request(prev_model)
 
         self._record_completion(transcript, completion, user_id=effective_user_id)
+        latency_trace.end("completion")
+        latency_trace.finish()
+        latency_trace.log_summary(logger, event="chat_latency")
         return completion  # type: ignore[no-any-return]
 
     def _begin_request(self, transcript: str) -> str | None:

--- a/rex/latency.py
+++ b/rex/latency.py
@@ -1,0 +1,82 @@
+"""Privacy-safe monotonic latency tracing for assistant request stages.
+
+The trace intentionally stores only diagnostic metadata supplied through explicit
+fields. User IDs, prompts, transcripts, tool payloads, and credentials are not
+accepted by this API.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+ClockNs = Callable[[], int]
+
+
+@dataclass
+class LatencyTrace:
+    """Collect monotonic stage timings without retaining request contents."""
+
+    channel: str
+    provider: str = "unknown"
+    model: str = "unknown"
+    settings_id: str = "default"
+    clock_ns: ClockNs = time.perf_counter_ns
+    trace_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    _started_ns: int = field(init=False, repr=False)
+    _finished_ns: int | None = field(default=None, init=False, repr=False)
+    _open_stages: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+    _durations_ns: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._started_ns = self.clock_ns()
+
+    def start(self, stage: str) -> None:
+        """Start or restart a named stage."""
+        self._open_stages[stage] = self.clock_ns()
+
+    def end(self, stage: str) -> float:
+        """Finish a stage and accumulate its duration in milliseconds."""
+        started = self._open_stages.pop(stage, None)
+        if started is None:
+            raise ValueError(f"Latency stage was not started: {stage}")
+        elapsed_ns = max(0, self.clock_ns() - started)
+        self._durations_ns[stage] = self._durations_ns.get(stage, 0) + elapsed_ns
+        return elapsed_ns / 1_000_000
+
+    def add_duration_ms(self, stage: str, duration_ms: float) -> None:
+        """Add an already-measured stage duration."""
+        if duration_ms < 0:
+            raise ValueError("Latency duration cannot be negative")
+        self._durations_ns[stage] = self._durations_ns.get(stage, 0) + int(duration_ms * 1_000_000)
+
+    def finish(self) -> None:
+        """Seal total timing. Calling twice is harmless."""
+        if self._finished_ns is None:
+            self._finished_ns = self.clock_ns()
+
+    def summary(self) -> dict[str, str | float]:
+        """Return privacy-safe structured diagnostic fields."""
+        end_ns = self._finished_ns if self._finished_ns is not None else self.clock_ns()
+        result: dict[str, str | float] = {
+            "trace_id": self.trace_id,
+            "channel": self.channel,
+            "provider": self.provider,
+            "model": self.model,
+            "settings_id": self.settings_id,
+            "total_ms": round(max(0, end_ns - self._started_ns) / 1_000_000, 3),
+        }
+        for stage, duration_ns in sorted(self._durations_ns.items()):
+            result[f"{stage}_ms"] = round(duration_ns / 1_000_000, 3)
+        return result
+
+    def log_summary(self, logger: logging.Logger, *, event: str = "latency_summary") -> None:
+        """Emit one structured INFO record with no request payload data."""
+        fields = self.summary()
+        logger.info("[latency] %s", event, extra={"event": event, **fields})
+
+
+__all__ = ["LatencyTrace"]

--- a/rex/rexbench.py
+++ b/rex/rexbench.py
@@ -1,0 +1,71 @@
+"""Privacy-safe benchmark aggregation used by Rex production-readiness gates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BenchmarkSample:
+    """One timing sample with no request payload or user identity."""
+
+    request_class: str
+    warm_state: str
+    evidence_class: str
+    stages_ms: dict[str, float]
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        raise ValueError("Cannot calculate a percentile from an empty sample")
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def build_report(samples: list[BenchmarkSample], *, profile: str) -> dict[str, Any]:
+    """Aggregate p50/p95 timings by request class and cold/warm state."""
+    grouped: dict[tuple[str, str], list[BenchmarkSample]] = {}
+    for sample in samples:
+        if sample.warm_state not in {"cold", "warm"}:
+            raise ValueError(f"Unsupported warm state: {sample.warm_state}")
+        if not sample.stages_ms or "total" not in sample.stages_ms:
+            raise ValueError("Every benchmark sample must include total timing")
+        if any(value < 0 for value in sample.stages_ms.values()):
+            raise ValueError("Benchmark timings cannot be negative")
+        grouped.setdefault((sample.request_class, sample.warm_state), []).append(sample)
+
+    results: dict[str, dict[str, Any]] = {}
+    for (request_class, warm_state), bucket in sorted(grouped.items()):
+        evidence = {sample.evidence_class for sample in bucket}
+        if len(evidence) != 1:
+            raise ValueError("A benchmark bucket cannot mix evidence classes")
+        stage_names = sorted({name for sample in bucket for name in sample.stages_ms})
+        stage_report: dict[str, dict[str, float]] = {}
+        for stage in stage_names:
+            values = [sample.stages_ms[stage] for sample in bucket if stage in sample.stages_ms]
+            stage_report[stage] = {
+                "p50": round(_percentile(values, 0.50), 3),
+                "p95": round(_percentile(values, 0.95), 3),
+            }
+        results.setdefault(request_class, {})[warm_state] = {
+            "evidence_class": next(iter(evidence)),
+            "sample_count": len(bucket),
+            "stages_ms": stage_report,
+        }
+
+    return {
+        "schema_version": 1,
+        "profile": profile,
+        "privacy": "timings_and_nonsecret_runtime_identifiers_only",
+        "results": results,
+    }
+
+
+__all__ = ["BenchmarkSample", "build_report"]

--- a/rex/voice/loop.py
+++ b/rex/voice/loop.py
@@ -157,7 +157,7 @@ class VoiceLoop:
 
     @staticmethod
     def _duration_ms(start_ns: int) -> float:
-        return round((time.monotonic_ns() - start_ns) / 1_000_000, 3)
+        return round((time.perf_counter_ns() - start_ns) / 1_000_000, 3)
 
     def _report_audio_device_error(
         self,
@@ -500,7 +500,7 @@ class VoiceLoop:
                     interaction_id = self._interaction_id
                     audio_device_kind = "microphone"
                     tracker = VoiceLatencyTracker()
-                    wake_detected_ns = time.monotonic_ns()
+                    wake_detected_ns = time.perf_counter_ns()
                     self._log_pipeline_event(
                         "wake_detected", interaction_id=interaction_id, start_ns=wake_detected_ns
                     )
@@ -526,7 +526,7 @@ class VoiceLoop:
                     # because no-pause commands can otherwise be clipped before
                     # phrase capture begins.
                     capture_started_at = time.perf_counter()
-                    capture_start_ns = time.monotonic_ns()
+                    capture_start_ns = time.perf_counter_ns()
                     self._log_pipeline_event(
                         "capture_started", interaction_id=interaction_id, start_ns=capture_start_ns
                     )
@@ -588,7 +588,7 @@ class VoiceLoop:
                         },
                     )
                     tracker.mark("stt_start")
-                    stt_start_ns = time.monotonic_ns()
+                    stt_start_ns = time.perf_counter_ns()
                     self._log_pipeline_event(
                         "stt_started", interaction_id=interaction_id, start_ns=stt_start_ns
                     )
@@ -783,7 +783,7 @@ class VoiceLoop:
                     # Get LLM response - voice_mode=True enables conciseness prompt
                     _emit("executing")
                     tracker.mark("llm_start")
-                    llm_start_ns = time.monotonic_ns()
+                    llm_start_ns = time.perf_counter_ns()
                     self._log_pipeline_event(
                         "llm_started", interaction_id=interaction_id, start_ns=llm_start_ns
                     )
@@ -791,7 +791,7 @@ class VoiceLoop:
                     if _speak_streaming is not None and callable(stream_reply):
                         tracker.mark("tts_synthesis_start")
                         tracker.mark("tts_first_chunk")
-                        tts_start_ns = time.monotonic_ns()
+                        tts_start_ns = time.perf_counter_ns()
                         self._log_pipeline_event(
                             "tts_started",
                             interaction_id=interaction_id,
@@ -879,7 +879,7 @@ class VoiceLoop:
                                 },
                             )
                             tracker.mark("tts_synthesis_start")
-                            tts_start_ns = time.monotonic_ns()
+                            tts_start_ns = time.perf_counter_ns()
                             self._log_pipeline_event(
                                 "tts_started", interaction_id=interaction_id, start_ns=tts_start_ns
                             )

--- a/scripts/rexbench.py
+++ b/scripts/rexbench.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Deterministic privacy-safe Rex latency baseline harness."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import rex.assistant as assistant_module  # noqa: E402
+from rex.model_router import ModelRouter  # noqa: E402
+from rex.rexbench import BenchmarkSample, build_report  # noqa: E402
+from rex.voice_loop import VoiceLoop  # noqa: E402
+
+REQUEST_CLASSES = (
+    "typed_chat",
+    "voice",
+    "read_only_tool",
+    "mutating_tool",
+    "unavailable_capability",
+)
+
+
+@dataclass
+class _Routing:
+    default: str = "bench-model"
+    coding: str = ""
+    reasoning: str = ""
+    search: str = ""
+    vision: str = ""
+    fast: str = ""
+
+
+@dataclass
+class _Settings:
+    llm_provider: str = "transformers"
+    llm_model: str = "bench-model"
+    llm_max_tokens: int = 10
+    llm_temperature: float = 0.7
+    llm_top_p: float = 0.9
+    llm_top_k: int = 50
+    llm_seed: int = 42
+    max_memory_items: int = 5
+    transcripts_dir: str = "transcripts"
+    persist_history: bool = False
+    followups_enabled: bool = False
+    ha_base_url: str | None = None
+    ha_token: str | None = None
+    user_id: str = "benchmark"
+    active_profile: str = "default"
+    response_cache_ttl: int = 0
+    model_routing: _Routing = field(default_factory=_Routing)
+
+
+class _BenchLLM:
+    def __init__(self, response: str = "benchmark reply") -> None:
+        self.model_name = "bench-model"
+        self.response = response
+
+    def generate(self, prompt=None, *, messages=None, config=None):
+        time.sleep(0.002)
+        return self.response
+
+    def stream(self, prompt=None, *, messages=None, config=None):
+        time.sleep(0.002)
+        yield self.response
+
+
+class _BenchToolDispatcher:
+    def __init__(self, operation: str) -> None:
+        self.operation = operation
+
+    def select_tools(self, transcript):
+        return [SimpleNamespace(operation=self.operation)]
+
+    def execute_tools(self, selected, transcript, *, user_id):
+        time.sleep(0.002)
+        return []
+
+    def format_tool_context(self, results):
+        return "benchmark result"
+
+
+class _RecordCapture(logging.Handler):
+    def __init__(self, event: str) -> None:
+        super().__init__()
+        self.event = event
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if getattr(record, "event", None) == self.event:
+            self.records.append(record)
+
+
+def _make_assistant(request_class: str):
+    response = (
+        "Capability unavailable."
+        if request_class == "unavailable_capability"
+        else "benchmark reply"
+    )
+    llm = _BenchLLM(response=response)
+
+    class _Factory:
+        def __new__(cls, *args, **kwargs):
+            return llm
+
+    started = time.perf_counter_ns()
+    with (
+        patch.object(assistant_module, "LanguageModel", _Factory),
+        patch.object(ModelRouter, "_fetch_ollama_models", lambda self: None),
+    ):
+        assistant = assistant_module.Assistant(
+            settings_obj=_Settings(), transcripts_dir="transcripts", user_id="benchmark"
+        )
+    startup_ms = (time.perf_counter_ns() - started) / 1_000_000
+    assistant._router._available_ollama_models = {"bench-model"}
+
+    tool_dispatcher = None
+    if request_class == "read_only_tool":
+        tool_dispatcher = _BenchToolDispatcher("read")
+    elif request_class == "mutating_tool":
+        tool_dispatcher = _BenchToolDispatcher("mutate")
+    assistant._tool_dispatcher = tool_dispatcher
+    assistant._ha_bridge = None
+    assistant._shopping_list_handler = None
+    assistant._music_handler = None
+    assistant._device_state_handler = None
+    assistant._skill_trainer = None
+    assistant._skill_router = None
+    assistant._action_dispatcher._tool_dispatcher = tool_dispatcher
+    assistant._action_dispatcher._ha_bridge = None
+    assistant._action_dispatcher._shopping_list_handler = None
+    assistant._action_dispatcher._music_handler = None
+    assistant._action_dispatcher._device_state_handler = None
+    assistant._action_dispatcher._skill_trainer = None
+    assistant._action_dispatcher._skill_router = None
+    return assistant, startup_ms
+
+
+def _chat_sample(
+    request_class: str, *, warm_state: str, assistant=None
+) -> tuple[BenchmarkSample, object]:
+    startup_ms = 0.0
+    if assistant is None:
+        assistant, startup_ms = _make_assistant(request_class)
+
+    logger = logging.getLogger("rex.assistant")
+    capture = _RecordCapture("chat_latency")
+    previous_level, previous_propagate = logger.level, logger.propagate
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    logger.addHandler(capture)
+    try:
+        asyncio.run(
+            assistant.generate_reply(f"benchmark {request_class}", active_user_id="benchmark")
+        )
+    finally:
+        logger.removeHandler(capture)
+        logger.setLevel(previous_level)
+        logger.propagate = previous_propagate
+    if not capture.records:
+        raise RuntimeError("Chat latency event was not emitted")
+    record = capture.records[-1]
+    stages = {
+        key[:-3]: float(value)
+        for key, value in vars(record).items()
+        if key.endswith("_ms") and isinstance(value, (int, float))
+    }
+    if warm_state == "cold":
+        stages["startup"] = startup_ms
+        stages["total"] = stages.get("total", 0.0) + startup_ms
+    return (
+        BenchmarkSample(
+            request_class=request_class,
+            warm_state=warm_state,
+            evidence_class="deterministic_mock",
+            stages_ms=stages,
+        ),
+        assistant,
+    )
+
+
+def _stream_chat_sample(*, warm_state: str, assistant=None) -> tuple[BenchmarkSample, object]:
+    startup_ms = 0.0
+    if assistant is None:
+        assistant, startup_ms = _make_assistant("typed_chat")
+
+    logger = logging.getLogger("rex.assistant")
+    capture = _RecordCapture("chat_stream_latency")
+    previous_level, previous_propagate = logger.level, logger.propagate
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    logger.addHandler(capture)
+
+    async def _consume() -> None:
+        async for _chunk in assistant.stream_reply(
+            "benchmark typed_chat", active_user_id="benchmark"
+        ):
+            pass
+
+    try:
+        asyncio.run(_consume())
+    finally:
+        logger.removeHandler(capture)
+        logger.setLevel(previous_level)
+        logger.propagate = previous_propagate
+    if not capture.records:
+        raise RuntimeError("Streaming chat latency event was not emitted")
+    record = capture.records[-1]
+    stages = {
+        key[:-3]: float(value)
+        for key, value in vars(record).items()
+        if key.endswith("_ms") and isinstance(value, (int, float))
+    }
+    if warm_state == "cold":
+        stages["startup"] = startup_ms
+        stages["total"] = stages.get("total", 0.0) + startup_ms
+    return (
+        BenchmarkSample(
+            request_class="typed_chat",
+            warm_state=warm_state,
+            evidence_class="deterministic_mock",
+            stages_ms=stages,
+        ),
+        assistant,
+    )
+
+
+class _OnceListener:
+    async def listen(self, _source):
+        yield b"wake"
+
+    def mark_listening_started(self, *, reason: str = "benchmark") -> None:
+        return None
+
+    def reset(self, *, reason: str = "benchmark") -> None:
+        return None
+
+
+def _voice_sample(*, warm_state: str) -> BenchmarkSample:
+    async def detection_source():
+        return b"wake"
+
+    async def record_phrase():
+        time.sleep(0.001)
+        return b"audio"
+
+    async def transcribe(_audio):
+        await asyncio.sleep(0.001)
+        return "benchmark voice request"
+
+    async def speak(_text: str) -> None:
+        await asyncio.sleep(0.001)
+
+    assistant = MagicMock()
+    assistant.generate_reply = AsyncMock(return_value="benchmark reply")
+    del assistant.stream_reply
+
+    started = time.perf_counter_ns()
+    loop = VoiceLoop(
+        assistant,
+        wake_listener=_OnceListener(),
+        detection_source=detection_source,
+        record_phrase=record_phrase,
+        transcribe=transcribe,
+        speak=speak,
+        post_interaction_cooldown=0,
+        post_wake_preroll_seconds=0,
+    )
+    startup_ms = (time.perf_counter_ns() - started) / 1_000_000
+
+    logger = logging.getLogger("rex.voice_loop")
+    capture = logging.Handler()
+    records: list[logging.LogRecord] = []
+    capture.emit = lambda record: records.append(record)  # type: ignore[method-assign]
+    previous_level, previous_propagate = logger.level, logger.propagate
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    logger.addHandler(capture)
+    try:
+        asyncio.run(loop.run(max_interactions=1))
+    finally:
+        logger.removeHandler(capture)
+        logger.setLevel(previous_level)
+        logger.propagate = previous_propagate
+
+    by_event = {
+        record.event: record
+        for record in records
+        if getattr(record, "event", None)
+        in {
+            "wake_detected",
+            "capture_started",
+            "capture_ended",
+            "stt_completed",
+            "llm_completed",
+            "playback_completed",
+        }
+    }
+    required = {
+        "wake_detected",
+        "capture_started",
+        "capture_ended",
+        "stt_completed",
+        "llm_completed",
+        "playback_completed",
+    }
+    if set(by_event) != required:
+        raise RuntimeError(f"Voice latency events missing: {sorted(required - set(by_event))}")
+    wake = by_event["wake_detected"]
+    playback = by_event["playback_completed"]
+    total_ms = ((playback.start_ns - wake.start_ns) / 1_000_000) + float(playback.duration_ms)
+    stages = {
+        "capture": float(by_event["capture_ended"].duration_ms),
+        "stt": float(by_event["stt_completed"].duration_ms),
+        "llm": float(by_event["llm_completed"].duration_ms),
+        "first_audio": (playback.start_ns - wake.start_ns) / 1_000_000,
+        "completion": total_ms,
+        "total": total_ms,
+    }
+    if warm_state == "cold":
+        stages["startup"] = startup_ms
+        stages["total"] += startup_ms
+    return BenchmarkSample(
+        request_class="voice",
+        warm_state=warm_state,
+        evidence_class="deterministic_mock",
+        stages_ms=stages,
+    )
+
+
+def run_baseline(iterations: int) -> dict:
+    if iterations < 1:
+        raise ValueError("iterations must be at least 1")
+    samples: list[BenchmarkSample] = []
+    for request_class in REQUEST_CLASSES:
+        if request_class == "voice":
+            for _ in range(iterations):
+                samples.append(_voice_sample(warm_state="cold"))
+                samples.append(_voice_sample(warm_state="warm"))
+            continue
+        if request_class == "typed_chat":
+            warm_assistant, _ = _make_assistant(request_class)
+            for _ in range(iterations):
+                cold, _ = _stream_chat_sample(warm_state="cold")
+                warm, warm_assistant = _stream_chat_sample(
+                    warm_state="warm", assistant=warm_assistant
+                )
+                samples.extend((cold, warm))
+            continue
+        warm_assistant, _ = _make_assistant(request_class)
+        for _ in range(iterations):
+            cold, _ = _chat_sample(request_class, warm_state="cold")
+            warm, warm_assistant = _chat_sample(
+                request_class, warm_state="warm", assistant=warm_assistant
+            )
+            samples.extend((cold, warm))
+    return build_report(samples, profile="baseline")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=("baseline",), default="baseline")
+    parser.add_argument("--iterations", type=int, default=8)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    report = run_baseline(args.iterations)
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+        print(f"RexBench baseline written: {args.output}")
+    else:
+        print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_assistant_latency.py
+++ b/tests/test_assistant_latency.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import rex.assistant as assistant_module
+from rex.actions.dispatcher import ActionDispatcher
+from rex.latency import LatencyTrace
+from rex.model_router import ModelRouter
+
+
+@dataclass
+class _Routing:
+    default: str = "bench-model"
+    coding: str = ""
+    reasoning: str = ""
+    search: str = ""
+    vision: str = ""
+    fast: str = ""
+
+
+@dataclass
+class _Settings:
+    llm_provider: str = "transformers"
+    llm_model: str = "bench-model"
+    llm_max_tokens: int = 10
+    llm_temperature: float = 0.7
+    llm_top_p: float = 0.9
+    llm_top_k: int = 50
+    llm_seed: int = 42
+    max_memory_items: int = 5
+    transcripts_dir: str = "transcripts"
+    persist_history: bool = False
+    followups_enabled: bool = False
+    ha_base_url: str | None = None
+    ha_token: str | None = None
+    user_id: str = "benchmark"
+    active_profile: str = "default"
+    model_routing: _Routing = field(default_factory=_Routing)
+
+
+class _LLM:
+    model_name = "bench-model"
+
+    def generate(self, prompt=None, *, messages=None, config=None):
+        time.sleep(0.001)
+        return "benchmark reply"
+
+    def stream(self, prompt=None, *, messages=None, config=None):
+        time.sleep(0.001)
+        yield "benchmark "
+        yield "reply"
+
+
+def _assistant(monkeypatch) -> assistant_module.Assistant:
+    llm = _LLM()
+
+    class _Factory:
+        def __new__(cls, *args, **kwargs):
+            return llm
+
+    monkeypatch.setattr(assistant_module, "LanguageModel", _Factory)
+    monkeypatch.setattr(ModelRouter, "_fetch_ollama_models", lambda self: None)
+    assistant = assistant_module.Assistant(
+        settings_obj=_Settings(), transcripts_dir="transcripts", user_id="benchmark"
+    )
+    assistant._router._available_ollama_models = {"bench-model"}
+    assistant._tool_dispatcher = None
+    assistant._ha_bridge = None
+    assistant._shopping_list_handler = None
+    assistant._music_handler = None
+    assistant._device_state_handler = None
+    assistant._skill_trainer = None
+    assistant._skill_router = None
+    return assistant
+
+
+def test_generate_reply_emits_privacy_safe_chat_stage_timings(monkeypatch, caplog) -> None:
+    assistant = _assistant(monkeypatch)
+    with caplog.at_level(logging.INFO, logger="rex.assistant"):
+        result = asyncio.run(assistant.generate_reply("Explain a benchmark fixture"))
+
+    assert result == "benchmark reply"
+    records = [
+        record for record in caplog.records if getattr(record, "event", None) == "chat_latency"
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record.routing_ms >= 0
+    assert hasattr(record, "llm_ms")
+    assert hasattr(record, "postprocess_ms")
+    assert not hasattr(record, "tool_ms")
+    assert record.llm_ms >= 0
+    assert record.postprocess_ms >= 0
+    assert record.total_ms >= record.llm_ms
+    assert record.provider == "transformers"
+    assert record.model == "bench-model"
+    assert not hasattr(record, "transcript")
+    assert not hasattr(record, "user_id")
+
+
+def test_voice_mode_latency_uses_safe_voice_identifiers(monkeypatch, caplog) -> None:
+    assistant = _assistant(monkeypatch)
+    with caplog.at_level(logging.INFO, logger="rex.assistant"):
+        asyncio.run(assistant.generate_reply("Benchmark voice request", voice_mode=True))
+
+    record = next(
+        record for record in caplog.records if getattr(record, "event", None) == "chat_latency"
+    )
+    assert record.channel == "voice"
+    assert record.provider == "transformers"
+    assert record.model == "bench-model"
+    assert record.settings_id == "voice"
+    assert not hasattr(record, "transcript")
+    assert not hasattr(record, "user_id")
+
+
+def test_stream_reply_emits_privacy_safe_first_token_timings(monkeypatch, caplog) -> None:
+    assistant = _assistant(monkeypatch)
+
+    async def _collect() -> list[str]:
+        return [
+            chunk
+            async for chunk in assistant.stream_reply(
+                "Explain a streaming benchmark fixture", active_user_id="benchmark"
+            )
+        ]
+
+    with caplog.at_level(logging.INFO, logger="rex.assistant"):
+        chunks = asyncio.run(_collect())
+
+    assert "".join(chunks).strip() == "benchmark reply"
+    records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "chat_stream_latency"
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record.routing_ms >= 0
+    assert record.first_token_ms >= 0
+    assert record.llm_ms >= 0
+    assert record.completion_ms >= 0
+    assert record.total_ms >= record.first_token_ms
+    assert record.provider == "transformers"
+    assert record.model == "bench-model"
+    assert record.settings_id == "text_stream"
+    assert not hasattr(record, "transcript")
+    assert not hasattr(record, "user_id")
+
+
+class _ToolDispatcher:
+    def select_tools(self, transcript):
+        return [SimpleNamespace(operation="read")]
+
+    def execute_tools(self, selected, transcript, *, user_id):
+        time.sleep(0.001)
+        return []
+
+    def format_tool_context(self, results):
+        return "benchmark tool context"
+
+
+class _ResultHandler:
+    async def process(self, transcript, completion, **kwargs):
+        return completion
+
+
+def test_action_dispatcher_records_tool_and_llm_segments() -> None:
+    dispatcher = ActionDispatcher(
+        context_builder=SimpleNamespace(
+            build=lambda *args, **kwargs: SimpleNamespace(
+                messages=[{"role": "user", "content": "benchmark"}],
+                prompt="benchmark",
+            )
+        ),
+        llm=_LLM(),
+        result_handler=_ResultHandler(),
+        tool_dispatcher=_ToolDispatcher(),
+    )
+    trace = LatencyTrace(channel="chat", provider="transformers", model="bench-model")
+    context = SimpleNamespace(
+        messages=[{"role": "user", "content": "benchmark"}], prompt="benchmark"
+    )
+
+    asyncio.run(
+        dispatcher.dispatch(
+            SimpleNamespace(handled=False),
+            context,
+            "benchmark request",
+            user_id="benchmark",
+            latency_trace=trace,
+        )
+    )
+    trace.finish()
+    summary = trace.summary()
+    assert "tool_ms" in summary
+    assert "llm_ms" in summary
+    assert summary["tool_ms"] >= 0
+    assert summary["llm_ms"] >= 0

--- a/tests/test_latency_trace.py
+++ b/tests/test_latency_trace.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from rex.latency import LatencyTrace
+
+
+def test_latency_trace_accumulates_segments_and_uses_safe_metadata() -> None:
+    ticks = iter(
+        [1_000_000_000, 1_000_000_000, 1_010_000_000, 1_025_000_000, 1_040_000_000, 1_070_000_000]
+    )
+    trace = LatencyTrace(
+        channel="chat",
+        provider="ollama",
+        model="qwen-test",
+        settings_id="local-default",
+        clock_ns=lambda: next(ticks),
+    )
+
+    trace.start("routing")
+    trace.end("routing")
+    trace.start("tool")
+    trace.end("tool")
+    trace.finish()
+
+    summary = trace.summary()
+    assert summary["channel"] == "chat"
+    assert summary["provider"] == "ollama"
+    assert summary["model"] == "qwen-test"
+    assert summary["settings_id"] == "local-default"
+    assert summary["routing_ms"] == pytest.approx(10.0)
+    assert summary["tool_ms"] == pytest.approx(15.0)
+    assert summary["total_ms"] == pytest.approx(70.0)
+    serialized = repr(summary).lower()
+    assert "prompt" not in serialized
+    assert "transcript" not in serialized
+    assert "user_id" not in serialized
+
+
+def test_latency_trace_logs_structured_summary_without_payload(caplog) -> None:
+    ticks = iter([2_000_000_000, 2_005_000_000])
+    trace = LatencyTrace(
+        channel="chat", provider="local", model="test", clock_ns=lambda: next(ticks)
+    )
+    trace.finish()
+
+    logger = logging.getLogger("tests.latency")
+    with caplog.at_level(logging.INFO, logger="tests.latency"):
+        trace.log_summary(logger, event="chat_latency")
+
+    record = caplog.records[-1]
+    assert record.event == "chat_latency"
+    assert record.channel == "chat"
+    assert record.total_ms == pytest.approx(5.0)
+    assert not hasattr(record, "prompt")
+    assert not hasattr(record, "transcript")
+    assert not hasattr(record, "user_id")

--- a/tests/test_rexbench.py
+++ b/tests/test_rexbench.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from rex.rexbench import BenchmarkSample, build_report
+
+
+def test_build_report_groups_p50_p95_without_private_payloads() -> None:
+    samples = [
+        BenchmarkSample(
+            request_class="typed_chat",
+            warm_state="warm",
+            evidence_class="deterministic_mock",
+            stages_ms={"routing": 10.0, "llm": 30.0, "completion": 2.0, "total": 42.0},
+        ),
+        BenchmarkSample(
+            request_class="typed_chat",
+            warm_state="warm",
+            evidence_class="deterministic_mock",
+            stages_ms={"routing": 12.0, "llm": 34.0, "completion": 3.0, "total": 49.0},
+        ),
+    ]
+
+    report = build_report(samples, profile="baseline")
+    bucket = report["results"]["typed_chat"]["warm"]
+    assert bucket["sample_count"] == 2
+    assert bucket["stages_ms"]["llm"]["p50"] == pytest.approx(32.0)
+    assert bucket["stages_ms"]["llm"]["p95"] == pytest.approx(33.8)
+    assert bucket["evidence_class"] == "deterministic_mock"
+    encoded = json.dumps(report).lower()
+    for forbidden in ("prompt", "transcript", "memory_content", "credential", "user_id"):
+        assert forbidden not in encoded
+
+
+def test_baseline_cli_emits_all_request_classes_and_safe_evidence(tmp_path) -> None:
+    output = tmp_path / "baseline.json"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/rexbench.py",
+            "--profile",
+            "baseline",
+            "--iterations",
+            "1",
+            "--output",
+            str(output),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert set(report["results"]) == {
+        "typed_chat",
+        "voice",
+        "read_only_tool",
+        "mutating_tool",
+        "unavailable_capability",
+    }
+    for request_class in report["results"].values():
+        assert set(request_class) == {"cold", "warm"}
+        for bucket in request_class.values():
+            assert bucket["evidence_class"] == "deterministic_mock"
+            assert "total" in bucket["stages_ms"]
+    for warm_state in ("cold", "warm"):
+        typed_stages = report["results"]["typed_chat"][warm_state]["stages_ms"]
+        assert "first_token" in typed_stages
+    encoded = output.read_text(encoding="utf-8").lower()
+    for forbidden in ("prompt", "transcript", "memory_content", "credential", "user_id"):
+        assert forbidden not in encoded
+
+
+def test_checked_in_baseline_covers_required_stages_and_privacy() -> None:
+    baseline = Path("docs/performance/rexbench-baseline.json")
+    report = json.loads(baseline.read_text(encoding="utf-8"))
+    required = {
+        "typed_chat": {"routing", "first_token", "llm", "completion", "total"},
+        "voice": {"capture", "stt", "llm", "first_audio", "completion", "total"},
+        "read_only_tool": {"routing", "tool", "llm", "completion", "total"},
+        "mutating_tool": {"routing", "tool", "llm", "completion", "total"},
+        "unavailable_capability": {"routing", "llm", "completion", "total"},
+    }
+
+    assert set(report["results"]) == set(required)
+    for request_class, required_stages in required.items():
+        assert set(report["results"][request_class]) == {"cold", "warm"}
+        for bucket in report["results"][request_class].values():
+            assert bucket["evidence_class"] == "deterministic_mock"
+            stages = bucket["stages_ms"]
+            assert required_stages <= set(stages)
+            for stage in required_stages:
+                assert set(stages[stage]) == {"p50", "p95"}
+
+    encoded = baseline.read_text(encoding="utf-8").lower()
+    for forbidden in ("prompt", "transcript", "memory_content", "credential", "user_id"):
+        assert forbidden not in encoded

--- a/tests/test_voice_latency_budget.py
+++ b/tests/test_voice_latency_budget.py
@@ -66,6 +66,7 @@ def _run_synthetic_pipeline(caplog) -> dict[str, logging.LogRecord]:
         "capture_ended",
         "stt_completed",
         "llm_completed",
+        "tts_started",
         "playback_completed",
     }
     records = {


### PR DESCRIPTION
## Summary
- add privacy-safe monotonic chat, tool, IPC, stream-first-token, and voice latency instrumentation
- add deterministic RexBench cold/warm p50/p95 baseline across typed chat, voice, read-only tool, mutating tool, and unavailable-capability classes
- document latency budgets, evidence classes, privacy rules, and follow-on optimization ownership

## Local verification
- 64/64 focused Python latency/voice/tool/RexBench tests pass
- GUI: 25 files / 116 tests pass; chat-latency 2/2
- both TypeScript configs pass when invoked directly
- ESLint 0 errors (3 existing warnings); Electron production build passes
- Ruff, Black, mypy, compileall, deprecated-API guard, pre-commit/detect-secrets, and diff hygiene pass

## Tracker
US-075 GitHub-check acceptance criterion intentionally remains open until all required checks pass on the exact final PR head.