### PR TITLE
docs(capabilities): inventory Electron parity for US-064

### DIFF
--- a/INTEGRATIONS_STATUS.md
+++ b/INTEGRATIONS_STATUS.md
@@ -6,6 +6,8 @@ This is the canonical integration release contract. Runtime status uses the same
 
 Credentials alone mean `configured`. They never mean connected, authenticated, write-capable, or verified.
 
+For the production-facing mapping from backend/docs capabilities to Electron visibility, configuration status, permissions, risk, health evidence, verification support, and future registry adapters, see [docs/CAPABILITY-PARITY.md](docs/CAPABILITY-PARITY.md). Capabilities that are backend-only remain explicitly developer-only rather than being implied production-ready.
+
 | Integration | Product tier | Current contract |
 |---|---|---|
 | Home Assistant | Supported, credential-gated | Read access requires live authentication. Mutations use the unified policy service; sensitive actions require action-bound confirmation and all writes return verified, attempted-but-unverified, denied, or failed. Live-device transitions remain externally verified. |

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2195,15 +2195,15 @@ cd gui && npm run typecheck && npm run build
 **Implementation notes:** Create a capability matrix covering OpenClaw, web search, Outlook, email, SMS, Home Assistant, shopping list, memory, profiles, voice, LLM providers, mobile/API access, and other registered tools. This is an inventory/story-routing task, not the implementation of every missing UI.
 
 **Acceptance Criteria:**
-- [ ] A committed inventory maps each backend/docs capability to GUI status: visible, configurable, disabled with explanation, developer-only, or missing.
-- [ ] Each missing or misleading GUI surface is linked to a User Story in this PRD.
-- [ ] No capability is marked production-ready unless the GUI can configure/status-check it or docs explicitly classify it as developer-only.
-- [ ] README and integration docs link to the inventory or summarize its production-facing conclusions.
+- [x] A committed inventory maps each backend/docs capability to GUI status: visible, configurable, disabled with explanation, developer-only, or missing.
+- [x] Each missing or misleading GUI surface is linked to a User Story in this PRD.
+- [x] No capability is marked production-ready unless the GUI can configure/status-check it or docs explicitly classify it as developer-only.
+- [x] README and integration docs link to the inventory or summarize its production-facing conclusions.
 - [ ] All relevant GitHub checks pass.
 
-- [ ] A committed migration appendix identifies every current capability/tool registry, its authority, consumers, duplicate metadata, and the target adapter into the future canonical Capability Registry.
-- [ ] Every inventoried capability records source, enabled state, required permissions, health state, operation type (read/mutate), risk tier, and verification support.
-- [ ] SMS remains backend/direct-route compatible but is explicitly absent from primary navigation.
+- [x] A committed migration appendix identifies every current capability/tool registry, its authority, consumers, duplicate metadata, and the target adapter into the future canonical Capability Registry.
+- [x] Every inventoried capability records source, enabled state, required permissions, health state, operation type (read/mutate), risk tier, and verification support.
+- [x] SMS remains backend/direct-route compatible but is explicitly absent from primary navigation.
 
 **Validation commands:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This README reflects the current milestone after recent live testing and repair 
 
 ## Capabilities & Status
 
-This is the high-level release/status view. Surface classifications mirror [SURFACE-CLASSIFICATION.md](SURFACE-CLASSIFICATION.md); integration evidence states mirror [INTEGRATIONS_STATUS.md](INTEGRATIONS_STATUS.md). The complete UI inventory is [docs/UI_SURFACES.md](docs/UI_SURFACES.md). Lower-level compatibility wrappers remain enumerated only in the detailed surface inventory.
+This is the high-level release/status view. Surface classifications mirror [SURFACE-CLASSIFICATION.md](SURFACE-CLASSIFICATION.md); integration evidence states mirror [INTEGRATIONS_STATUS.md](INTEGRATIONS_STATUS.md). The complete UI inventory is [docs/UI_SURFACES.md](docs/UI_SURFACES.md), and the backend-to-Electron capability parity and migration inventory is [docs/CAPABILITY-PARITY.md](docs/CAPABILITY-PARITY.md). Lower-level compatibility wrappers remain enumerated only in the detailed surface inventory.
 
 | Capability / surface | Release status | Current contract | Details |
 |---|---|---|---|

--- a/SURFACE-CLASSIFICATION.md
+++ b/SURFACE-CLASSIFICATION.md
@@ -45,6 +45,8 @@ The mobile API gateway is a CLI subcommand, not a `[project.scripts]` console sc
 | Surface | Classification | Notes |
 |---------|----------------|-------|
 | `gui/` (React + Electron desktop app) | `shippable` | Primary user-facing release artifact. The supported install path for end users. |
+
+Capability presence is tracked separately from surface classification. See [docs/CAPABILITY-PARITY.md](docs/CAPABILITY-PARITY.md) for whether each backend/docs capability is visible, configurable, disabled with explanation, developer-only, or missing in the Electron product, plus the owning follow-up story for each gap.
 | `rex/ui/` (Vite/React developer dashboard) | `developer-only` | Confirmed developer-only by `package.json` description: "Developer-only surface. Not included in packaged Electron app." Served by `rex-gui` at `/ui/`. Not bundled in the packaged Electron installer. |
 
 ---

--- a/docs/CAPABILITY-PARITY.md
+++ b/docs/CAPABILITY-PARITY.md
@@ -1,0 +1,74 @@
+# Capability parity inventory
+
+> **Release-truth inventory for US-064.** This document maps current AskRex capability authorities to the primary Electron product surface. Backend code, a CLI route, or an OpenClaw tool does not by itself make a capability production-ready. Runtime evidence states remain defined by `INTEGRATIONS_STATUS.md`.
+
+## Status vocabulary
+
+- **visible**: present in the primary Electron UI, but may still require configuration or live verification.
+- **configurable**: Electron exposes the settings needed to configure the supported path.
+- **disabled with explanation**: Electron may show the capability, but the unavailable action must be disabled and explain what is missing.
+- **developer-only**: intentionally available through CLI/backend/operator surfaces, not the primary packaged UI.
+- **missing**: backend/docs capability exists but the intended Electron surface is not yet present or truthful.
+
+Enabled state is evidence-based: `configured` means required values are stored; it does not imply `authenticated`, `write_capable`, or `verified`. Risk uses the current product convention: **low** for read-only/non-consequential work, **sensitive** for user-data or external mutations requiring permission/confirmation, and **prohibited** where policy denies the action.
+
+## Capability parity matrix
+
+| Capability | Current source / authority | Electron GUI status | Enabled-state evidence | Required permissions | Health evidence | Operation | Risk | Verification support | Gap owner |
+|---|---|---|---|---|---|---|---|---|---|
+| Text chat | `rex.assistant`, chat bridges, Electron chat handlers | visible | session identity + available model path | authenticated local user/session | reply/error event | read + generated response | low | response delivered to requesting session | US-094 to US-097 converge runtime contract |
+| Voice interaction | `rex.voice_loop`, voice bridges, Electron voice handlers | visible | microphone/TTS/wake configuration | microphone + explicit user identity | structured voice/runtime state | read + local audio output | sensitive | partial automated evidence; physical mic/speaker remains external | US-068 to US-070, US-074, US-079, US-100, US-102, US-103 |
+| Home Assistant | Electron `integrationInventory.ts`, `rex.home_assistant`, OpenClaw HA tool | configurable | saved base URL/token plus live auth state | authenticated HA credentials; confirmation for sensitive writes | canonical integration state + mutation result | read + mutate | sensitive | writes distinguish verified / attempted-unverified / denied / failed | US-080 improves UX; existing verification contract retained |
+| Email | Electron integration settings, IMAP/SMTP backend, OpenClaw email tool | visible; send disabled with explanation | account/server credentials | account credentials; send permission for external mutation | configured/auth evidence where supported | read + draft; backend send path exists | sensitive | GUI does not claim send success; draft/copy only | US-065 configure truth; US-081 Outlook end-to-end |
+| Outlook / Microsoft Graph | docs/provider code references | missing | unavailable until Graph OAuth is implemented and verified | Microsoft OAuth scopes | none production-grade today | read + mutate target | sensitive | unavailable; must not claim connected | US-081 |
+| Calendar / ICS | Electron integration settings + backend calendar provider | configurable | ICS/provider configuration | calendar read credentials | configured/read evidence | read | sensitive | reads can be evidenced; provider writes unavailable | US-065; US-081 for Outlook path |
+| SMS (Twilio) | backend/direct route + OpenClaw `sms_tool.py` | developer-only in primary navigation | complete Twilio credentials + tested write capability | Twilio credentials + external-send permission | integration state; delivery remains external | mutate | sensitive | no delivery claim without provider evidence | US-082; primary navigation intentionally remains absent |
+| Phone (Twilio) | backend integration inventory | configurable/experimental settings, not a primary workflow | complete Twilio credentials | Twilio credentials + call permission | configuration/test evidence only | mutate | sensitive | live calling externally verified | US-065 / US-082 policy truth |
+| Web search | search provider config + SerpAPI/Brave credential references | visible in Integrations; configuration path is incomplete/misleading | stored provider key only proves configured | provider API credential | no general connected proof from stored key | read | low | result freshness/provider failures must be surfaced | US-065 configure truth; US-077 current-info routing |
+| OpenAI | Electron AI settings + provider client | configurable | stored API key | provider credential | live request required | read/generate | low | provider response/error | US-071 provider persistence; US-110/US-111 routing/reliability |
+| OpenRouter | provider/runtime config | missing or non-parity in current Electron inventory | stored key/config if present | provider credential | live request required | read/generate | low | provider response/error | US-071, US-110, US-111 |
+| Ollama | Electron AI settings + runtime provider | configurable | configured base URL/model | local endpoint access | endpoint/model discovery required | read/generate | low | live local request | US-072 discovery; US-099 warm runtime |
+| LM Studio | runtime/provider support | missing configuration parity | configured endpoint/model if manually supplied | local endpoint access | endpoint/model discovery required | read/generate | low | live local request | US-072 |
+| OpenClaw gateway | `rex.openclaw`, Electron integration inventory | configurable, experimental | gateway URL + vault token; disabled by default | gateway credential + Rex permission policy | GUI may prove reachable; auth/tool capability remain separate | read + mutate depending tool | sensitive | Rex remains authority; each consequential tool result must be verified | US-113 dynamic sync; US-114 reconnect/verification |
+| OpenClaw registered tools | `rex/openclaw/tool_registry.py`, `rex/openclaw/tools/*` | developer-only unless separately surfaced | registry metadata + provider configuration | per-tool policy/credentials | registry health checks vary by tool | read + mutate | low/sensitive by tool | tool-specific verification; metadata never widens authority | US-106 canonical registry; US-107 permission retrieval; US-113 sync |
+| Shopping list | shopping bridge/backend user data | visible capability path is incomplete across chat/voice | scoped user/session data | authenticated user; household rules where applicable | local persistence result | read + mutate | sensitive | verify persisted list mutation | US-084 |
+| Memory | memory APIs/bridges and scoped stores | visible in parts; controls incomplete | explicit user/household scope | authenticated identity + memory scope | persistence/retrieval evidence | read + mutate | sensitive | scoped write/readback where applicable | US-085; US-087 identity unification; US-105/US-112 caching/experience memory |
+| Profiles / users | profile store + Electron Users/Profile surfaces | visible; identity semantics not fully unified | explicit session/profile identity | authenticated user; admin/owner for cross-user changes | profile read/write result | read + mutate | sensitive | fail-closed identity and scoped persistence | US-066 avatar/settings split; US-087 unification |
+| Chat history | history bridges/store | missing selectable per-user product surface | authenticated user scope | user identity | persisted conversation records | read + mutate/delete | sensitive | scoped retrieval/deletion evidence | US-083; US-087 |
+| Document upload / indexing | file extract/vector backend paths | missing | none production-ready until scoped indexing is exposed | user identity + file permission + memory/index scope | parse/index result | read + mutate index | sensitive | index success must be scoped and queryable | US-086 |
+| Telegram | Electron integration inventory | configurable/experimental | chat ID + vault bot token | Telegram bot credential | limited configuration evidence | mutate/notify | sensitive | delivery externally verified | US-065 configure truth |
+| MQTT | Electron inventory placeholder | disabled with explanation / unimplemented configuration | currently false in Electron inventory | broker credential if implemented | unavailable today | read + mutate target | sensitive | none production-grade | US-065 |
+| Push notifications | Electron inventory placeholder | disabled with explanation / unimplemented configuration | currently false in Electron inventory | notification provider/device permission | unavailable today | mutate/notify | sensitive | none production-grade | US-065; mobile notification work remains outside current capability claim |
+| Browser automation | CLI/OpenClaw/operator tooling | developer-only | environment/tool availability | explicit desktop/browser permission | tool execution evidence | read + mutate | sensitive | action-specific verification | US-106/US-109 registry/action lifecycle |
+| Windows / desktop control | CLI/operator tools and Desktop Commander style adapters | developer-only | local environment availability | explicit desktop permission | tool execution evidence | mutate | sensitive | action-specific verification | US-106/US-109 |
+| WordPress | OpenClaw WordPress tool | developer-only | site credentials/config | site credential + permission | health/read result | mostly read | sensitive | live site remains externally verified | US-106/US-113 |
+| WooCommerce | OpenClaw WooCommerce tool | developer-only | store credentials/config | store credential + approval for writes | health/read result | read + mutate | sensitive | approval-gated writes require result verification | US-106/US-109/US-113 |
+| Plex | OpenClaw Plex tool | developer-only | server/token config | Plex credential | live service health | read + mutate depending action | sensitive | hardware/service-dependent | US-106/US-113 |
+| Time / weather | OpenClaw/local tools | developer-only as direct tool cards; available through assistant routing | tool/provider availability | normally none or provider credential | tool response | read | low | response/error returned | US-106/US-107 |
+| Mobile API gateway | `rex.mobile_api` and mobile capability modules | developer-only backend; companion pre-release | JWT secret + paired device/session/grants | paired device + least-privilege scopes | truthful mobile capability endpoint | read + mutate only where implemented | sensitive | capability false for scaffolded endpoints; physical device still external | US-088; US-087 identity semantics |
+
+## Migration appendix: current registries to canonical Capability Registry
+
+US-106 owns the runtime consolidation. US-064 records the authorities and duplication that must be adapted rather than silently replaced.
+
+| Current registry / metadata source | Current authority and consumers | Duplicate or divergent metadata | Target adapter into canonical Capability Registry |
+|---|---|---|---|
+| `rex/capabilities/registry.py` | Python capability/profile feature registry; consumed by capability query/runtime code | capability name/description/enabled semantics overlap Electron and mobile representations | Python capability adapter preserving profile/enablement rules |
+| `rex/openclaw/tool_registry.py` | OpenClaw/Rex tool metadata, health checks, risk/tool execution consumers | tool name, description, health, availability and risk overlap capability metadata | tool adapter that contributes operations, risk, health and verification without granting authority |
+| `gui/src/main/integrationInventory.ts` | Electron integration/capability cards and settings/status consumers | names, configure routes, enabled state and health presentation are Electron-specific duplicates | Electron presentation adapter derived from canonical capability records plus local settings routes |
+| `rex/integration_state.py` and provider status helpers | canonical evidence vocabulary for integration readiness | state is sometimes re-expressed by GUI/tool-specific booleans | health/evidence adapter; retain evidence vocabulary as authoritative state semantics |
+| mobile capability/grant modules under `rex/mobile_*` | paired-device capabilities and least-privilege grants | mobile surface has a separate capability shape and false scaffolding flags | mobile adapter filters canonical records by device grants and implemented endpoint support |
+| CLI command registrations under `rex/cli_commands/` | command discovery and operator/developer entry points | command availability can be mistaken for product capability/readiness | CLI adapter maps commands to capability operations without changing GUI tier |
+| `SURFACE-CLASSIFICATION.md` and `INTEGRATIONS_STATUS.md` | release classification and integration support contracts | documentation can drift from runtime registries | generated/validated documentation view sourced from canonical registry plus release-evidence annotations |
+
+### Canonical record fields required by US-106
+
+The future registry must be able to express, at minimum: stable capability ID/name, source/provider, product tier/surface visibility, enabled/configured state, required permissions/scopes, health/evidence state, supported operations (read/mutate), risk tier, verification contract, configure/status route where applicable, and adapter/provider-specific metadata. A consumer may narrow a capability based on identity, permissions, device grants, or health; it must never widen authority from metadata alone.
+
+## Production-facing conclusions
+
+1. Electron is the primary shippable user surface, but it is not yet at parity with every backend/CLI/OpenClaw capability.
+2. OpenClaw is optional and experimental. Its registry supplies capability candidates, not permission or verification authority.
+3. Stored credentials mean only `configured`; production-ready claims require an appropriate GUI/status surface or an explicit `developer-only` classification.
+4. SMS remains callable through backend/direct routes where configured and permitted, but it is intentionally absent from primary navigation.
+5. Mobile remains paired, least-privilege, and pre-release; false capability flags for unimplemented endpoints are correct behavior, not missing production claims.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1671,3 +1671,16 @@ Local evidence:
 - Final acceptance sweep: 64 latency/voice/tool/RexBench tests passed; Electron chat latency: 2 passed; full GUI TypeScript typecheck passed.
 - Deprecated-API guard, compileall, Ruff, Black, mypy, and `git diff --check` all passed.
 - Relevant GitHub checks remain pending the US-075 story PR; that final checkbox intentionally remains open.
+
+2026-08-09 - US-064 Electron capability parity inventory
+
+Implementation:
+- Added `docs/CAPABILITY-PARITY.md` as the release-truth matrix mapping backend/docs capabilities to Electron visibility/configurability/developer-only/missing status.
+- Recorded source authority, enabled-state evidence, permissions, health evidence, operation class, risk tier, verification support, and owning follow-up story for each capability.
+- Added the migration appendix mapping current Python, OpenClaw, Electron, integration-state, mobile, CLI, and documentation metadata sources into the future canonical Capability Registry owned by US-106.
+- Linked the inventory from README, the canonical integration contract, and surface classification so backend existence is not mistaken for production-ready Electron support.
+- Preserved SMS as a backend/direct-route capability while explicitly keeping it out of primary navigation.
+
+Local evidence:
+- Documentation acceptance checks passed: required capability terms, matrix evidence fields, migration appendix, SMS navigation contract, and documentation links were all present; `git diff --check` passed.
+- GitHub checks remain pending until the US-064 branch is pushed; the final PRD checkbox intentionally remains open until independent CI evidence passes.


### PR DESCRIPTION
## Summary
- add backend/docs-to-Electron capability parity inventory
- map capability authorities and future canonical-registry adapters
- link release truth from README, integration status, and surface classification
- preserve SMS as backend/direct-route while absent from primary navigation

## Local validation
- required capability/evidence fields present
- migration appendix present
- SMS navigation contract present
- git diff --check passes

Tracks US-064 in PRD-production-readiness.md.