### PR TITLE
feat(runtime): define canonical turn contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,8 @@ Home Assistant safety:
 
 - `PRD-production-readiness.md` is the single authoritative tracker for the current integrated production-readiness/Rex 2.0 work. For remaining work, follow its dated `Integrated execution order` rather than raw story file position. Planned Rex 2.0 contracts are not implemented behavior until their individual story is merged and verified.
 
+- `rex.runtime` is the canonical interface-agnostic turn contract layer. `TurnContext` owns immutable validated identity/scope, origin/response mode, monotonic timing/deadline, and authorization snapshot references; `TurnEventStream` owns ordered correlated events and exactly one terminal outcome; `TurnEngine` preserves wrapped return/exception behavior while emitting those events. Do not claim CLI/Electron/voice/mobile/API parity until US-095 through US-097 migrate those surfaces.
+
 - Prefer clear, testable functions over clever code.
 - Keep changes small and reviewable.
 - Add logging for non-trivial behavior.

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2199,7 +2199,7 @@ cd gui && npm run typecheck && npm run build
 - [x] Each missing or misleading GUI surface is linked to a User Story in this PRD.
 - [x] No capability is marked production-ready unless the GUI can configure/status-check it or docs explicitly classify it as developer-only.
 - [x] README and integration docs link to the inventory or summarize its production-facing conclusions.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 - [x] A committed migration appendix identifies every current capability/tool registry, its authority, consumers, duplicate metadata, and the target adapter into the future canonical Capability Registry.
 - [x] Every inventoried capability records source, enabled state, required permissions, health state, operation type (read/mutate), risk tier, and verification support.
@@ -3271,11 +3271,11 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 **Files/areas likely involved:** `rex/runtime/turn.py`, `rex/runtime/events.py`, `rex/runtime/turn_engine.py`, `rex/assistant.py`, `tests/rex2/`.
 
 **Acceptance Criteria:**
-- [ ] TurnContext has a unique turn ID, immutable validated user ID/scope, source/device/response mode, monotonic timing/deadline context, and policy/permission snapshot reference.
-- [ ] Typed ordered events cover turn start, context/route/capability/action/model/response progress and exactly one terminal `completed`, `failed`, or `cancelled` event.
-- [ ] Event timestamps/order/correlation are deterministic; terminal double-emission fails closed.
-- [ ] TurnEngine initially wraps existing components without changing public behavior or bypassing identity/security checks.
-- [ ] Tests prove identity immutability and concurrent-user event isolation.
+- [x] TurnContext has a unique turn ID, immutable validated user ID/scope, source/device/response mode, monotonic timing/deadline context, and policy/permission snapshot reference.
+- [x] Typed ordered events cover turn start, context/route/capability/action/model/response progress and exactly one terminal `completed`, `failed`, or `cancelled` event.
+- [x] Event timestamps/order/correlation are deterministic; terminal double-emission fails closed.
+- [x] TurnEngine initially wraps existing components without changing public behavior or bypassing identity/security checks.
+- [x] Tests prove identity immutability and concurrent-user event isolation.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_turn_contracts.py -q`; `mypy rex/runtime --ignore-missing-imports`; `ruff check rex/runtime tests/rex2/test_turn_contracts.py`.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1684,3 +1684,21 @@ Implementation:
 Local evidence:
 - Documentation acceptance checks passed: required capability terms, matrix evidence fields, migration appendix, SMS navigation contract, and documentation links were all present; `git diff --check` passed.
 - GitHub checks remain pending until the US-064 branch is pushed; the final PRD checkbox intentionally remains open until independent CI evidence passes.
+
+
+2026-08-09 - US-094 canonical TurnEngine contracts and event runtime
+
+Implementation:
+- Added `rex/runtime/turn.py` with immutable validated `TurnContext`, unique turn IDs, typed source/scope/response mode, monotonic start/deadline context, and immutable policy/permission snapshot references.
+- Added `rex/runtime/events.py` with ordered correlated progress events covering turn/context/route/capability/action/model/response stages plus exactly one completed/failed/cancelled terminal outcome; post-terminal emission fails closed and observer failures cannot alter wrapped operation behavior.
+- Added `rex/runtime/turn_engine.py` as an initial facade that returns the wrapped operation result unchanged, re-raises the original failure, and emits canonical lifecycle events as a side channel. Existing Assistant surfaces are intentionally not migrated until US-095 through US-097.
+- Added `tests/rex2/test_turn_contracts.py` for identity immutability, deterministic event order/timestamps/correlation, terminal enforcement, preserved success/failure behavior, and concurrent James/Cole event isolation.
+- Updated CLAUDE.md with the new runtime contract invariant and preserved the no-parity-before-migration rule.
+
+Local evidence:
+- TDD red phase first proved `rex.runtime` was absent, then proved the typed contract imports were absent before implementation.
+- `pytest tests/rex2/test_turn_contracts.py -q`: 10 passed on Python 3.11.9, including direct-construction scope validation and observer-failure isolation.
+- `pytest tests/test_identity.py tests/test_assistant.py -q`: 84 passed on Python 3.11.9.
+- Ruff and Black pass on `rex/runtime` and `tests/rex2/test_turn_contracts.py`; mypy reports no issues in 4 runtime source files.
+- US-064 PR #375 full CI, including Python 3.11 Tests & Coverage, subsequently completed successfully; its final PRD CI criterion is now closed.
+- US-094 GitHub checks remain pending until this story PR is pushed; its final PRD checkbox intentionally remains open.

--- a/rex/runtime/__init__.py
+++ b/rex/runtime/__init__.py
@@ -1,0 +1,24 @@
+"""Canonical interface-agnostic turn runtime contracts."""
+
+from rex.runtime.events import EventKind, TerminalStateError, TurnEvent, TurnEventStream
+from rex.runtime.turn import (
+    AuthorizationSnapshotRef,
+    ResponseMode,
+    TurnContext,
+    TurnScope,
+    TurnSource,
+)
+from rex.runtime.turn_engine import TurnEngine
+
+__all__ = [
+    "AuthorizationSnapshotRef",
+    "EventKind",
+    "ResponseMode",
+    "TerminalStateError",
+    "TurnContext",
+    "TurnEngine",
+    "TurnEvent",
+    "TurnEventStream",
+    "TurnScope",
+    "TurnSource",
+]

--- a/rex/runtime/events.py
+++ b/rex/runtime/events.py
@@ -1,0 +1,125 @@
+"""Ordered, correlated event contracts for assistant turns."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from threading import Lock
+from types import MappingProxyType
+from typing import Any
+
+from rex.runtime.turn import TurnContext
+
+logger = logging.getLogger(__name__)
+
+
+class EventKind(StrEnum):
+    TURN_STARTED = "turn_started"
+    CONTEXT_PROGRESS = "context_progress"
+    ROUTE_PROGRESS = "route_progress"
+    CAPABILITY_PROGRESS = "capability_progress"
+    ACTION_PROGRESS = "action_progress"
+    MODEL_PROGRESS = "model_progress"
+    RESPONSE_PROGRESS = "response_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+TERMINAL_EVENT_KINDS = frozenset({EventKind.COMPLETED, EventKind.FAILED, EventKind.CANCELLED})
+
+
+class TerminalStateError(RuntimeError):
+    """The turn already emitted a terminal event."""
+
+
+@dataclass(frozen=True, slots=True)
+class TurnEvent:
+    """One immutable event correlated to one validated turn."""
+
+    kind: EventKind
+    turn_id: str
+    user_id: str
+    sequence: int
+    monotonic_ns: int
+    details: Mapping[str, Any]
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.kind in TERMINAL_EVENT_KINDS
+
+
+EventObserver = Callable[[TurnEvent], None]
+
+
+class TurnEventStream:
+    """Emit strictly ordered events for one turn and fail closed after terminal."""
+
+    def __init__(
+        self,
+        context: TurnContext,
+        *,
+        clock: Callable[[], int] = time.monotonic_ns,
+        observer: EventObserver | None = None,
+    ) -> None:
+        self.context = context
+        self._clock = clock
+        self._observer = observer
+        self._sequence = 0
+        self._last_monotonic_ns: int | None = None
+        self._terminal_event: TurnEvent | None = None
+        self._lock = Lock()
+
+    @property
+    def is_terminal(self) -> bool:
+        return self._terminal_event is not None
+
+    @property
+    def terminal_event(self) -> TurnEvent | None:
+        return self._terminal_event
+
+    def emit(self, kind: EventKind | str, details: Mapping[str, Any] | None = None) -> TurnEvent:
+        resolved = EventKind(kind)
+        if resolved in TERMINAL_EVENT_KINDS:
+            raise ValueError("terminal events must use finish()")
+        return self._record(resolved, details)
+
+    def finish(self, kind: EventKind | str, details: Mapping[str, Any] | None = None) -> TurnEvent:
+        resolved = EventKind(kind)
+        if resolved not in TERMINAL_EVENT_KINDS:
+            raise ValueError("finish() requires a terminal event kind")
+        return self._record(resolved, details)
+
+    def _record(self, kind: EventKind, details: Mapping[str, Any] | None) -> TurnEvent:
+        with self._lock:
+            if self._terminal_event is not None:
+                raise TerminalStateError(f"turn {self.context.turn_id} is already terminal")
+            timestamp = self._clock()
+            if self._last_monotonic_ns is not None and timestamp < self._last_monotonic_ns:
+                raise ValueError("turn event clock moved backwards")
+            self._sequence += 1
+            event = TurnEvent(
+                kind=kind,
+                turn_id=self.context.turn_id,
+                user_id=self.context.user_id,
+                sequence=self._sequence,
+                monotonic_ns=timestamp,
+                details=MappingProxyType(dict(details or {})),
+            )
+            self._last_monotonic_ns = timestamp
+            if event.is_terminal:
+                self._terminal_event = event
+            observer = self._observer
+        if observer is not None:
+            try:
+                observer(event)
+            except Exception:
+                logger.exception(
+                    "Turn event observer failed for turn %s sequence %s",
+                    event.turn_id,
+                    event.sequence,
+                )
+        return event

--- a/rex/runtime/turn.py
+++ b/rex/runtime/turn.py
@@ -1,0 +1,125 @@
+"""Immutable context contracts for one assistant turn."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+from rex.identity import validate_user_id
+
+
+class TurnScope(StrEnum):
+    """Data/authority scope associated with a turn."""
+
+    USER = "user"
+    HOUSEHOLD = "household"
+
+
+class TurnSource(StrEnum):
+    """Interface that originated a turn."""
+
+    CLI = "cli"
+    ELECTRON = "electron"
+    VOICE = "voice"
+    MOBILE = "mobile"
+    API = "api"
+
+
+class ResponseMode(StrEnum):
+    """Delivery mode requested by the originating surface."""
+
+    VOICE = "voice"
+    SCREEN = "screen"
+    HYBRID = "hybrid"
+    AUTOMATION = "automation"
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationSnapshotRef:
+    """Immutable references to policy and permission snapshots."""
+
+    policy_ref: str
+    permission_ref: str
+
+    def __post_init__(self) -> None:
+        if not self.policy_ref.strip():
+            raise ValueError("policy_ref must not be empty")
+        if not self.permission_ref.strip():
+            raise ValueError("permission_ref must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class TurnContext:
+    """Validated identity, timing, and delivery context for one turn."""
+
+    turn_id: str
+    user_id: str
+    scope: TurnScope
+    source: TurnSource
+    device_id: str | None
+    response_mode: ResponseMode
+    authorization: AuthorizationSnapshotRef
+    started_monotonic_ns: int
+    deadline_monotonic_ns: int | None = None
+
+    def __post_init__(self) -> None:
+        validate_user_id(self.user_id)
+        try:
+            object.__setattr__(self, "scope", TurnScope(self.scope))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid turn scope: {self.scope!r}") from exc
+        try:
+            object.__setattr__(self, "source", TurnSource(self.source))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid turn source: {self.source!r}") from exc
+        try:
+            object.__setattr__(self, "response_mode", ResponseMode(self.response_mode))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid response mode: {self.response_mode!r}") from exc
+        if not self.turn_id.strip():
+            raise ValueError("turn_id must not be empty")
+        if self.started_monotonic_ns < 0:
+            raise ValueError("started_monotonic_ns must be non-negative")
+        if (
+            self.deadline_monotonic_ns is not None
+            and self.deadline_monotonic_ns < self.started_monotonic_ns
+        ):
+            raise ValueError("deadline_monotonic_ns precedes turn start")
+        if self.device_id is not None and not self.device_id.strip():
+            raise ValueError("device_id must be non-empty when supplied")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        user_id: str,
+        scope: TurnScope | str,
+        source: TurnSource | str,
+        device_id: str | None,
+        response_mode: ResponseMode | str,
+        authorization: AuthorizationSnapshotRef,
+        timeout_seconds: float | None = None,
+        clock: Callable[[], int] = time.monotonic_ns,
+    ) -> TurnContext:
+        """Create a validated context using a monotonic deadline."""
+        validated_user = validate_user_id(user_id)
+        if timeout_seconds is not None and timeout_seconds < 0:
+            raise ValueError("timeout_seconds must be non-negative")
+        started_ns = clock()
+        deadline_ns = None
+        if timeout_seconds is not None:
+            deadline_ns = started_ns + int(timeout_seconds * 1_000_000_000)
+        return cls(
+            turn_id=uuid.uuid4().hex,
+            user_id=validated_user,
+            scope=TurnScope(scope),
+            source=TurnSource(source),
+            device_id=device_id,
+            response_mode=ResponseMode(response_mode),
+            authorization=authorization,
+            started_monotonic_ns=started_ns,
+            deadline_monotonic_ns=deadline_ns,
+        )

--- a/rex/runtime/turn_engine.py
+++ b/rex/runtime/turn_engine.py
@@ -1,0 +1,38 @@
+"""Initial interface-agnostic TurnEngine facade."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+from rex.runtime.events import EventKind, EventObserver, TurnEventStream
+from rex.runtime.turn import TurnContext
+
+T = TypeVar("T")
+
+
+class TurnEngine:
+    """Wrap existing work with canonical events without changing its result contract."""
+
+    def __init__(self, *, clock: Callable[[], int] = time.monotonic_ns) -> None:
+        self._clock = clock
+
+    def execute(
+        self,
+        context: TurnContext,
+        operation: Callable[[TurnEventStream], T],
+        *,
+        on_event: EventObserver | None = None,
+    ) -> T:
+        stream = TurnEventStream(context, clock=self._clock, observer=on_event)
+        stream.emit(EventKind.TURN_STARTED)
+        try:
+            result = operation(stream)
+        except Exception as exc:
+            if not stream.is_terminal:
+                stream.finish(EventKind.FAILED, {"exception_type": type(exc).__name__})
+            raise
+        if not stream.is_terminal:
+            stream.finish(EventKind.COMPLETED)
+        return result

--- a/tests/rex2/test_turn_contracts.py
+++ b/tests/rex2/test_turn_contracts.py
@@ -1,0 +1,174 @@
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError, replace
+from importlib.util import find_spec
+from itertools import count
+
+import pytest
+
+from rex.runtime.events import EventKind, TerminalStateError, TurnEventStream
+from rex.runtime.turn import (
+    AuthorizationSnapshotRef,
+    ResponseMode,
+    TurnContext,
+    TurnScope,
+    TurnSource,
+)
+from rex.runtime.turn_engine import TurnEngine
+
+
+def _context(user_id: str = "james") -> TurnContext:
+    return TurnContext.create(
+        user_id=user_id,
+        scope=TurnScope.USER,
+        source=TurnSource.ELECTRON,
+        device_id="desktop-1",
+        response_mode=ResponseMode.SCREEN,
+        authorization=AuthorizationSnapshotRef(
+            policy_ref="policy:v1",
+            permission_ref=f"permissions:{user_id}:v1",
+        ),
+    )
+
+
+def test_turn_runtime_modules_exist() -> None:
+    assert find_spec("rex.runtime.turn") is not None
+    assert find_spec("rex.runtime.events") is not None
+    assert find_spec("rex.runtime.turn_engine") is not None
+
+
+def test_turn_context_validates_identity_and_is_immutable() -> None:
+    context = TurnContext.create(
+        user_id="james",
+        scope=TurnScope.USER,
+        source=TurnSource.VOICE,
+        device_id="kitchen-mic",
+        response_mode=ResponseMode.VOICE,
+        authorization=AuthorizationSnapshotRef("policy:v2", "permissions:james:v5"),
+        timeout_seconds=2.0,
+        clock=lambda: 1_000,
+    )
+
+    assert context.user_id == "james"
+    assert context.started_monotonic_ns == 1_000
+    assert context.deadline_monotonic_ns == 2_000_001_000
+    with pytest.raises(FrozenInstanceError):
+        context.user_id = "cole"  # type: ignore[misc]
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        _context("../cole")
+
+
+def test_turn_ids_are_unique() -> None:
+    assert _context().turn_id != _context().turn_id
+
+
+def test_event_stream_orders_and_correlates_all_progress_stages() -> None:
+    ticks = count(100, 10)
+    context = _context()
+    events = TurnEventStream(context, clock=lambda: next(ticks))
+    kinds = [
+        EventKind.TURN_STARTED,
+        EventKind.CONTEXT_PROGRESS,
+        EventKind.ROUTE_PROGRESS,
+        EventKind.CAPABILITY_PROGRESS,
+        EventKind.ACTION_PROGRESS,
+        EventKind.MODEL_PROGRESS,
+        EventKind.RESPONSE_PROGRESS,
+    ]
+    emitted = [events.emit(kind) for kind in kinds]
+    emitted.append(events.finish(EventKind.COMPLETED))
+
+    assert [event.sequence for event in emitted] == list(range(1, 9))
+    assert [event.monotonic_ns for event in emitted] == list(range(100, 180, 10))
+    assert all(event.turn_id == context.turn_id for event in emitted)
+    assert all(event.user_id == "james" for event in emitted)
+    assert emitted[-1].is_terminal is True
+
+
+def test_terminal_state_fails_closed() -> None:
+    events = TurnEventStream(_context())
+    events.emit(EventKind.TURN_STARTED)
+    events.finish(EventKind.CANCELLED, {"reason": "caller_cancelled"})
+
+    with pytest.raises(TerminalStateError):
+        events.finish(EventKind.COMPLETED)
+    with pytest.raises(TerminalStateError):
+        events.emit(EventKind.RESPONSE_PROGRESS)
+
+
+def test_turn_engine_preserves_success_value_and_emits_one_terminal() -> None:
+    observed = []
+
+    def operation(events: TurnEventStream) -> str:
+        events.emit(EventKind.ROUTE_PROGRESS, {"route": "direct"})
+        return "same-public-result"
+
+    result = TurnEngine().execute(_context(), operation, on_event=observed.append)
+
+    assert result == "same-public-result"
+    assert [event.kind for event in observed] == [
+        EventKind.TURN_STARTED,
+        EventKind.ROUTE_PROGRESS,
+        EventKind.COMPLETED,
+    ]
+    assert sum(event.is_terminal for event in observed) == 1
+
+
+def test_turn_engine_preserves_failure_and_emits_failed_terminal() -> None:
+    observed = []
+
+    class ExpectedFailure(RuntimeError):
+        pass
+
+    def operation(events: TurnEventStream) -> str:
+        events.emit(EventKind.MODEL_PROGRESS)
+        raise ExpectedFailure("provider failed")
+
+    with pytest.raises(ExpectedFailure, match="provider failed"):
+        TurnEngine().execute(_context(), operation, on_event=observed.append)
+
+    assert observed[-1].kind is EventKind.FAILED
+    assert sum(event.is_terminal for event in observed) == 1
+
+
+def test_concurrent_users_have_isolated_event_correlation() -> None:
+    engine = TurnEngine()
+
+    def run(user_id: str) -> tuple[TurnContext, list]:
+        context = _context(user_id)
+        observed = []
+        engine.execute(
+            context,
+            lambda stream: stream.emit(EventKind.CONTEXT_PROGRESS),
+            on_event=observed.append,
+        )
+        return context, observed
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        james_future = pool.submit(run, "james")
+        cole_future = pool.submit(run, "cole")
+        james_context, james_events = james_future.result()
+        cole_context, cole_events = cole_future.result()
+
+    assert james_context.turn_id != cole_context.turn_id
+    assert {event.user_id for event in james_events} == {"james"}
+    assert {event.user_id for event in cole_events} == {"cole"}
+    assert {event.turn_id for event in james_events} == {james_context.turn_id}
+    assert {event.turn_id for event in cole_events} == {cole_context.turn_id}
+
+
+def test_turn_context_rejects_invalid_scope_on_direct_construction() -> None:
+    with pytest.raises(ValueError, match="turn scope"):
+        replace(_context(), scope="global")  # type: ignore[arg-type]
+
+
+def test_event_observer_failure_does_not_change_wrapped_result() -> None:
+    def broken_observer(_event: object) -> None:
+        raise RuntimeError("observer unavailable")
+
+    result = TurnEngine().execute(
+        _context(),
+        lambda _events: "operation-result",
+        on_event=broken_observer,
+    )
+
+    assert result == "operation-result"


### PR DESCRIPTION
## Summary
- add immutable validated TurnContext contracts with unique IDs and monotonic deadlines
- add ordered correlated TurnEventStream with fail-closed terminal semantics
- add initial TurnEngine facade preserving wrapped return/exception behavior
- add concurrent-user and observer-failure contract coverage
- update CLAUDE.md, PRD-production-readiness.md, and progress evidence

## Local validation
- 10 passed: tests/rex2/test_turn_contracts.py
- 84 passed: tests/test_identity.py + tests/test_assistant.py
- ruff check rex/runtime tests/rex2/test_turn_contracts.py
- black --check rex/runtime tests/rex2/test_turn_contracts.py
- mypy rex/runtime --ignore-missing-imports --no-incremental
- python -m compileall -q rex/runtime
- git diff --check

US-094 only. Surface migration remains explicitly deferred to US-095 through US-097.