### PR TITLE
feat(runtime): route generate_reply through turn engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Home Assistant safety:
 
 - `PRD-production-readiness.md` is the single authoritative tracker for the current integrated production-readiness/Rex 2.0 work. For remaining work, follow its dated `Integrated execution order` rather than raw story file position. Planned Rex 2.0 contracts are not implemented behavior until their individual story is merged and verified.
 
-- `rex.runtime` is the canonical interface-agnostic turn contract layer. `TurnContext` owns immutable validated identity/scope, origin/response mode, monotonic timing/deadline, and authorization snapshot references; `TurnEventStream` owns ordered correlated events and exactly one terminal outcome; `TurnEngine` preserves wrapped return/exception behavior while emitting those events. Do not claim CLI/Electron/voice/mobile/API parity until US-095 through US-097 migrate those surfaces.
+- `rex.runtime` is the canonical interface-agnostic turn contract layer. `TurnContext` owns immutable validated identity/scope, origin/response mode, monotonic timing/deadline, and authorization snapshot references; `TurnEventStream` owns ordered correlated events and exactly one terminal outcome; `TurnEngine` preserves wrapped return/exception behavior while emitting those events. `Assistant.generate_reply()` now runs through this engine; `stream_reply()` remains on the legacy streaming path until US-096, and interface adapter parity remains unclaimed until US-097.
 
 - Prefer clear, testable functions over clever code.
 - Keep changes small and reviewable.
@@ -305,10 +305,10 @@ Bridge compatibility wrappers (17) — exec canonical `bridge/<name>.py` in thei
 
 ### Assistant architecture
 
-`Assistant.generate_reply()` is a thin orchestrator. The pipeline is:
+`Assistant.generate_reply()` is the canonical non-streaming TurnEngine entry point. Identity is validated before the turn begins; all subsequent intent/cache/model routing, context building, action/tool dispatch, result verification, response building, and history recording run inside one correlated turn. `stream_reply()` is not yet migrated (US-096). The non-streaming pipeline is:
 
 ```
-Assistant → ContextBuilder → IntentRouter → ActionDispatcher → ResponseBuilder
+Assistant → TurnEngine → IntentRouter/Cache → ContextBuilder → ActionDispatcher → ResponseBuilder → History
 ```
 
 | Component | Module | Responsibility |

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -3276,7 +3276,7 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 - [x] Event timestamps/order/correlation are deterministic; terminal double-emission fails closed.
 - [x] TurnEngine initially wraps existing components without changing public behavior or bypassing identity/security checks.
 - [x] Tests prove identity immutability and concurrent-user event isolation.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_turn_contracts.py -q`; `mypy rex/runtime --ignore-missing-imports`; `ruff check rex/runtime tests/rex2/test_turn_contracts.py`.
 
@@ -3293,11 +3293,11 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 **Files/areas likely involved:** `rex/assistant.py`, `rex/runtime/turn_engine.py`, routing/context/action/response services, `tests/rex2/`.
 
 **Acceptance Criteria:**
-- [ ] `generate_reply()` delegates routing, context, capability/action execution, output validation, history, and final response production through TurnEngine.
-- [ ] Existing cache, ModelRouter request scope, ActionDispatcher/verification, ResponseBuilder, and fail-closed identity remain covered and observable through events.
-- [ ] Public callers keep the same final result shape except already-required truthful status corrections.
-- [ ] Regression tests cover direct answer, read-only tool, mutation/confirmation, model failure, and unavailable capability.
-- [ ] No direct model shortcut bypasses TurnEngine from `generate_reply()`.
+- [x] `generate_reply()` delegates routing, context, capability/action execution, output validation, history, and final response production through TurnEngine.
+- [x] Existing cache, ModelRouter request scope, ActionDispatcher/verification, ResponseBuilder, and fail-closed identity remain covered and observable through events.
+- [x] Public callers keep the same final result shape except already-required truthful status corrections.
+- [x] Regression tests cover direct answer, read-only tool, mutation/confirmation, model failure, and unavailable capability.
+- [x] No direct model shortcut bypasses TurnEngine from `generate_reply()`.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_generate_reply_turn_engine.py tests/test_assistant.py -q`; `mypy rex/assistant.py rex/runtime --ignore-missing-imports`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,11 +34,14 @@ selection (`cuda` vs `cpu`) is resolved at model-load time from
 ### LLM response handling
 
 The `Assistant` class in `rex/assistant.py` is the single entry point for
-generating replies. It injects system context, routes through the tool
-layer, and delegates raw model calls to the providers in
-`rex/llm_client.py` (local Transformers, OpenAI-compatible, Anthropic, or
-Ollama). The voice loop must always call `Assistant.generate_reply()`
-rather than the LLM client directly so tool routing is preserved.
+generating replies. Non-streaming `Assistant.generate_reply()` runs through
+`rex.runtime.TurnEngine`, which correlates intent/cache/model routing, context,
+action/tool dispatch, verification/post-processing, response assembly, and
+history under one immutable user-scoped turn. Raw model calls remain delegated
+to providers in `rex/llm_client.py` (local Transformers, OpenAI-compatible,
+Anthropic, or Ollama). `Assistant.stream_reply()` remains on the legacy
+streaming path until US-096. The voice loop must always call Assistant rather
+than the LLM client directly so tool routing and verification are preserved.
 
 ### Text-to-speech (TTS)
 

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1702,3 +1702,22 @@ Local evidence:
 - Ruff and Black pass on `rex/runtime` and `tests/rex2/test_turn_contracts.py`; mypy reports no issues in 4 runtime source files.
 - US-064 PR #375 full CI, including Python 3.11 Tests & Coverage, subsequently completed successfully; its final PRD CI criterion is now closed.
 - US-094 GitHub checks remain pending until this story PR is pushed; its final PRD checkbox intentionally remains open.
+
+
+2026-08-09 - US-095 generate_reply migrated onto TurnEngine
+
+Implementation:
+- Added async TurnEngine execution with the same success/failure/terminal semantics as the synchronous facade.
+- Routed every post-identity `Assistant.generate_reply()` path through one TurnEngine turn, including intent shortcuts, per-user cache hits, ModelRouter request scope, context construction, ActionDispatcher, ResponseBuilder, history, and final response.
+- Preserved fail-closed identity outside the engine boundary so missing/invalid identity still fails before turn events or private request state are touched.
+- Passed the canonical turn event stream into ActionDispatcher and added truthful capability/action/model/result-handler progress at real execution boundaries; neutral `returned` status never implies external verification.
+- Added `TurnSource.ASSISTANT` for interface-agnostic direct Assistant calls; adapters remain responsible for exact source/device attribution in US-097.
+- Updated CLAUDE.md and docs/ARCHITECTURE.md to state that non-streaming generate_reply is migrated while stream_reply remains legacy until US-096.
+
+Local evidence:
+- TDD red phase: 6 of 7 initial migration tests failed because generate_reply emitted no TurnEngine events; the existing missing-identity fail-closed case passed before migration.
+- `pytest tests/rex2/test_generate_reply_turn_engine.py -q`: 10 passed, covering direct answer, cache, read-only tool, mutation confirmation wording, model failure, unavailable capability, fail-closed identity ordering, real dispatcher event boundaries, no direct model shortcut, and no invented surface provenance from voice response mode.
+- Final runtime/identity/action/verification/documentation-truth sweep: 205 passed on Python 3.11.9.
+- Ruff and Black pass on touched runtime/assistant/dispatcher/tests; mypy reports no issues across assistant, dispatcher, and runtime modules.
+- US-094 PR #376 passed every relevant GitHub check, including full Python coverage and installed Windows Electron artifact smoke; its final PRD CI criterion is now closed.
+- US-095 GitHub checks remain pending until this story PR is pushed; its final PRD checkbox intentionally remains open.

--- a/rex/actions/dispatcher.py
+++ b/rex/actions/dispatcher.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from rex.latency import LatencyTrace
+from rex.runtime.events import EventKind, TurnEventStream
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +133,7 @@ class ActionDispatcher:
         user_id: str | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         latency_trace: LatencyTrace | None = None,
+        turn_events: TurnEventStream | None = None,
     ) -> ActionResult:
         """Dispatch *transcript* through all action layers and return an :class:`ActionResult`.
 
@@ -152,6 +154,8 @@ class ActionDispatcher:
                             ``"default"``.
             loop:           Running event loop; obtained via ``asyncio.get_running_loop()`` when
                             *None*.
+            turn_events:    Optional canonical turn event stream for truthful progress
+                            observation. It never grants or widens execution authority.
 
         Returns:
             :class:`ActionResult` with ``success=True`` and the final response string.
@@ -173,6 +177,10 @@ class ActionDispatcher:
             )
         effective_user = validate_user_id(effective_user)
 
+        def emit(kind: EventKind, details: dict[str, Any]) -> None:
+            if turn_events is not None:
+                turn_events.emit(kind, details)
+
         from rex.mobile_api.action_context import (  # noqa: PLC0415
             mobile_action_context_active,
             mobile_scope_granted,
@@ -189,6 +197,14 @@ class ActionDispatcher:
                 transcript, self._skill_registry
             )
             if training_response is not None:
+                emit(
+                    EventKind.CAPABILITY_PROGRESS,
+                    {"capability": "skill_training", "status": "selected"},
+                )
+                emit(
+                    EventKind.ACTION_PROGRESS,
+                    {"capability": "skill_training", "status": "returned"},
+                )
                 return ActionResult(
                     success=True,
                     response=str(training_response),
@@ -199,7 +215,15 @@ class ActionDispatcher:
         if self._skill_router is not None and not mobile_action_context_active():
             matched_skill = self._skill_router.match(transcript)
             if matched_skill is not None:
+                emit(
+                    EventKind.CAPABILITY_PROGRESS,
+                    {"capability": "skill_invocation", "status": "selected"},
+                )
                 skill_response = str(self._skill_router.execute(matched_skill, transcript))
+                emit(
+                    EventKind.ACTION_PROGRESS,
+                    {"capability": "skill_invocation", "status": "returned"},
+                )
                 return ActionResult(
                     success=True,
                     response=skill_response,
@@ -210,6 +234,13 @@ class ActionDispatcher:
         if self._shopping_list_handler is not None and mobile_scope_granted("tasks.write"):
             _sl_response = self._shopping_list_handler.handle(transcript, user_id=effective_user)
             if _sl_response is not None:
+                emit(
+                    EventKind.CAPABILITY_PROGRESS,
+                    {"capability": "shopping_list", "status": "selected"},
+                )
+                emit(
+                    EventKind.ACTION_PROGRESS, {"capability": "shopping_list", "status": "returned"}
+                )
                 return ActionResult(
                     success=True,
                     response=str(_sl_response),
@@ -220,6 +251,8 @@ class ActionDispatcher:
         if self._music_handler is not None and mobile_scope_granted("home.control"):
             _music_response = self._music_handler.handle(transcript)
             if _music_response is not None:
+                emit(EventKind.CAPABILITY_PROGRESS, {"capability": "music", "status": "selected"})
+                emit(EventKind.ACTION_PROGRESS, {"capability": "music", "status": "returned"})
                 return ActionResult(
                     success=True,
                     response=str(_music_response),
@@ -230,6 +263,13 @@ class ActionDispatcher:
         if self._device_state_handler is not None and mobile_scope_granted("home.read"):
             _ds_response = self._device_state_handler.handle(transcript)
             if _ds_response is not None:
+                emit(
+                    EventKind.CAPABILITY_PROGRESS,
+                    {"capability": "device_state", "status": "selected"},
+                )
+                emit(
+                    EventKind.ACTION_PROGRESS, {"capability": "device_state", "status": "returned"}
+                )
                 return ActionResult(
                     success=True,
                     response=str(_ds_response),
@@ -248,6 +288,14 @@ class ActionDispatcher:
                     tool for tool in _selected_tools if getattr(tool, "operation", "read") == "read"
                 ]
             if _selected_tools:
+                capability_names = [
+                    str(getattr(tool, "name", getattr(tool, "tool_name", "unknown")))
+                    for tool in _selected_tools
+                ]
+                emit(
+                    EventKind.CAPABILITY_PROGRESS,
+                    {"stage": "tool_selection", "capabilities": capability_names},
+                )
                 if latency_trace is not None:
                     latency_trace.start("tool")
                 try:
@@ -264,6 +312,10 @@ class ActionDispatcher:
                     if latency_trace is not None:
                         latency_trace.end("tool")
                 _tool_context = self._tool_dispatcher.format_tool_context(_tool_results) or None
+                emit(
+                    EventKind.ACTION_PROGRESS,
+                    {"stage": "tool_execution", "status": "returned", "count": len(_tool_results)},
+                )
 
         completion: str | None = None
 
@@ -274,6 +326,10 @@ class ActionDispatcher:
             and not mobile_action_context_active()
             and mobile_scope_granted("home.control")
         ):
+            emit(
+                EventKind.CAPABILITY_PROGRESS,
+                {"capability": "home_assistant", "status": "entered"},
+            )
             if latency_trace is not None:
                 latency_trace.start("tool")
             if _UNDO_PATTERN.match(transcript):
@@ -321,6 +377,11 @@ class ActionDispatcher:
                             pass
             if latency_trace is not None:
                 latency_trace.end("tool")
+            if completion is not None:
+                emit(
+                    EventKind.ACTION_PROGRESS,
+                    {"capability": "home_assistant", "status": "returned"},
+                )
 
         # 8. LLM call (if no pre-LLM handler produced a completion)
         if completion is None:
@@ -339,6 +400,10 @@ class ActionDispatcher:
             prompt = ctx.prompt
             if latency_trace is not None:
                 latency_trace.start("llm")
+            emit(
+                EventKind.MODEL_PROGRESS,
+                {"stage": "generation", "status": "started"},
+            )
             try:
                 try:
                     completion = await run_in_executor_with_mobile_context(
@@ -353,6 +418,10 @@ class ActionDispatcher:
             finally:
                 if latency_trace is not None:
                     latency_trace.end("llm")
+            emit(
+                EventKind.MODEL_PROGRESS,
+                {"stage": "generation", "status": "returned"},
+            )
 
             # 9. Post-process LLM output (TOOL_REQUEST resolution, OpenClaw bridge)
             plugin_enrichments: list[str] = []
@@ -379,6 +448,10 @@ class ActionDispatcher:
                     tool_context=tool_context_dict,
                     model_call_fn=model_call_fn,
                     plugin_enrichments=plugin_enrichments,
+                )
+                emit(
+                    EventKind.ACTION_PROGRESS,
+                    {"stage": "result_handler", "status": "returned"},
                 )
             finally:
                 if latency_trace is not None:

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -26,6 +26,15 @@ from .llm_client import LanguageModel
 from .memory import trim_history
 from .model_router import ModelRouter
 from .plugins import PluginSpec
+from .runtime.events import EventKind, EventObserver, TurnEventStream
+from .runtime.turn import (
+    AuthorizationSnapshotRef,
+    ResponseMode,
+    TurnContext,
+    TurnScope,
+    TurnSource,
+)
+from .runtime.turn_engine import TurnEngine
 from .runtime_paths import household_data_path
 
 logger = logging.getLogger(__name__)
@@ -171,6 +180,11 @@ class Assistant:
             ollama_base_url=_ollama_url,
             routing_config=_routing_cfg,
         )
+
+        # Canonical turn runtime. Surfaces remain adapters; generate_reply owns
+        # the shared non-streaming orchestration path from US-095 onward.
+        self._turn_engine = TurnEngine()
+        self._turn_event_observer: EventObserver | None = None
 
         # Route all tool calls through OpenClaw ToolBridge (US-P7-008)
         from .openclaw.tool_bridge import ToolBridge
@@ -824,6 +838,28 @@ class Assistant:
         if not stream_released:
             yield completion
 
+    def _get_or_create_turn_engine(self) -> TurnEngine:
+        """Return the canonical turn engine, creating it for legacy test shells."""
+        engine = getattr(self, "_turn_engine", None)
+        if engine is None:
+            engine = TurnEngine()
+            self._turn_engine = engine
+        return engine
+
+    def _build_turn_context(self, effective_user_id: str, *, voice_mode: bool) -> TurnContext:
+        """Create a turn context without widening existing runtime authority."""
+        return TurnContext.create(
+            user_id=effective_user_id,
+            scope=TurnScope.USER,
+            source=TurnSource.ASSISTANT,
+            device_id=None,
+            response_mode=ResponseMode.VOICE if voice_mode else ResponseMode.SCREEN,
+            authorization=AuthorizationSnapshotRef(
+                policy_ref="rex-policy:existing-runtime",
+                permission_ref=f"rex-permissions:validated-user:{effective_user_id}",
+            ),
+        )
+
     async def generate_reply(
         self,
         transcript: str,
@@ -831,93 +867,129 @@ class Assistant:
         voice_mode: bool = False,
         active_user_id: str | None = None,
     ) -> str:
-        """Orchestrate a full reply: identity → intent → cache → context → dispatch → response."""
-        loop = asyncio.get_running_loop()
-        # The user this turn belongs to: an explicit validated request
-        # identity, otherwise the explicit constructor identity.  Missing
-        # identity fails closed before intent routing, cache lookup, early
-        # returns, history, context, and tool dispatch (issue #303).
+        """Orchestrate one non-streaming reply through the canonical TurnEngine."""
+        # Identity remains outside the engine on purpose: invalid or missing identity
+        # must fail before turn events or any private request state are touched.
         effective_user_id = self._resolve_request_user_id(active_user_id)
-        self._ensure_followup_session(effective_user_id)
+        turn_context = self._build_turn_context(effective_user_id, voice_mode=voice_mode)
+        observer = getattr(self, "_turn_event_observer", None)
 
-        latency_provider, latency_model = self._latency_provider_model()
-        latency_trace = LatencyTrace(
-            channel="voice" if voice_mode else "chat",
-            provider=latency_provider,
-            model=latency_model,
-            settings_id="voice" if voice_mode else "text",
-        )
-        latency_trace.start("routing")
+        async def _run_turn(turn_events: TurnEventStream) -> str:
+            loop = asyncio.get_running_loop()
+            self._ensure_followup_session(effective_user_id)
+            latency_provider, latency_model = self._latency_provider_model()
+            latency_trace = LatencyTrace(
+                channel="voice" if voice_mode else "chat",
+                provider=latency_provider,
+                model=latency_model,
+                settings_id="voice" if voice_mode else "text",
+            )
+            latency_trace.start("routing")
 
-        # Route intent: capability queries, pending suggestions, time/date, greetings, recipes
-        _intent = self._get_or_create_intent_router().route(
-            transcript,
-            settings=self._settings,
-            suggestion_engine=getattr(self, "_suggestion_engine", None),
-            user_id=effective_user_id,
-        )
-        if _intent.handled:
-            # Greeting shortcuts are suppressed in multi-user voice sessions
-            if not (_intent.intent_type == "greeting" and active_user_id is not None):
+            _intent = self._get_or_create_intent_router().route(
+                transcript,
+                settings=self._settings,
+                suggestion_engine=getattr(self, "_suggestion_engine", None),
+                user_id=effective_user_id,
+            )
+            turn_events.emit(
+                EventKind.ROUTE_PROGRESS,
+                {
+                    "stage": "intent",
+                    "handled": bool(_intent.handled),
+                    "intent_type": _intent.intent_type or "unknown",
+                },
+            )
+            if _intent.handled and not (
+                _intent.intent_type == "greeting" and active_user_id is not None
+            ):
                 latency_trace.end("routing")
                 latency_trace.start("completion")
                 self._record_completion(transcript, _intent.response, user_id=effective_user_id)
+                turn_events.emit(
+                    EventKind.RESPONSE_PROGRESS,
+                    {"stage": "completed", "source": "intent", "history_recorded": True},
+                )
                 latency_trace.end("completion")
                 latency_trace.finish()
                 latency_trace.log_summary(logger, event="chat_latency")
-                return _intent.response  # type: ignore[no-any-return]
+                return cast(str, _intent.response)
 
-        # Fast path: return cached response without hitting the LLM.
-        # Lookup is confined to the effective user's cache partition.
-        _cached = self._get_or_create_response_builder().check_cache(
-            transcript, user_id=effective_user_id
-        )
-        if _cached is not None:
+            _cached = self._get_or_create_response_builder().check_cache(
+                transcript, user_id=effective_user_id
+            )
+            turn_events.emit(
+                EventKind.ROUTE_PROGRESS,
+                {"stage": "cache", "cache_hit": _cached is not None},
+            )
+            if _cached is not None:
+                latency_trace.end("routing")
+                latency_trace.start("completion")
+                self._record_completion(transcript, _cached, user_id=effective_user_id)
+                turn_events.emit(
+                    EventKind.RESPONSE_PROGRESS,
+                    {"stage": "completed", "source": "cache", "history_recorded": True},
+                )
+                latency_trace.end("completion")
+                latency_trace.finish()
+                latency_trace.log_summary(logger, event="chat_latency")
+                return cast(str, _cached)
+
+            prev_model = self._begin_request(transcript)
+            latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
             latency_trace.end("routing")
-            latency_trace.start("completion")
-            self._record_completion(transcript, _cached, user_id=effective_user_id)
+            turn_events.emit(
+                EventKind.ROUTE_PROGRESS,
+                {"stage": "model_router", "model": latency_trace.model},
+            )
+            try:
+                _ctx = self._get_or_create_context_builder().build(
+                    transcript, voice_mode=voice_mode, active_user_id=active_user_id
+                )
+                turn_events.emit(
+                    EventKind.CONTEXT_PROGRESS,
+                    {"stage": "built", "scope": turn_context.scope.value},
+                )
+                result = await self._get_or_create_action_dispatcher().dispatch(
+                    _intent,
+                    _ctx,
+                    transcript,
+                    voice_mode=voice_mode,
+                    active_user_id=active_user_id,
+                    user_id=effective_user_id,
+                    loop=loop,
+                    latency_trace=latency_trace,
+                    turn_events=turn_events,
+                )
+                latency_trace.start("completion")
+                final = self._get_or_create_response_builder().build(
+                    result, _ctx, transcript=transcript, user_id=effective_user_id
+                )
+                completion = final.text
+                turn_events.emit(
+                    EventKind.RESPONSE_PROGRESS,
+                    {"stage": "response_builder", "status": "completed"},
+                )
+            except Exception:
+                latency_trace.finish()
+                latency_trace.log_summary(logger, event="chat_latency")
+                raise
+            finally:
+                self._end_request(prev_model)
+
+            self._record_completion(transcript, completion, user_id=effective_user_id)
+            turn_events.emit(
+                EventKind.RESPONSE_PROGRESS,
+                {"stage": "history", "history_recorded": True},
+            )
             latency_trace.end("completion")
             latency_trace.finish()
             latency_trace.log_summary(logger, event="chat_latency")
-            return _cached  # type: ignore[no-any-return]
+            return cast(str, completion)
 
-        # Apply per-request model routing; restore in finally.  The request
-        # identity is propagated explicitly (never via self._user_id, which
-        # would race across overlapping requests for different users).
-        prev_model = self._begin_request(transcript)
-        latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
-        latency_trace.end("routing")
-        try:
-            _ctx = self._get_or_create_context_builder().build(
-                transcript, voice_mode=voice_mode, active_user_id=active_user_id
-            )
-            result = await self._get_or_create_action_dispatcher().dispatch(
-                _intent,
-                _ctx,
-                transcript,
-                voice_mode=voice_mode,
-                active_user_id=active_user_id,
-                user_id=effective_user_id,
-                loop=loop,
-                latency_trace=latency_trace,
-            )
-            latency_trace.start("completion")
-            final = self._get_or_create_response_builder().build(
-                result, _ctx, transcript=transcript, user_id=effective_user_id
-            )
-            completion = final.text
-        except Exception:
-            latency_trace.finish()
-            latency_trace.log_summary(logger, event="chat_latency")
-            raise
-        finally:
-            self._end_request(prev_model)
-
-        self._record_completion(transcript, completion, user_id=effective_user_id)
-        latency_trace.end("completion")
-        latency_trace.finish()
-        latency_trace.log_summary(logger, event="chat_latency")
-        return completion  # type: ignore[no-any-return]
+        return await self._get_or_create_turn_engine().execute_async(
+            turn_context, _run_turn, on_event=observer
+        )
 
     def _begin_request(self, transcript: str) -> str | None:
         """Apply per-request model routing.

--- a/rex/runtime/turn.py
+++ b/rex/runtime/turn.py
@@ -21,6 +21,7 @@ class TurnScope(StrEnum):
 class TurnSource(StrEnum):
     """Interface that originated a turn."""
 
+    ASSISTANT = "assistant"
     CLI = "cli"
     ELECTRON = "electron"
     VOICE = "voice"

--- a/rex/runtime/turn_engine.py
+++ b/rex/runtime/turn_engine.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
 from rex.runtime.events import EventKind, EventObserver, TurnEventStream
@@ -29,6 +29,26 @@ class TurnEngine:
         stream.emit(EventKind.TURN_STARTED)
         try:
             result = operation(stream)
+        except Exception as exc:
+            if not stream.is_terminal:
+                stream.finish(EventKind.FAILED, {"exception_type": type(exc).__name__})
+            raise
+        if not stream.is_terminal:
+            stream.finish(EventKind.COMPLETED)
+        return result
+
+    async def execute_async(
+        self,
+        context: TurnContext,
+        operation: Callable[[TurnEventStream], Awaitable[T]],
+        *,
+        on_event: EventObserver | None = None,
+    ) -> T:
+        """Async counterpart to :meth:`execute` with identical lifecycle semantics."""
+        stream = TurnEventStream(context, clock=self._clock, observer=on_event)
+        stream.emit(EventKind.TURN_STARTED)
+        try:
+            result = await operation(stream)
         except Exception as exc:
             if not stream.is_terminal:
                 stream.finish(EventKind.FAILED, {"exception_type": type(exc).__name__})

--- a/tests/rex2/test_generate_reply_turn_engine.py
+++ b/tests/rex2/test_generate_reply_turn_engine.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rex.actions.dispatcher import ActionResult
+from rex.assistant import Assistant
+from rex.assistant_errors import IdentityRequiredError
+from rex.intent.router import IntentResult
+from rex.response.builder import FinalResponse
+from rex.runtime.events import EventKind, TurnEventStream
+
+
+def _assistant(*, user_id: str | None = "james") -> Assistant:
+    assistant = Assistant.__new__(Assistant)
+    assistant._settings = SimpleNamespace(
+        max_memory_items=50,
+        persist_history=False,
+        followups_enabled=False,
+        model_routing=None,
+        transcripts_enabled=False,
+        llm_provider="test",
+        llm_model="test-model",
+        llm=None,
+    )
+    assistant._user_id = user_id
+    assistant._histories = {}
+    assistant._history_limit = 50
+    assistant._plugins = []
+    assistant._history_store = None
+    assistant._followup_engine = None
+    assistant._followup_sessions = set()
+    assistant._followup_bootstrap_pending = False
+    assistant._pending_followups = {}
+    assistant._router = None
+    assistant._response_cache = None
+    assistant._ha_bridge = None
+    assistant._suggestion_engine = None
+    assistant._pattern_entries = {}
+    assistant._llm = MagicMock()
+    assistant._llm.model_name = "test-model"
+    assistant._context_builder = MagicMock()
+    assistant._context_builder.build.return_value = SimpleNamespace(
+        messages=[], prompt="prompt", system_prompt="system"
+    )
+    assistant._response_builder = MagicMock()
+    assistant._response_builder.check_cache.return_value = None
+    assistant._turn_events: list = []
+    assistant._turn_event_observer = assistant._turn_events.append
+    return assistant
+
+
+def _unhandled_intent(assistant: Assistant) -> None:
+    router = MagicMock()
+    router.route.return_value = IntentResult(handled=False, response=None, intent_type=None)
+    assistant._intent_router = router
+
+
+def _final_response(text: str) -> FinalResponse:
+    return FinalResponse(text=text, tts_text=text)
+
+
+def test_direct_answer_runs_inside_turn_engine() -> None:
+    assistant = _assistant()
+    router = MagicMock()
+    router.route.return_value = IntentResult(
+        handled=True,
+        response="Hello. How can I help?",
+        intent_type="greeting",
+    )
+    assistant._intent_router = router
+
+    reply = asyncio.run(assistant.generate_reply("hello"))
+
+    assert reply == "Hello. How can I help?"
+    assert assistant._turn_events[0].kind is EventKind.TURN_STARTED
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+    assert any(event.kind is EventKind.ROUTE_PROGRESS for event in assistant._turn_events)
+    assert any(event.kind is EventKind.RESPONSE_PROGRESS for event in assistant._turn_events)
+
+
+def test_cache_hit_does_not_bypass_turn_engine() -> None:
+    assistant = _assistant()
+    _unhandled_intent(assistant)
+    assistant._response_builder.check_cache.return_value = "cached-answer"
+    assistant._action_dispatcher = MagicMock()
+
+    reply = asyncio.run(assistant.generate_reply("cached question"))
+
+    assert reply == "cached-answer"
+    assistant._action_dispatcher.dispatch.assert_not_called()
+    assert assistant._turn_events[0].kind is EventKind.TURN_STARTED
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+
+
+def test_read_only_tool_result_preserves_response_and_event_stream() -> None:
+    assistant = _assistant()
+    _unhandled_intent(assistant)
+    seen_streams: list[TurnEventStream] = []
+
+    async def dispatch(*_args, turn_events=None, **_kwargs):
+        assert isinstance(turn_events, TurnEventStream)
+        seen_streams.append(turn_events)
+        turn_events.emit(
+            EventKind.CAPABILITY_PROGRESS,
+            {"capability": "web_search", "operation": "read"},
+        )
+        turn_events.emit(EventKind.ACTION_PROGRESS, {"status": "completed"})
+        return ActionResult(success=True, response="tool-answer", actions_taken=["web_search"])
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+    assistant._response_builder.build.return_value = _final_response("tool-answer")
+
+    reply = asyncio.run(assistant.generate_reply("search the web"))
+
+    assert reply == "tool-answer"
+    assert seen_streams
+    assert any(event.kind is EventKind.CAPABILITY_PROGRESS for event in assistant._turn_events)
+    assert any(event.kind is EventKind.ACTION_PROGRESS for event in assistant._turn_events)
+
+
+def test_mutation_confirmation_wording_is_preserved() -> None:
+    assistant = _assistant()
+    _unhandled_intent(assistant)
+
+    async def dispatch(*_args, turn_events=None, **_kwargs):
+        assert isinstance(turn_events, TurnEventStream)
+        turn_events.emit(
+            EventKind.CAPABILITY_PROGRESS,
+            {"capability": "home_assistant", "operation": "mutate"},
+        )
+        turn_events.emit(
+            EventKind.ACTION_PROGRESS,
+            {"status": "confirmation_required"},
+        )
+        return ActionResult(
+            success=False,
+            response="Please confirm locking the front door.",
+            actions_taken=["home_assistant"],
+        )
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+    assistant._response_builder.build.return_value = _final_response(
+        "Please confirm locking the front door."
+    )
+
+    reply = asyncio.run(assistant.generate_reply("lock the front door"))
+
+    assert reply == "Please confirm locking the front door."
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+
+
+def test_model_failure_is_re_raised_with_failed_terminal() -> None:
+    assistant = _assistant()
+    _unhandled_intent(assistant)
+
+    async def dispatch(*_args, turn_events=None, **_kwargs):
+        assert isinstance(turn_events, TurnEventStream)
+        turn_events.emit(
+            EventKind.MODEL_PROGRESS,
+            {"stage": "generation", "status": "started"},
+        )
+        raise RuntimeError("model unavailable")
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+
+    with pytest.raises(RuntimeError, match="model unavailable"):
+        asyncio.run(assistant.generate_reply("explain this"))
+
+    assert assistant._turn_events[-1].kind is EventKind.FAILED
+    assert sum(event.is_terminal for event in assistant._turn_events) == 1
+
+
+def test_unavailable_capability_response_shape_is_preserved() -> None:
+    assistant = _assistant()
+    _unhandled_intent(assistant)
+
+    async def dispatch(*_args, turn_events=None, **_kwargs):
+        assert isinstance(turn_events, TurnEventStream)
+        turn_events.emit(
+            EventKind.CAPABILITY_PROGRESS,
+            {"capability": "calendar_write", "status": "unavailable"},
+        )
+        return ActionResult(
+            success=False,
+            response="Calendar write is unavailable.",
+            error="unavailable",
+        )
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+    assistant._response_builder.build.return_value = _final_response(
+        "Calendar write is unavailable."
+    )
+
+    reply = asyncio.run(assistant.generate_reply("add an event"))
+
+    assert reply == "Calendar write is unavailable."
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+
+
+def test_missing_identity_fails_before_turn_engine() -> None:
+    assistant = _assistant(user_id=None)
+    _unhandled_intent(assistant)
+    engine = MagicMock()
+    assistant._turn_engine = engine
+
+    with pytest.raises(IdentityRequiredError):
+        asyncio.run(assistant.generate_reply("hello"))
+
+    engine.execute_async.assert_not_called()
+    assert assistant._turn_events == []
+
+
+def test_real_dispatcher_emits_tool_model_and_result_boundaries() -> None:
+    from rex.actions.dispatcher import ActionDispatcher
+    from rex.runtime.turn import (
+        AuthorizationSnapshotRef,
+        ResponseMode,
+        TurnContext,
+        TurnScope,
+        TurnSource,
+    )
+
+    context_builder = MagicMock()
+    context_builder.build.return_value = SimpleNamespace(messages=[], prompt="prompt")
+    llm = MagicMock()
+    llm.generate.return_value = "model-answer"
+    result_handler = MagicMock()
+
+    async def process(*_args, **_kwargs):
+        return "model-answer"
+
+    result_handler.process = process
+    tool = SimpleNamespace(name="time_now", operation="read")
+    tool_dispatcher = MagicMock()
+    tool_dispatcher.select_tools.return_value = [tool]
+    tool_dispatcher.execute_tools.return_value = [{"ok": True}]
+    tool_dispatcher.format_tool_context.return_value = "time context"
+
+    dispatcher = ActionDispatcher(
+        context_builder=context_builder,
+        llm=llm,
+        result_handler=result_handler,
+        tool_dispatcher=tool_dispatcher,
+    )
+    turn_context = TurnContext.create(
+        user_id="james",
+        scope=TurnScope.USER,
+        source=TurnSource.ASSISTANT,
+        device_id=None,
+        response_mode=ResponseMode.SCREEN,
+        authorization=AuthorizationSnapshotRef(
+            "rex-policy:existing-runtime",
+            "rex-permissions:validated-user:james",
+        ),
+    )
+    observed = []
+    stream = TurnEventStream(turn_context, observer=observed.append)
+
+    result = asyncio.run(
+        dispatcher.dispatch(
+            IntentResult(handled=False, response=None, intent_type=None),
+            context_builder.build.return_value,
+            "what time is it",
+            user_id="james",
+            turn_events=stream,
+        )
+    )
+
+    assert result.response == "model-answer"
+    assert any(
+        event.kind is EventKind.CAPABILITY_PROGRESS
+        and "time_now" in event.details.get("capabilities", [])
+        for event in observed
+    )
+    assert any(
+        event.kind is EventKind.ACTION_PROGRESS and event.details.get("stage") == "tool_execution"
+        for event in observed
+    )
+    model_events = [event for event in observed if event.kind is EventKind.MODEL_PROGRESS]
+    assert [event.details.get("status") for event in model_events] == [
+        "started",
+        "returned",
+    ]
+    assert any(
+        event.kind is EventKind.ACTION_PROGRESS and event.details.get("stage") == "result_handler"
+        for event in observed
+    )
+
+
+def test_generate_reply_has_no_direct_model_shortcut() -> None:
+    source = inspect.getsource(Assistant.generate_reply)
+
+    assert "execute_async" in source
+    assert "._llm.generate" not in source
+    assert "._generate_model_reply" not in source
+
+
+def test_voice_mode_does_not_invent_surface_provenance() -> None:
+    from rex.runtime.turn import ResponseMode, TurnSource
+
+    context = _assistant()._build_turn_context("james", voice_mode=True)
+
+    assert context.source is TurnSource.ASSISTANT
+    assert context.response_mode is ResponseMode.VOICE


### PR DESCRIPTION
## Summary
- route every post-identity `Assistant.generate_reply()` path through canonical TurnEngine
- preserve intent shortcuts, per-user cache, ModelRouter request scope, context, ActionDispatcher, ResponseBuilder, history, latency, and public result/exception behavior
- pass TurnEventStream into ActionDispatcher and emit truthful capability/action/model/result progress at real boundaries
- keep fail-closed identity outside the turn boundary and avoid inventing interface provenance before US-097
- add async TurnEngine execution and focused migration regressions
- update CLAUDE.md, architecture docs, PRD, and progress evidence

## Local validation
- 10 passed: tests/rex2/test_generate_reply_turn_engine.py
- 205 passed: runtime/assistant/identity/action/verification/docs truth sweep
- ruff check on touched runtime/assistant/dispatcher/tests
- black --check on touched runtime/assistant/dispatcher/tests
- mypy assistant + dispatcher + runtime: no issues
- compileall and git diff --check pass

US-095 only. `stream_reply()` intentionally remains legacy until US-096; interface adapter parity remains deferred to US-097.