### PR TITLE
feat(runtime): unify streaming turn pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Home Assistant safety:
 
 - `PRD-production-readiness.md` is the single authoritative tracker for the current integrated production-readiness/Rex 2.0 work. For remaining work, follow its dated `Integrated execution order` rather than raw story file position. Planned Rex 2.0 contracts are not implemented behavior until their individual story is merged and verified.
 
-- `rex.runtime` is the canonical interface-agnostic turn contract layer. `TurnContext` owns immutable validated identity/scope, origin/response mode, monotonic timing/deadline, and authorization snapshot references; `TurnEventStream` owns ordered correlated events and exactly one terminal outcome; `TurnEngine` preserves wrapped return/exception behavior while emitting those events. `Assistant.generate_reply()` now runs through this engine; `stream_reply()` remains on the legacy streaming path until US-096, and interface adapter parity remains unclaimed until US-097.
+- `rex.runtime` is the canonical interface-agnostic turn contract layer. `TurnContext` owns immutable validated identity/scope, origin/response mode, monotonic timing/deadline, and authorization snapshot references; `TurnEventStream` owns ordered correlated events and exactly one terminal outcome; `TurnEngine` preserves wrapped return/exception behavior while emitting those events. `Assistant.generate_reply()` and `Assistant.stream_reply()` now share the same TurnEngine-backed routing/cache/context/action/verification/response/history pipeline. Streaming is delivery-only: it releases sentence chunks only after the final response has passed result handling and ResponseBuilder checks. Interface adapter provenance/parity remains unclaimed until US-097.
 
 - Prefer clear, testable functions over clever code.
 - Keep changes small and reviewable.
@@ -305,10 +305,10 @@ Bridge compatibility wrappers (17) — exec canonical `bridge/<name>.py` in thei
 
 ### Assistant architecture
 
-`Assistant.generate_reply()` is the canonical non-streaming TurnEngine entry point. Identity is validated before the turn begins; all subsequent intent/cache/model routing, context building, action/tool dispatch, result verification, response building, and history recording run inside one correlated turn. `stream_reply()` is not yet migrated (US-096). The non-streaming pipeline is:
+`Assistant.generate_reply()` and `Assistant.stream_reply()` are canonical TurnEngine entry points over one shared reply pipeline. Identity is validated before the turn begins; all subsequent intent/cache/model routing, context building, action/tool dispatch, result verification, response building, and history recording run inside one correlated turn. Streaming changes only delivery: verified final text is split into ordered sentence chunks before the terminal event. The shared pipeline is:
 
 ```
-Assistant → TurnEngine → IntentRouter/Cache → ContextBuilder → ActionDispatcher → ResponseBuilder → History
+Assistant → TurnEngine → IntentRouter/Cache → ContextBuilder → ActionDispatcher → ResponseBuilder → History → [final text or verified sentence chunks]
 ```
 
 | Component | Module | Responsibility |

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -3298,7 +3298,7 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 - [x] Public callers keep the same final result shape except already-required truthful status corrections.
 - [x] Regression tests cover direct answer, read-only tool, mutation/confirmation, model failure, and unavailable capability.
 - [x] No direct model shortcut bypasses TurnEngine from `generate_reply()`.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_generate_reply_turn_engine.py tests/test_assistant.py -q`; `mypy rex/assistant.py rex/runtime --ignore-missing-imports`.
 
@@ -3315,11 +3315,11 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 **Files/areas likely involved:** `rex/assistant.py`, `rex/runtime/events.py`, `rex/runtime/turn_engine.py`, chat stream bridges, `tests/rex2/`.
 
 **Acceptance Criteria:**
-- [ ] Streaming and non-streaming use the same router, cache policy, context, capability/action pipeline, verification, memory/history, and output validation.
-- [ ] Streaming emits ordered deltas/sentences plus the same canonical terminal outcome as non-streaming.
-- [ ] Tool syntax, internal plans, raw provider tool-call payloads, and unverified action claims never leak to the user stream.
-- [ ] Parity fixtures compare final semantic/status outcomes across both delivery modes.
-- [ ] Error/fallback/escalation behavior is equivalent across both delivery modes.
+- [x] Streaming and non-streaming use the same router, cache policy, context, capability/action pipeline, verification, memory/history, and output validation.
+- [x] Streaming emits ordered deltas/sentences plus the same canonical terminal outcome as non-streaming.
+- [x] Tool syntax, internal plans, raw provider tool-call payloads, and unverified action claims never leak to the user stream.
+- [x] Parity fixtures compare final semantic/status outcomes across both delivery modes.
+- [x] Error/fallback/escalation behavior is equivalent across both delivery modes.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_stream_turn_parity.py tests/test_assistant_streaming.py -q`; `mypy rex/assistant.py rex/runtime --ignore-missing-imports`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,14 +34,16 @@ selection (`cuda` vs `cpu`) is resolved at model-load time from
 ### LLM response handling
 
 The `Assistant` class in `rex/assistant.py` is the single entry point for
-generating replies. Non-streaming `Assistant.generate_reply()` runs through
-`rex.runtime.TurnEngine`, which correlates intent/cache/model routing, context,
-action/tool dispatch, verification/post-processing, response assembly, and
-history under one immutable user-scoped turn. Raw model calls remain delegated
-to providers in `rex/llm_client.py` (local Transformers, OpenAI-compatible,
-Anthropic, or Ollama). `Assistant.stream_reply()` remains on the legacy
-streaming path until US-096. The voice loop must always call Assistant rather
-than the LLM client directly so tool routing and verification are preserved.
+generating replies. `Assistant.generate_reply()` and `Assistant.stream_reply()`
+run through the same `rex.runtime.TurnEngine` reply pipeline, which correlates
+intent/cache/model routing, context, action/tool dispatch, verification and
+post-processing, response assembly, and history under one immutable user-scoped
+turn. Streaming is a delivery mode only: raw provider tokens, internal tool
+syntax, and pre-verification action claims are never released; verified final
+text is split into ordered sentence chunks before the canonical terminal event.
+Raw model calls remain delegated to providers in `rex/llm_client.py`. The voice
+loop must always call Assistant rather than the LLM client directly so tool
+routing and verification are preserved.
 
 ### Text-to-speech (TTS)
 

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1721,3 +1721,24 @@ Local evidence:
 - Ruff and Black pass on touched runtime/assistant/dispatcher/tests; mypy reports no issues across assistant, dispatcher, and runtime modules.
 - US-094 PR #376 passed every relevant GitHub check, including full Python coverage and installed Windows Electron artifact smoke; its final PRD CI criterion is now closed.
 - US-095 GitHub checks remain pending until this story PR is pushed; its final PRD checkbox intentionally remains open.
+
+
+2026-08-09 - US-096 streaming parity on shared TurnEngine pipeline
+
+Implementation:
+- Replaced the reduced-intelligence provider-token streaming path with the same `_run_reply_turn` pipeline used by `generate_reply()`: identical intent routing, per-user cache, ModelRouter request scope, ContextBuilder, ActionDispatcher/tool verification, ResultHandler, ResponseBuilder, and history semantics.
+- `stream_reply()` now owns only transport: it runs the shared operation inside TurnEngine, queues verified sentence chunks, and exposes them through the existing async-iterator API.
+- Added metadata-only ordered `response_progress` delta events before the single terminal event; response text itself is not copied into canonical event metadata.
+- Raw provider tokens are no longer user-visible. Internal `TOOL_REQUEST` syntax and unverified action claims must pass the canonical result/verification path before any sentence is released.
+- Preserved fail-closed identity before TurnEngine and kept source provenance interface-agnostic until US-097.
+- Updated legacy stream tests from raw provider-token chunk expectations to verified sentence-delivery semantics while preserving final response meaning.
+- Added the previously missing `tests/test_assistant_streaming.py` so the PRD validation command is executable and guards against reintroducing the legacy provider-stream bypass.
+
+Local evidence:
+- TDD red phase: 7 of 8 new parity tests failed on the legacy stream path; only the existing fail-closed identity boundary already passed.
+- Exact PRD validation: `pytest tests/rex2/test_stream_turn_parity.py tests/test_assistant_streaming.py -q` -> 12 passed.
+- Initial streaming/identity/latency/Electron-bridge/progressive-voice/voice-loop/TTS compatibility sweep -> 174 passed; the later 305-test final sweep includes the added routing escalation/fallback parity cases.
+- Mobile chat stream, strong-auth, Electron stream verification, voice latency, and voice-loop-fix sweep -> 33 passed.
+- Final combined runtime/streaming/identity/action/verification/docs/mobile/Electron/voice sweep -> 305 passed. The only 2 warnings are pre-existing deliberate deprecation checks in `tests/test_voice_loop_fixes.py`, not introduced by this story.
+- US-095 PR #377 passed every relevant GitHub check, including Python 3.11 Tests & Coverage (9m04s) and installed Windows Electron artifact (12m31s); its final PRD CI criterion is now closed.
+- US-096 GitHub checks remain pending until this story PR is pushed; its final PRD checkbox intentionally remains open.

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -7,7 +7,7 @@ import logging
 import re
 import threading
 import time
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -693,20 +693,42 @@ class Assistant:
         finally:
             latency_trace.end("tool")
 
+    async def _deliver_safe_response(
+        self,
+        text: str,
+        *,
+        turn_events: TurnEventStream,
+        response_sink: Callable[[str], Awaitable[None]] | None,
+        latency_trace: LatencyTrace,
+        stream_started_ns: int | None,
+    ) -> None:
+        """Deliver only post-validation text as ordered sentence chunks."""
+        if response_sink is None:
+            return
+        from rex.voice.transcripts import _split_into_sentences  # noqa: PLC0415
+
+        chunks = _split_into_sentences(text)
+        if not chunks and text.strip():
+            chunks = [text.strip()]
+        for index, chunk in enumerate(chunks):
+            if index == 0 and stream_started_ns is not None:
+                latency_trace.add_duration_ms(
+                    "first_token",
+                    (time.perf_counter_ns() - stream_started_ns) / 1_000_000,
+                )
+            turn_events.emit(
+                EventKind.RESPONSE_PROGRESS,
+                {"stage": "delta", "index": index, "kind": "sentence"},
+            )
+            await response_sink(chunk)
+
     async def stream_reply(
         self, transcript: str, *, voice_mode: bool = False, active_user_id: str | None = None
     ) -> AsyncIterator[str]:
-        loop = asyncio.get_running_loop()
-        completion: str | None = None
-        from rex.mobile_api.action_context import (  # noqa: PLC0415
-            run_in_executor_with_mobile_context,
-        )
-
-        # Resolve and validate the request identity before any private state
-        # (intent shortcuts, history, cues) is touched (issue #303).
+        """Stream verified response sentences from the canonical TurnEngine path."""
         effective_user_id = self._resolve_request_user_id(active_user_id)
-        self._ensure_followup_session(effective_user_id)
-
+        turn_context = self._build_turn_context(effective_user_id, voice_mode=voice_mode)
+        observer = getattr(self, "_turn_event_observer", None)
         latency_provider, latency_model = self._latency_provider_model()
         latency_trace = LatencyTrace(
             channel="voice" if voice_mode else "chat",
@@ -715,128 +737,46 @@ class Assistant:
             settings_id="voice_stream" if voice_mode else "text_stream",
         )
         stream_started_ns = time.perf_counter_ns()
-        first_token_recorded = False
-
-        def _mark_first_token() -> None:
-            nonlocal first_token_recorded
-            if first_token_recorded:
-                return
-            latency_trace.add_duration_ms(
-                "first_token", (time.perf_counter_ns() - stream_started_ns) / 1_000_000
-            )
-            first_token_recorded = True
-
-        latency_trace.start("routing")
-
-        # Intent routing: time/date, greetings, recipes (US-015)
-        _intent = self._get_or_create_intent_router().route(transcript)
-        latency_trace.end("routing")
-        if _intent.handled:
-            latency_trace.start("completion")
-            self._record_completion(transcript, _intent.response, user_id=effective_user_id)
-            latency_trace.end("completion")
-            _mark_first_token()
-            latency_trace.finish()
-            latency_trace.log_summary(logger, event="chat_stream_latency")
-            yield _intent.response
-            return
-
-        completion = await self._stream_home_assistant_completion(
-            transcript, loop=loop, latency_trace=latency_trace
-        )
-
-        if completion is not None:
-            latency_trace.start("completion")
-            completion = await self._post_process_completion(
-                transcript, completion, user_id=effective_user_id
-            )
-            self._record_completion(transcript, completion, user_id=effective_user_id)
-            latency_trace.end("completion")
-            _mark_first_token()
-            latency_trace.finish()
-            latency_trace.log_summary(logger, event="chat_stream_latency")
-            yield completion
-            return
-
-        prompt, messages = await self._prepare_model_input(
-            transcript, voice_mode=voice_mode, active_user_id=active_user_id
-        )
-
-        latency_trace.start("llm")
-        try:
-            token_iterator = self._stream_model_reply(prompt, messages)
-        except NotImplementedError:
-            completion = await run_in_executor_with_mobile_context(
-                loop, self._generate_model_reply, prompt, messages
-            )
-            latency_trace.end("llm")
-            latency_trace.start("completion")
-            completion = await self._post_process_completion(
-                transcript, completion, user_id=effective_user_id
-            )
-            self._record_completion(transcript, completion, user_id=effective_user_id)
-            latency_trace.end("completion")
-            _mark_first_token()
-            latency_trace.finish()
-            latency_trace.log_summary(logger, event="chat_stream_latency")
-            yield completion
-            return
-
         queue: asyncio.Queue[object] = asyncio.Queue()
         sentinel = object()
-        collected_tokens: list[str] = []
-        pending_stream_text = ""
-        stream_released = False
 
-        def _pump_tokens() -> None:
+        async def response_sink(chunk: str) -> None:
+            await queue.put(chunk)
+
+        async def run_turn() -> None:
             try:
-                for token in token_iterator:
-                    if token:
-                        loop.call_soon_threadsafe(queue.put_nowait, token)
-            except Exception as exc:
-                loop.call_soon_threadsafe(queue.put_nowait, exc)
+                await self._get_or_create_turn_engine().execute_async(
+                    turn_context,
+                    lambda turn_events: self._run_reply_turn(
+                        turn_events,
+                        turn_context=turn_context,
+                        transcript=transcript,
+                        voice_mode=voice_mode,
+                        active_user_id=active_user_id,
+                        effective_user_id=effective_user_id,
+                        latency_trace=latency_trace,
+                        latency_event="chat_stream_latency",
+                        response_sink=response_sink,
+                        stream_started_ns=stream_started_ns,
+                    ),
+                    on_event=observer,
+                )
+            except BaseException as exc:
+                await queue.put(exc)
             finally:
-                loop.call_soon_threadsafe(queue.put_nowait, sentinel)
+                await queue.put(sentinel)
 
-        pump_task = asyncio.create_task(asyncio.to_thread(_pump_tokens))
+        task = asyncio.create_task(run_turn())
         try:
             while True:
                 item = await queue.get()
                 if item is sentinel:
                     break
-                if isinstance(item, Exception):
+                if isinstance(item, BaseException):
                     raise item
-                token = str(item)
-                collected_tokens.append(token)
-                if stream_released:
-                    _mark_first_token()
-                    yield token
-                    continue
-
-                pending_stream_text += token
-                prefix_state = self._stream_tool_prefix_state(pending_stream_text)
-                if prefix_state == "text":
-                    stream_released = True
-                    _mark_first_token()
-                    yield pending_stream_text
-                    pending_stream_text = ""
+                yield str(item)
         finally:
-            await pump_task
-
-        latency_trace.end("llm")
-        latency_trace.start("completion")
-        completion = "".join(collected_tokens).strip() or "(silence)"
-        completion = await self._post_process_completion(
-            transcript, completion, user_id=effective_user_id
-        )
-        self._record_completion(transcript, completion, user_id=effective_user_id)
-        latency_trace.end("completion")
-        if not stream_released:
-            _mark_first_token()
-        latency_trace.finish()
-        latency_trace.log_summary(logger, event="chat_stream_latency")
-        if not stream_released:
-            yield completion
+            await task
 
     def _get_or_create_turn_engine(self) -> TurnEngine:
         """Return the canonical turn engine, creating it for legacy test shells."""
@@ -860,6 +800,147 @@ class Assistant:
             ),
         )
 
+    async def _run_reply_turn(
+        self,
+        turn_events: TurnEventStream,
+        *,
+        turn_context: TurnContext,
+        transcript: str,
+        voice_mode: bool,
+        active_user_id: str | None,
+        effective_user_id: str,
+        latency_trace: LatencyTrace,
+        latency_event: str,
+        response_sink: Callable[[str], Awaitable[None]] | None = None,
+        stream_started_ns: int | None = None,
+    ) -> str:
+        """Run the shared verified reply pipeline for text and streaming delivery."""
+        loop = asyncio.get_running_loop()
+        self._ensure_followup_session(effective_user_id)
+        latency_trace.start("routing")
+
+        intent = self._get_or_create_intent_router().route(
+            transcript,
+            settings=self._settings,
+            suggestion_engine=getattr(self, "_suggestion_engine", None),
+            user_id=effective_user_id,
+        )
+        turn_events.emit(
+            EventKind.ROUTE_PROGRESS,
+            {
+                "stage": "intent",
+                "handled": bool(intent.handled),
+                "intent_type": intent.intent_type or "unknown",
+            },
+        )
+        if intent.handled and not (intent.intent_type == "greeting" and active_user_id is not None):
+            latency_trace.end("routing")
+            latency_trace.start("completion")
+            completion = cast(str, intent.response)
+            self._record_completion(transcript, completion, user_id=effective_user_id)
+            turn_events.emit(
+                EventKind.RESPONSE_PROGRESS,
+                {"stage": "completed", "source": "intent", "history_recorded": True},
+            )
+            await self._deliver_safe_response(
+                completion,
+                turn_events=turn_events,
+                response_sink=response_sink,
+                latency_trace=latency_trace,
+                stream_started_ns=stream_started_ns,
+            )
+            latency_trace.end("completion")
+            latency_trace.finish()
+            latency_trace.log_summary(logger, event=latency_event)
+            return completion
+
+        cached = self._get_or_create_response_builder().check_cache(
+            transcript, user_id=effective_user_id
+        )
+        turn_events.emit(
+            EventKind.ROUTE_PROGRESS,
+            {"stage": "cache", "cache_hit": cached is not None},
+        )
+        if cached is not None:
+            latency_trace.end("routing")
+            latency_trace.start("completion")
+            completion = cast(str, cached)
+            self._record_completion(transcript, completion, user_id=effective_user_id)
+            turn_events.emit(
+                EventKind.RESPONSE_PROGRESS,
+                {"stage": "completed", "source": "cache", "history_recorded": True},
+            )
+            await self._deliver_safe_response(
+                completion,
+                turn_events=turn_events,
+                response_sink=response_sink,
+                latency_trace=latency_trace,
+                stream_started_ns=stream_started_ns,
+            )
+            latency_trace.end("completion")
+            latency_trace.finish()
+            latency_trace.log_summary(logger, event=latency_event)
+            return completion
+
+        prev_model = self._begin_request(transcript)
+        latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
+        latency_trace.end("routing")
+        turn_events.emit(
+            EventKind.ROUTE_PROGRESS,
+            {"stage": "model_router", "model": latency_trace.model},
+        )
+        try:
+            context = self._get_or_create_context_builder().build(
+                transcript, voice_mode=voice_mode, active_user_id=active_user_id
+            )
+            turn_events.emit(
+                EventKind.CONTEXT_PROGRESS,
+                {"stage": "built", "scope": turn_context.scope.value},
+            )
+            result = await self._get_or_create_action_dispatcher().dispatch(
+                intent,
+                context,
+                transcript,
+                voice_mode=voice_mode,
+                active_user_id=active_user_id,
+                user_id=effective_user_id,
+                loop=loop,
+                latency_trace=latency_trace,
+                turn_events=turn_events,
+            )
+            latency_trace.start("completion")
+            final = self._get_or_create_response_builder().build(
+                result, context, transcript=transcript, user_id=effective_user_id
+            )
+            completion = final.text
+            turn_events.emit(
+                EventKind.RESPONSE_PROGRESS,
+                {"stage": "response_builder", "status": "completed"},
+            )
+        except Exception:
+            latency_trace.finish()
+            latency_trace.log_summary(logger, event=latency_event)
+            raise
+        finally:
+            self._end_request(prev_model)
+
+        self._record_completion(transcript, completion, user_id=effective_user_id)
+        turn_events.emit(
+            EventKind.RESPONSE_PROGRESS,
+            {"stage": "history", "history_recorded": True},
+        )
+        await self._deliver_safe_response(
+            completion,
+            turn_events=turn_events,
+            response_sink=response_sink,
+            latency_trace=latency_trace,
+            stream_started_ns=stream_started_ns,
+        )
+        latency_trace.end("completion")
+        latency_trace.finish()
+        latency_trace.log_summary(logger, event=latency_event)
+        return cast(str, completion)
+
     async def generate_reply(
         self,
         transcript: str,
@@ -867,128 +948,30 @@ class Assistant:
         voice_mode: bool = False,
         active_user_id: str | None = None,
     ) -> str:
-        """Orchestrate one non-streaming reply through the canonical TurnEngine."""
-        # Identity remains outside the engine on purpose: invalid or missing identity
-        # must fail before turn events or any private request state are touched.
+        """Generate one verified reply through the canonical TurnEngine pipeline."""
         effective_user_id = self._resolve_request_user_id(active_user_id)
         turn_context = self._build_turn_context(effective_user_id, voice_mode=voice_mode)
         observer = getattr(self, "_turn_event_observer", None)
-
-        async def _run_turn(turn_events: TurnEventStream) -> str:
-            loop = asyncio.get_running_loop()
-            self._ensure_followup_session(effective_user_id)
-            latency_provider, latency_model = self._latency_provider_model()
-            latency_trace = LatencyTrace(
-                channel="voice" if voice_mode else "chat",
-                provider=latency_provider,
-                model=latency_model,
-                settings_id="voice" if voice_mode else "text",
-            )
-            latency_trace.start("routing")
-
-            _intent = self._get_or_create_intent_router().route(
-                transcript,
-                settings=self._settings,
-                suggestion_engine=getattr(self, "_suggestion_engine", None),
-                user_id=effective_user_id,
-            )
-            turn_events.emit(
-                EventKind.ROUTE_PROGRESS,
-                {
-                    "stage": "intent",
-                    "handled": bool(_intent.handled),
-                    "intent_type": _intent.intent_type or "unknown",
-                },
-            )
-            if _intent.handled and not (
-                _intent.intent_type == "greeting" and active_user_id is not None
-            ):
-                latency_trace.end("routing")
-                latency_trace.start("completion")
-                self._record_completion(transcript, _intent.response, user_id=effective_user_id)
-                turn_events.emit(
-                    EventKind.RESPONSE_PROGRESS,
-                    {"stage": "completed", "source": "intent", "history_recorded": True},
-                )
-                latency_trace.end("completion")
-                latency_trace.finish()
-                latency_trace.log_summary(logger, event="chat_latency")
-                return cast(str, _intent.response)
-
-            _cached = self._get_or_create_response_builder().check_cache(
-                transcript, user_id=effective_user_id
-            )
-            turn_events.emit(
-                EventKind.ROUTE_PROGRESS,
-                {"stage": "cache", "cache_hit": _cached is not None},
-            )
-            if _cached is not None:
-                latency_trace.end("routing")
-                latency_trace.start("completion")
-                self._record_completion(transcript, _cached, user_id=effective_user_id)
-                turn_events.emit(
-                    EventKind.RESPONSE_PROGRESS,
-                    {"stage": "completed", "source": "cache", "history_recorded": True},
-                )
-                latency_trace.end("completion")
-                latency_trace.finish()
-                latency_trace.log_summary(logger, event="chat_latency")
-                return cast(str, _cached)
-
-            prev_model = self._begin_request(transcript)
-            latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
-            latency_trace.end("routing")
-            turn_events.emit(
-                EventKind.ROUTE_PROGRESS,
-                {"stage": "model_router", "model": latency_trace.model},
-            )
-            try:
-                _ctx = self._get_or_create_context_builder().build(
-                    transcript, voice_mode=voice_mode, active_user_id=active_user_id
-                )
-                turn_events.emit(
-                    EventKind.CONTEXT_PROGRESS,
-                    {"stage": "built", "scope": turn_context.scope.value},
-                )
-                result = await self._get_or_create_action_dispatcher().dispatch(
-                    _intent,
-                    _ctx,
-                    transcript,
-                    voice_mode=voice_mode,
-                    active_user_id=active_user_id,
-                    user_id=effective_user_id,
-                    loop=loop,
-                    latency_trace=latency_trace,
-                    turn_events=turn_events,
-                )
-                latency_trace.start("completion")
-                final = self._get_or_create_response_builder().build(
-                    result, _ctx, transcript=transcript, user_id=effective_user_id
-                )
-                completion = final.text
-                turn_events.emit(
-                    EventKind.RESPONSE_PROGRESS,
-                    {"stage": "response_builder", "status": "completed"},
-                )
-            except Exception:
-                latency_trace.finish()
-                latency_trace.log_summary(logger, event="chat_latency")
-                raise
-            finally:
-                self._end_request(prev_model)
-
-            self._record_completion(transcript, completion, user_id=effective_user_id)
-            turn_events.emit(
-                EventKind.RESPONSE_PROGRESS,
-                {"stage": "history", "history_recorded": True},
-            )
-            latency_trace.end("completion")
-            latency_trace.finish()
-            latency_trace.log_summary(logger, event="chat_latency")
-            return cast(str, completion)
-
+        latency_provider, latency_model = self._latency_provider_model()
+        latency_trace = LatencyTrace(
+            channel="voice" if voice_mode else "chat",
+            provider=latency_provider,
+            model=latency_model,
+            settings_id="voice" if voice_mode else "text",
+        )
         return await self._get_or_create_turn_engine().execute_async(
-            turn_context, _run_turn, on_event=observer
+            turn_context,
+            lambda turn_events: self._run_reply_turn(
+                turn_events,
+                turn_context=turn_context,
+                transcript=transcript,
+                voice_mode=voice_mode,
+                active_user_id=active_user_id,
+                effective_user_id=effective_user_id,
+                latency_trace=latency_trace,
+                latency_event="chat_latency",
+            ),
+            on_event=observer,
         )
 
     def _begin_request(self, transcript: str) -> str | None:

--- a/tests/rex2/test_stream_turn_parity.py
+++ b/tests/rex2/test_stream_turn_parity.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rex.actions.dispatcher import ActionResult
+from rex.assistant import Assistant
+from rex.assistant_errors import IdentityRequiredError
+from rex.intent.router import IntentResult
+from rex.response.builder import FinalResponse
+from rex.runtime.events import EventKind, TurnEventStream
+
+
+def _assistant(*, user_id: str | None = "james") -> Assistant:
+    assistant = Assistant.__new__(Assistant)
+    assistant._settings = SimpleNamespace(
+        max_memory_items=50,
+        persist_history=False,
+        followups_enabled=False,
+        model_routing=None,
+        transcripts_enabled=False,
+        llm_provider="test",
+        llm_model="test-model",
+        llm=None,
+    )
+    assistant._user_id = user_id
+    assistant._histories = {}
+    assistant._history_limit = 50
+    assistant._plugins = []
+    assistant._history_store = None
+    assistant._followup_engine = None
+    assistant._followup_sessions = set()
+    assistant._followup_bootstrap_pending = False
+    assistant._pending_followups = {}
+    assistant._router = None
+    assistant._response_cache = None
+    assistant._ha_bridge = None
+    assistant._suggestion_engine = None
+    assistant._pattern_entries = {}
+    assistant._llm = MagicMock()
+    assistant._llm.model_name = "test-model"
+    assistant._llm.stream.return_value = iter(["legacy-stream"])
+    assistant._context_builder = MagicMock()
+    assistant._context_builder.build.return_value = SimpleNamespace(
+        messages=[], prompt="prompt", system_prompt="system"
+    )
+    assistant._response_builder = MagicMock()
+    assistant._response_builder.check_cache.return_value = None
+    assistant._response_builder.build.side_effect = lambda result, _ctx, **_kwargs: FinalResponse(
+        text=result.response,
+        tts_text=result.response,
+    )
+    assistant._turn_events: list = []
+    assistant._turn_event_observer = assistant._turn_events.append
+    return assistant
+
+
+def _unhandled(assistant: Assistant) -> None:
+    router = MagicMock()
+    router.route.return_value = IntentResult(handled=False, response=None, intent_type=None)
+    assistant._intent_router = router
+
+
+async def _collect(assistant: Assistant, text: str, **kwargs) -> list[str]:
+    return [chunk async for chunk in assistant.stream_reply(text, **kwargs)]
+
+
+def _join(chunks: list[str]) -> str:
+    return " ".join(chunk.strip() for chunk in chunks if chunk.strip()).strip()
+
+
+def test_stream_direct_answer_uses_turn_engine_and_matches_generate_reply() -> None:
+    assistant = _assistant()
+    router = MagicMock()
+    router.route.return_value = IntentResult(
+        handled=True,
+        response="Hello. How can I help?",
+        intent_type="greeting",
+    )
+    assistant._intent_router = router
+
+    generated = asyncio.run(assistant.generate_reply("hello"))
+    assistant._turn_events.clear()
+    streamed = asyncio.run(_collect(assistant, "hello"))
+
+    assert _join(streamed) == generated
+    assert assistant._turn_events[0].kind is EventKind.TURN_STARTED
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+    assert sum(event.is_terminal for event in assistant._turn_events) == 1
+
+
+def test_stream_cache_hit_matches_generate_and_skips_dispatch() -> None:
+    assistant = _assistant()
+    _unhandled(assistant)
+    assistant._response_builder.check_cache.return_value = "Cached answer."
+    assistant._action_dispatcher = MagicMock()
+
+    generated = asyncio.run(assistant.generate_reply("same question"))
+    assistant._turn_events.clear()
+    streamed = asyncio.run(_collect(assistant, "same question"))
+
+    assert _join(streamed) == generated == "Cached answer."
+    assistant._action_dispatcher.dispatch.assert_not_called()
+    assert any(
+        event.kind is EventKind.ROUTE_PROGRESS
+        and event.details.get("stage") == "cache"
+        and event.details.get("cache_hit") is True
+        for event in assistant._turn_events
+    )
+
+
+@pytest.mark.parametrize(
+    ("response", "success", "capability", "status"),
+    [
+        ("The current result is 72 degrees.", True, "weather", "returned"),
+        (
+            "Please confirm locking the front door.",
+            False,
+            "home_assistant",
+            "confirmation_required",
+        ),
+        ("Calendar write is unavailable.", False, "calendar_write", "unavailable"),
+    ],
+)
+def test_stream_action_outcomes_match_nonstreaming(
+    response: str, success: bool, capability: str, status: str
+) -> None:
+    assistant = _assistant()
+    _unhandled(assistant)
+
+    async def dispatch(*_args, turn_events=None, **_kwargs):
+        assert isinstance(turn_events, TurnEventStream)
+        turn_events.emit(
+            EventKind.CAPABILITY_PROGRESS,
+            {"capability": capability, "status": "selected"},
+        )
+        turn_events.emit(
+            EventKind.ACTION_PROGRESS,
+            {"capability": capability, "status": status},
+        )
+        return ActionResult(success=success, response=response, actions_taken=[capability])
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+
+    generated = asyncio.run(assistant.generate_reply("do the thing"))
+    assistant._turn_events.clear()
+    streamed = asyncio.run(_collect(assistant, "do the thing"))
+
+    assert _join(streamed) == generated == response
+    assert any(
+        event.kind is EventKind.ACTION_PROGRESS and event.details.get("status") == status
+        for event in assistant._turn_events
+    )
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+
+
+def test_stream_model_failure_matches_generate_failure_and_terminal() -> None:
+    assistant = _assistant()
+    _unhandled(assistant)
+
+    async def dispatch(*_args, turn_events=None, **_kwargs):
+        assert isinstance(turn_events, TurnEventStream)
+        turn_events.emit(EventKind.MODEL_PROGRESS, {"status": "started"})
+        raise RuntimeError("provider failed")
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        asyncio.run(assistant.generate_reply("fail"))
+
+    assistant._turn_events.clear()
+    with pytest.raises(RuntimeError, match="provider failed"):
+        asyncio.run(_collect(assistant, "fail"))
+
+    assert assistant._turn_events[-1].kind is EventKind.FAILED
+    assert sum(event.is_terminal for event in assistant._turn_events) == 1
+
+
+def test_stream_fails_closed_before_turn_engine_without_identity() -> None:
+    assistant = _assistant(user_id=None)
+    _unhandled(assistant)
+    engine = MagicMock()
+    assistant._turn_engine = engine
+
+    with pytest.raises(IdentityRequiredError):
+        asyncio.run(_collect(assistant, "hello"))
+
+    engine.execute_async.assert_not_called()
+    assert assistant._turn_events == []
+
+
+def test_stream_response_events_are_ordered_before_terminal() -> None:
+    assistant = _assistant()
+    _unhandled(assistant)
+
+    async def dispatch(*_args, **_kwargs):
+        return ActionResult(
+            success=True,
+            response="First sentence. Second sentence.",
+            actions_taken=["llm"],
+        )
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+
+    chunks = asyncio.run(_collect(assistant, "two sentences"))
+
+    assert chunks == ["First sentence.", "Second sentence."]
+    response_events = [
+        event
+        for event in assistant._turn_events
+        if event.kind is EventKind.RESPONSE_PROGRESS and event.details.get("stage") == "delta"
+    ]
+    assert [event.details.get("index") for event in response_events] == [0, 1]
+    assert all(event.sequence < assistant._turn_events[-1].sequence for event in response_events)
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+
+
+@pytest.mark.parametrize(
+    ("resolved_model", "expected_model"),
+    [("deep-model", "deep-model"), (None, "fast-model")],
+)
+def test_stream_model_routing_escalation_and_fallback_match_generate(
+    resolved_model: str | None, expected_model: str
+) -> None:
+    assistant = _assistant()
+    _unhandled(assistant)
+    assistant._llm.model_name = "fast-model"
+    router = MagicMock()
+    router.classify.return_value = "complex"
+    router.resolve_model.return_value = resolved_model
+    assistant._router = router
+    observed_models: list[str] = []
+
+    async def dispatch(*_args, **_kwargs):
+        observed_models.append(assistant._llm.model_name)
+        return ActionResult(success=True, response=f"used {assistant._llm.model_name}")
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+
+    generated = asyncio.run(assistant.generate_reply("complex request"))
+    streamed = asyncio.run(_collect(assistant, "complex request"))
+
+    assert generated == f"used {expected_model}"
+    assert _join(streamed) == generated
+    assert observed_models == [expected_model, expected_model]
+    assert assistant._llm.model_name == "fast-model"

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -419,13 +419,13 @@ def test_stream_reply_freeform_uses_structured_messages(monkeypatch, tmp_path):
         def __init__(self, *args, **kwargs):
             pass
 
-        def generate(self, *args, **kwargs):
-            raise AssertionError("streaming provider should not fall back to generate")
-
-        def stream(self, prompt=None, *, messages=None, config=None):
+        def generate(self, prompt=None, *, messages=None, config=None, **kwargs):
             captured["prompt"] = prompt
             captured["messages"] = messages
-            return iter(["normal ", "reply"])
+            return "normal reply"
+
+        def stream(self, *args, **kwargs):
+            raise AssertionError("verified streaming must not expose raw provider tokens")
 
     monkeypatch.setattr(assistant_module, "LanguageModel", DummyLanguageModel)
 
@@ -436,7 +436,7 @@ def test_stream_reply_freeform_uses_structured_messages(monkeypatch, tmp_path):
 
     chunks = asyncio.run(collect())
 
-    assert chunks == ["normal ", "reply"]
+    assert chunks == ["normal reply"]
     assert captured["prompt"] is None
     messages = captured["messages"]
     assert isinstance(messages, list)
@@ -487,7 +487,7 @@ def test_stream_reply_direct_conversation_bypasses_llm(monkeypatch, tmp_path):
     async def collect():
         return [chunk async for chunk in asst.stream_reply("hello")]
 
-    assert asyncio.run(collect()) == ["Hello. How can I help?"]
+    assert " ".join(asyncio.run(collect())) == "Hello. How can I help?"
 
 
 def test_generate_reply_direct_recipe_bypasses_shopping_and_llm(monkeypatch, tmp_path):
@@ -533,9 +533,9 @@ def test_stream_reply_direct_recipe_bypasses_llm(monkeypatch, tmp_path):
 
     chunks = asyncio.run(collect())
 
-    assert len(chunks) == 1
-    assert "chocolate cake recipe" in chunks[0].lower()
-    assert "shopping list" not in chunks[0].lower()
+    streamed_text = " ".join(chunks)
+    assert "chocolate cake recipe" in streamed_text.lower()
+    assert "shopping list" not in streamed_text.lower()
 
 
 def test_generate_reply_suppresses_unverified_action_claim(monkeypatch, tmp_path):
@@ -660,10 +660,10 @@ def test_stream_reply_suppresses_unverified_action_claim(monkeypatch, tmp_path):
 
     chunks = asyncio.run(collect())
 
-    assert chunks == [
+    assert " ".join(chunks) == (
         "I did not change anything. Please tell me exactly what you want me to add, "
         "send, save, or update."
-    ]
+    )
 
 
 def test_generate_reply_direct_time_query_bypasses_llm(monkeypatch, tmp_path):

--- a/tests/test_assistant_identity_binding.py
+++ b/tests/test_assistant_identity_binding.py
@@ -388,7 +388,7 @@ class TestExplicitIdentityWorks:
         a = _make_assistant(user_id=None)
         ir = MagicMock()
         ir.route.return_value = IntentResult(
-            handled=True, response="Hello. How can I help?", intent_type="greeting"
+            handled=True, response="Direct answer.", intent_type="direct_answer"
         )
         a._intent_router = ir
 
@@ -396,7 +396,7 @@ class TestExplicitIdentityWorks:
             return [chunk async for chunk in a.stream_reply("hello", active_user_id="alice")]
 
         chunks = asyncio.run(_consume())
-        assert chunks == ["Hello. How can I help?"]
+        assert chunks == ["Direct answer."]
         assert any("hello" in t.text for t in a._history_for("alice"))
         assert "default" not in a._histories
 

--- a/tests/test_assistant_streaming.py
+++ b/tests/test_assistant_streaming.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from rex.assistant import Assistant
+from rex.latency import LatencyTrace
+from rex.runtime.events import EventKind, TurnEventStream
+from rex.runtime.turn import (
+    AuthorizationSnapshotRef,
+    ResponseMode,
+    TurnContext,
+    TurnScope,
+    TurnSource,
+)
+
+
+def test_stream_reply_uses_shared_turn_pipeline_not_legacy_provider_stream() -> None:
+    source = inspect.getsource(Assistant.stream_reply)
+
+    assert "execute_async" in source
+    assert "_run_reply_turn" in source
+    assert "_stream_model_reply" not in source
+    assert "_stream_home_assistant_completion" not in source
+    assert "_generate_model_reply" not in source
+
+
+def test_safe_stream_delivery_emits_metadata_only_sentence_deltas() -> None:
+    assistant = Assistant.__new__(Assistant)
+    context = TurnContext.create(
+        user_id="james",
+        scope=TurnScope.USER,
+        source=TurnSource.ASSISTANT,
+        device_id=None,
+        response_mode=ResponseMode.SCREEN,
+        authorization=AuthorizationSnapshotRef("policy:v1", "permissions:james:v1"),
+    )
+    observed = []
+    stream = TurnEventStream(context, observer=observed.append)
+    delivered: list[str] = []
+
+    async def sink(chunk: str) -> None:
+        delivered.append(chunk)
+
+    asyncio.run(
+        assistant._deliver_safe_response(
+            "First sentence. Second sentence.",
+            turn_events=stream,
+            response_sink=sink,
+            latency_trace=LatencyTrace(channel="chat"),
+            stream_started_ns=None,
+        )
+    )
+
+    assert delivered == ["First sentence.", "Second sentence."]
+    assert [event.kind for event in observed] == [
+        EventKind.RESPONSE_PROGRESS,
+        EventKind.RESPONSE_PROGRESS,
+    ]
+    assert [event.details["index"] for event in observed] == [0, 1]
+    assert all(event.details["stage"] == "delta" for event in observed)
+    assert all("First sentence" not in repr(event.details) for event in observed)
+    assert all("Second sentence" not in repr(event.details) for event in observed)


### PR DESCRIPTION
## Summary
- replace reduced-intelligence provider-token streaming with the same TurnEngine reply pipeline as generate_reply
- share intent routing, per-user cache, ModelRouter fallback/escalation, ContextBuilder, ActionDispatcher/tool verification, ResultHandler, ResponseBuilder, history, and errors across delivery modes
- stream only post-validation sentence chunks and emit metadata-only ordered response deltas before the canonical terminal event
- preserve TOOL_REQUEST/internal-syntax and unverified-action suppression before user delivery
- keep fail-closed identity outside TurnEngine and defer exact interface provenance to US-097
- add parity and streaming-contract tests; update architecture truth and PRD evidence

## Local validation
- 12 passed: exact US-096 PRD validation command
- 305 passed: combined runtime/streaming/identity/action/verification/docs/mobile/Electron/voice sweep
- 33 passed: mobile stream/strong-auth/Electron verification/voice latency/voice-loop-fix sweep
- ruff, black, mypy, compileall, deprecated-API guard, git diff --check all pass
- 2 warnings in the combined sweep are pre-existing deliberate deprecation checks in tests/test_voice_loop_fixes.py

US-096 only. Interface adapter provenance/parity remains deferred to US-097.