### PR TITLE
feat(capabilities): consolidate canonical registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,8 @@ Home Assistant safety:
 
 - Every `TurnContext` owns exactly one idempotent `TurnCancellation`. `TurnEngine.cancel_turn()` is identity-bound to the validated owner and emits one canonical `cancelled` terminal outcome. Blocking/async model, retrieval, tool/OpenClaw, response-delivery, and TTS boundaries must observe the current turn cancellation and discard stale output. Cancellation is never rollback: once a mutation may have been dispatched, its canonical outcome remains `attempted_unverified` until independent verification proves otherwise.
 
+- `rex.capabilities.registry.Capability` is the canonical Capability/Tool Card metadata schema. The global `rex.tools.registry.ToolRegistry` binds executable handlers to that same `CapabilityRegistry`; duplicate IDs with divergent metadata fail closed unless a migration explicitly uses `replace=True`. Static source/schema/permission/operation/risk/verification metadata is local authority, while runtime enabled/health evidence may be updated explicitly. OpenClaw compatibility registries adapt remote cards through this authority and may never overwrite an existing local security classification; unknown remote tools default to identity-required sensitive mutations. Capability permissions are descriptive metadata only: current-user authorization is resolved at selection time and rechecked at execution time, with `admin` satisfying declared Rex permissions.
+
 - Prefer clear, testable functions over clever code.
 - Keep changes small and reviewable.
 - Add logging for non-trivial behavior.

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -3364,7 +3364,7 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 - [x] If cancellation/transport loss occurs after a mutation may have dispatched, outcome is `attempted/unverified` until independently proven, never fabricated as failure/success.
 - [x] Cancelling one user/turn cannot cancel another user's concurrent work.
 - [x] Tests cover cancellation before dispatch, during generation, during read-only work, after mutation dispatch, and repeated cancellation calls.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_turn_cancellation.py tests/rex2/test_cancellation_identity_isolation.py -q`; `mypy rex/runtime rex/openclaw --ignore-missing-imports`.
 
@@ -3535,11 +3535,11 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 **Files/areas likely involved:** `rex/capabilities/`, existing tool registries/consumers, OpenClaw adapters, capability inventory docs.
 
 **Acceptance Criteria:**
-- [ ] One authoritative Capability/Tool Card schema records ID/source/input-output schema/enabled state/required permissions/health/operation type/risk/verification support and user-facing description/examples.
-- [ ] Existing local registries adapt into or migrate to that authority; duplicate metadata cannot silently diverge.
-- [ ] Registry metadata itself is deterministic; authorization is always evaluated for the current user at selection/execution time.
-- [ ] Compatibility adapters keep current callers functional until their migration removes obsolete paths.
-- [ ] Tests detect duplicate IDs/schema drift and prove remote metadata cannot overwrite local security classification.
+- [x] One authoritative Capability/Tool Card schema records ID/source/input-output schema/enabled state/required permissions/health/operation type/risk/verification support and user-facing description/examples.
+- [x] Existing local registries adapt into or migrate to that authority; duplicate metadata cannot silently diverge.
+- [x] Registry metadata itself is deterministic; authorization is always evaluated for the current user at selection/execution time.
+- [x] Compatibility adapters keep current callers functional until their migration removes obsolete paths.
+- [x] Tests detect duplicate IDs/schema drift and prove remote metadata cannot overwrite local security classification.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_capability_registry.py tests/test_tool_registry.py -q`; `mypy rex/capabilities --ignore-missing-imports`.

--- a/docs/CAPABILITY-PARITY.md
+++ b/docs/CAPABILITY-PARITY.md
@@ -49,12 +49,13 @@ Enabled state is evidence-based: `configured` means required values are stored; 
 
 ## Migration appendix: current registries to canonical Capability Registry
 
-US-106 owns the runtime consolidation. US-064 records the authorities and duplication that must be adapted rather than silently replaced.
+US-106 completed the runtime metadata consolidation. The canonical `Capability` / Tool Card authority now lives in `rex/capabilities/registry.py`; executable and OpenClaw registries are compatibility adapters over that authority. US-064 remains the release-truth inventory for UI parity.
 
 | Current registry / metadata source | Current authority and consumers | Duplicate or divergent metadata | Target adapter into canonical Capability Registry |
 |---|---|---|---|
-| `rex/capabilities/registry.py` | Python capability/profile feature registry; consumed by capability query/runtime code | capability name/description/enabled semantics overlap Electron and mobile representations | Python capability adapter preserving profile/enablement rules |
-| `rex/openclaw/tool_registry.py` | OpenClaw/Rex tool metadata, health checks, risk/tool execution consumers | tool name, description, health, availability and risk overlap capability metadata | tool adapter that contributes operations, risk, health and verification without granting authority |
+| `rex/capabilities/registry.py` | **Canonical Capability / Tool Card metadata authority** consumed by capability query/runtime code and executable adapters | legacy capability fields remain as compatibility aliases | owns stable ID/source/schema/enabled/permissions/health/operation/risk/verification/description/examples and rejects divergent duplicate metadata |
+| `rex/tools/registry.py` | executable local tool handlers and selection compatibility | previously duplicated description/config/security metadata | binds handlers to canonical Tool Cards; the default singleton shares the global Capability Registry and rechecks live user permissions |
+| `rex/openclaw/tool_registry.py` | OpenClaw metadata, health checks, planner compatibility | remote metadata previously mirrored by replacement into the executable registry | adapts remote cards through the canonical registry; local security metadata cannot be overwritten and unknown remote tools enter conservatively |
 | `gui/src/main/integrationInventory.ts` | Electron integration/capability cards and settings/status consumers | names, configure routes, enabled state and health presentation are Electron-specific duplicates | Electron presentation adapter derived from canonical capability records plus local settings routes |
 | `rex/integration_state.py` and provider status helpers | canonical evidence vocabulary for integration readiness | state is sometimes re-expressed by GUI/tool-specific booleans | health/evidence adapter; retain evidence vocabulary as authoritative state semantics |
 | mobile capability/grant modules under `rex/mobile_*` | paired-device capabilities and least-privilege grants | mobile surface has a separate capability shape and false scaffolding flags | mobile adapter filters canonical records by device grants and implemented endpoint support |

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1784,3 +1784,25 @@ Local evidence:
 - `mypy rex/runtime rex/openclaw --ignore-missing-imports`: success, no issues in 38 source files.
 - US-097 PR #379 passed all 18 relevant checks and merged as `4c2ae7170f4ee9e151a30db3bb1ffdcf1f21868a`; its final PRD CI criterion is now closed.
 - US-098 GitHub checks remain pending until this story PR is pushed; its final PRD checkbox intentionally remains open.
+
+2026-08-11 - US-106 canonical Capability Registry and Tool Cards
+
+Implementation:
+- Expanded `rex.capabilities.registry.Capability` into the canonical Tool Card schema covering stable ID/source, input/output schemas, enabled and health evidence, required permissions, operation/risk, verification support, descriptions/examples, identity/config requirements, and compatibility aliases.
+- Canonical metadata rejects divergent duplicate IDs; static security metadata is sealed after construction, while runtime enabled/health/integration evidence is updated explicitly.
+- Bound the default executable `rex.tools.registry.ToolRegistry` to the same global Capability Registry and made capability/tool singleton resets rebind together.
+- Preserved isolated compatibility registries while requiring explicit replacement for legacy executable metadata migration; duplicate schema drift otherwise fails closed.
+- Added current-user permission filtering at tool selection and a second permission check inside the execution lifecycle; `admin` satisfies declared Rex permissions.
+- Added canonical built-in permission metadata for email, SMS, Home Assistant/music, and local computer/file tools without changing the existing permission vocabulary.
+- Migrated `rex.openclaw.tool_registry` through canonical remote-card registration. Existing local security classification wins; unknown remote tools default to identity-required sensitive mutations; health-check evidence updates canonical runtime health.
+- Updated `CLAUDE.md` and `docs/CAPABILITY-PARITY.md` to make the implemented registry authority and adapter boundaries explicit.
+
+Local evidence:
+- TDD red phases proved missing Tool Card fields/conflict contracts, missing current-user permission filtering/recheck, separate global registry authorities, OpenClaw security overwrite/conservative-default gaps, and unsynchronized remote health evidence before each implementation slice.
+- Exact PRD validation: `pytest tests/rex2/test_capability_registry.py tests/test_tool_registry.py -q` -> 57 passed on Python 3.11.9.
+- Final registry/planner/tool/TurnEngine/capability-status/mobile-action compatibility matrix -> 437 passed.
+- CLI tool-registry compatibility after the supported `set_tool_registry(None)` reset API change -> 22 passed.
+- Exact `mypy rex/capabilities --ignore-missing-imports` passes; expanded mypy passes on the five additional changed runtime modules.
+- Ruff and Black pass on every touched Python/test file; `git diff --check` is clean.
+- US-098 PR #380 passed all 18 relevant GitHub checks and merged as `0adf4ca4fcc8865a52b0ab6ef855890482c62e6c`; its final PRD CI criterion is now closed.
+- US-106 GitHub checks remain pending until this story PR is pushed; its final PRD checkbox intentionally remains open.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1806,3 +1806,10 @@ Local evidence:
 - Ruff and Black pass on every touched Python/test file; `git diff --check` is clean.
 - US-098 PR #380 passed all 18 relevant GitHub checks and merged as `0adf4ca4fcc8865a52b0ab6ef855890482c62e6c`; its final PRD CI criterion is now closed.
 - US-106 GitHub checks remain pending until this story PR is pushed; its final PRD checkbox intentionally remains open.
+US-106 PR #382 CI follow-up (2026-08-11):
+- Initial Python 3.11 Tests & Coverage exposed two compatibility regressions not reached by the earlier focused matrix. First, `ActionDispatcher` passed the new `user_id` keyword directly to every `select_tools` compatibility adapter, breaking older selectors that implement only `select_tools(message)`. Second, the first compatibility fallback used dynamic `getattr`, so an unspecced `MagicMock` fabricated a `select_tools_for_user` attribute and bypassed its configured legacy selector.
+- Fixed the root cause without weakening live authorization: canonical `ToolDispatcher` now exposes `select_tools_for_user(...)`, while `ActionDispatcher` uses `inspect.getattr_static` to call that extension only when it is actually defined and otherwise preserves the legacy `select_tools(message)` contract.
+- Reproduced/fixed regression tests: latency compatibility selector, real-dispatcher TurnEngine capability/action boundary emission, and canonical permission-aware selection all pass together (3 passed).
+- Complete non-mobile/non-Rex2 marker surface -> 8,195 passed, 49 skipped. Mobile + Rex2 marker surface -> 424 passed. Combined CI marker set therefore reports 8,619 passed and 49 skipped.
+- CI-equivalent pytest+coverage report -> 8,619 passed, 49 skipped; required 75% coverage reached at 83.52%. The local PowerShell wrapper itself reported a nonzero shell result after post-pytest Torch shutdown logging to a closed stream, so GitHub CI remains the authoritative process-exit gate for the republished head.
+- US-106 final GitHub-check criterion remains open until the corrected immutable PR head passes the complete repository matrix.

--- a/rex/actions/dispatcher.py
+++ b/rex/actions/dispatcher.py
@@ -293,7 +293,7 @@ class ActionDispatcher:
         # 6. Auto tool dispatch: build pre-LLM tool context string
         _tool_context: str | None = None
         if self._tool_dispatcher is not None:
-            _selected_tools = self._tool_dispatcher.select_tools(transcript)
+            _selected_tools = self._tool_dispatcher.select_tools(transcript, user_id=effective_user)
             if mobile_action_context_active():
                 # Pre-LLM dispatch has only free-form transcript text. Mobile
                 # mutations must wait for a canonical structured tool call so

--- a/rex/actions/dispatcher.py
+++ b/rex/actions/dispatcher.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import inspect
 import logging
 import re
 import time
@@ -293,7 +294,17 @@ class ActionDispatcher:
         # 6. Auto tool dispatch: build pre-LLM tool context string
         _tool_context: str | None = None
         if self._tool_dispatcher is not None:
-            _selected_tools = self._tool_dispatcher.select_tools(transcript, user_id=effective_user)
+            defined_select_for_user = inspect.getattr_static(
+                self._tool_dispatcher, "select_tools_for_user", None
+            )
+            if defined_select_for_user is not None:
+                select_for_user = self._tool_dispatcher.select_tools_for_user
+                _selected_tools = select_for_user(transcript, user_id=effective_user)
+            else:
+                # Compatibility adapters predating US-106 implement only
+                # select_tools(message). The canonical dispatcher exposes the
+                # user-aware extension above, while older adapters remain valid.
+                _selected_tools = self._tool_dispatcher.select_tools(transcript)
             if mobile_action_context_active():
                 # Pre-LLM dispatch has only free-form transcript text. Mobile
                 # mutations must wait for a canonical structured tool call so

--- a/rex/capabilities/registry.py
+++ b/rex/capabilities/registry.py
@@ -18,22 +18,32 @@ from __future__ import annotations
 import builtins
 import logging
 from dataclasses import dataclass, field
+from typing import Any, ClassVar, Literal
 
 logger = logging.getLogger(__name__)
 
 
+class CapabilityConflictError(ValueError):
+    """Raised when duplicate capability metadata would silently diverge."""
+
+
+class SecurityClassificationError(CapabilityConflictError):
+    """Raised when remote metadata attempts to weaken local security metadata."""
+
+
+_ALLOWED_SOURCES = {"local", "openclaw", "integration", "system"}
+_ALLOWED_HEALTH = {"unknown", "healthy", "degraded", "unhealthy", "unavailable"}
+_ALLOWED_OPERATIONS = {"read", "mutation"}
+_ALLOWED_RISKS = {"safe", "sensitive", "prohibited"}
+
+
 @dataclass
 class Capability:
-    """Metadata describing a single Rex capability.
+    """Canonical Capability / Tool Card metadata.
 
-    Attributes:
-        name: Unique slug for the capability (e.g. ``"home_assistant"``).
-        description: Human-readable description of what the capability does.
-        inputs: List of input parameter names / types the capability accepts.
-        outputs: List of output value names / types the capability returns.
-        triggers: Words or phrases that typically invoke this capability.
-        enabled: Whether the capability is currently available for use.
-        category: Grouping label used by the UI (e.g. "Home", "Search").
+    ``name`` remains the compatibility spelling for the canonical ``id``. Static
+    metadata is sealed after construction so runtime state updates cannot silently
+    rewrite source, schemas, permissions, operation, risk, or verification policy.
     """
 
     name: str
@@ -46,12 +56,139 @@ class Capability:
     integration_state: str | None = None
     read_capable: bool | None = None
     write_capable: bool | None = None
+    source: str = "local"
+    input_schema: dict[str, str] = field(default_factory=dict)
+    output_schema: dict[str, str] = field(default_factory=dict)
+    required_permissions: tuple[str, ...] = ()
+    health: str = "unknown"
+    operation: Literal["read", "mutation"] = "read"
+    risk: Literal["safe", "sensitive", "prohibited"] = "safe"
+    verification_supported: bool = False
+    examples: tuple[str, ...] = ()
+    requires_identity: bool = False
+    required_args: tuple[str, ...] = ()
+    requires_config: tuple[str, ...] = ()
+    _sealed: bool = field(default=False, init=False, repr=False, compare=False)
+
+    _STATIC_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "name",
+            "description",
+            "inputs",
+            "outputs",
+            "triggers",
+            "category",
+            "source",
+            "input_schema",
+            "output_schema",
+            "required_permissions",
+            "operation",
+            "risk",
+            "verification_supported",
+            "examples",
+            "requires_identity",
+            "required_args",
+            "requires_config",
+        }
+    )
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, "_sealed", False) and name in self._STATIC_FIELDS:
+            raise AttributeError(f"Capability static metadata is sealed: {name}")
+        object.__setattr__(self, name, value)
 
     def __post_init__(self) -> None:
-        if not self.name:
+        name = self.name.strip()
+        description = self.description.strip()
+        if not name:
             raise ValueError("Capability name cannot be empty")
-        if not self.description:
+        if not description:
             raise ValueError("Capability description cannot be empty")
+        source = self.source.strip().lower()
+        if source not in _ALLOWED_SOURCES:
+            raise ValueError(f"Unsupported capability source: {self.source!r}")
+        if self.health not in _ALLOWED_HEALTH:
+            raise ValueError(f"Unsupported capability health: {self.health!r}")
+        if self.operation not in _ALLOWED_OPERATIONS:
+            raise ValueError(f"Unsupported capability operation: {self.operation!r}")
+        if self.risk not in _ALLOWED_RISKS:
+            raise ValueError(f"Unsupported capability risk: {self.risk!r}")
+
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "source", source)
+        input_schema = dict(self.input_schema) or dict.fromkeys(self.inputs, "any")
+        output_schema = dict(self.output_schema) or dict.fromkeys(self.outputs, "any")
+        object.__setattr__(self, "input_schema", dict(sorted(input_schema.items())))
+        object.__setattr__(self, "output_schema", dict(sorted(output_schema.items())))
+        object.__setattr__(
+            self, "inputs", list(input_schema) if input_schema else list(self.inputs)
+        )
+        object.__setattr__(
+            self, "outputs", list(output_schema) if output_schema else list(self.outputs)
+        )
+        object.__setattr__(self, "triggers", sorted(dict.fromkeys(self.triggers)))
+        object.__setattr__(
+            self, "required_permissions", tuple(sorted(set(self.required_permissions)))
+        )
+        object.__setattr__(self, "examples", tuple(dict.fromkeys(self.examples)))
+        object.__setattr__(self, "required_args", tuple(dict.fromkeys(self.required_args)))
+        object.__setattr__(self, "requires_config", tuple(dict.fromkeys(self.requires_config)))
+        object.__setattr__(self, "_sealed", True)
+
+    @property
+    def id(self) -> str:
+        """Canonical stable identifier (legacy name alias)."""
+        return self.name
+
+    def security_signature(self) -> tuple[object, ...]:
+        return (
+            self.operation,
+            self.risk,
+            self.required_permissions,
+            self.requires_identity,
+            self.verification_supported,
+        )
+
+    def static_signature(self) -> tuple[object, ...]:
+        return (
+            self.name,
+            self.description,
+            tuple(self.inputs),
+            tuple(self.outputs),
+            tuple(self.triggers),
+            self.category,
+            self.source,
+            tuple(self.input_schema.items()),
+            tuple(self.output_schema.items()),
+            self.required_permissions,
+            self.operation,
+            self.risk,
+            self.verification_supported,
+            self.examples,
+            self.requires_identity,
+            self.required_args,
+            self.requires_config,
+        )
+
+    def to_metadata(self) -> dict[str, object]:
+        """Return deterministic, serializable metadata without user-specific authority."""
+        return {
+            "id": self.id,
+            "source": self.source,
+            "description": self.description,
+            "input_schema": dict(self.input_schema),
+            "output_schema": dict(self.output_schema),
+            "enabled": self.enabled,
+            "required_permissions": list(self.required_permissions),
+            "health": self.health,
+            "operation": self.operation,
+            "risk": self.risk,
+            "verification_supported": self.verification_supported,
+            "examples": list(self.examples),
+            "category": self.category,
+            "triggers": list(self.triggers),
+        }
 
 
 class CapabilityRegistry:
@@ -83,14 +220,47 @@ class CapabilityRegistry:
     # Mutation helpers
     # ------------------------------------------------------------------
 
-    def register(self, capability: Capability) -> None:
-        """Add or overwrite a capability in the registry.
+    def register(self, capability: Capability, *, replace: bool = False) -> Capability:
+        """Register canonical metadata without silent duplicate drift."""
+        existing = self._capabilities.get(capability.id)
+        if existing is not None:
+            if existing.static_signature() == capability.static_signature():
+                return existing
+            if not replace:
+                raise CapabilityConflictError(
+                    f"Capability {capability.id!r} is already registered with different metadata"
+                )
+        self._capabilities[capability.id] = capability
+        logger.debug("Registered capability: %s", capability.id)
+        return capability
 
-        Args:
-            capability: :class:`Capability` instance to register.
-        """
-        self._capabilities[capability.name] = capability
-        logger.debug("Registered capability: %s", capability.name)
+    def register_remote(self, capability: Capability) -> Capability:
+        """Register remote metadata without weakening an existing local card."""
+        if capability.source != "openclaw":
+            raise ValueError("register_remote() requires source='openclaw'")
+        existing = self._capabilities.get(capability.id)
+        if existing is None:
+            return self.register(capability)
+        if existing.security_signature() != capability.security_signature():
+            raise SecurityClassificationError(
+                f"Remote metadata for {capability.id!r} conflicts with local security classification"
+            )
+        if existing.source != "openclaw":
+            return existing
+        return self.register(capability)
+
+    def update_runtime_state(self, name: str, **updates: object) -> Capability:
+        """Update only mutable operational evidence for a registered card."""
+        capability = self._capabilities[name]
+        allowed = {"enabled", "health", "integration_state", "read_capable", "write_capable"}
+        invalid = set(updates) - allowed
+        if invalid:
+            raise ValueError(f"Static capability metadata cannot be updated: {sorted(invalid)}")
+        for field_name, value in updates.items():
+            setattr(capability, field_name, value)
+        if capability.health not in _ALLOWED_HEALTH:
+            raise ValueError(f"Unsupported capability health: {capability.health!r}")
+        return capability
 
     def unregister(self, name: str) -> bool:
         """Remove a capability by name.
@@ -147,6 +317,20 @@ class CapabilityRegistry:
             if q in haystack:
                 results.append(cap)
         return sorted(results, key=lambda c: c.name)
+
+    def metadata_snapshot(self) -> builtins.list[dict[str, object]]:
+        """Return a deterministic metadata snapshot sorted by stable ID."""
+        return [cap.to_metadata() for cap in self.list(include_disabled=True)]
+
+    def is_authorized(self, name: str, granted_permissions: set[str] | frozenset[str]) -> bool:
+        """Evaluate authority from the caller's current permission snapshot."""
+        capability = self.get(name)
+        if capability is None:
+            return False
+        granted = set(granted_permissions)
+        if "admin" in granted:
+            return True
+        return set(capability.required_permissions).issubset(granted)
 
     def get(self, name: str) -> Capability | None:
         """Look up a capability by exact name.
@@ -246,8 +430,10 @@ _BUILTIN_CAPABILITIES: list[Capability] = [
 def _build_default_registry() -> CapabilityRegistry:
     """Create a registry pre-loaded with built-in capabilities (all disabled by default)."""
     registry = CapabilityRegistry()
+    executable_tool_ids = {"time_now", "weather_now", "web_search", "send_email"}
     for cap in _BUILTIN_CAPABILITIES:
-        registry.register(cap)
+        if cap.name not in executable_tool_ids:
+            registry.register(cap)
     return registry
 
 
@@ -330,7 +516,10 @@ def get_capability_registry(config: object | None = None) -> CapabilityRegistry:
     global _registry
     if _registry is None:
         _registry = _build_default_registry()
-        logger.debug("CapabilityRegistry created with %d built-in capabilities", len(_registry))
+        from rex.tools.registry import ensure_default_registry  # noqa: PLC0415
+
+        ensure_default_registry(_registry)
+        logger.debug("CapabilityRegistry created with %d canonical capabilities", len(_registry))
     if config is not None:
         populate_from_config(_registry, config)
     return _registry
@@ -340,11 +529,19 @@ def reset_capability_registry() -> None:
     """Reset the global registry (useful in tests)."""
     global _registry
     _registry = None
+    try:
+        from rex.tools.registry import reset_default_registry  # noqa: PLC0415
+
+        reset_default_registry()
+    except ImportError:
+        pass
 
 
 __all__ = [
     "Capability",
+    "CapabilityConflictError",
     "CapabilityRegistry",
+    "SecurityClassificationError",
     "get_capability_registry",
     "populate_from_config",
     "reset_capability_registry",

--- a/rex/openclaw/tool_registry.py
+++ b/rex/openclaw/tool_registry.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from rex.credentials import CredentialManager, get_credential_manager
+
+if TYPE_CHECKING:
+    from rex.tools.registry import ToolRegistry as CanonicalToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +54,14 @@ class ToolMeta:
     health_check: HealthCheckFn = field(default=_default_health_check)
     version: str = "1.0.0"
     enabled: bool = True
+    operation: Literal["read", "mutation"] = "mutation"
+    risk: Literal["safe", "sensitive", "prohibited"] = "sensitive"
+    requires_identity: bool = True
+    required_permissions: tuple[str, ...] = ()
+    input_schema: dict[str, str] = field(default_factory=dict)
+    output_schema: dict[str, str] = field(default_factory=dict)
+    examples: tuple[str, ...] = ()
+    verification_supported: bool = False
 
     def __post_init__(self) -> None:
         """Validate tool metadata after initialization."""
@@ -144,6 +155,7 @@ class ToolRegistry:
         self,
         *,
         credential_manager: CredentialManager | None = None,
+        canonical_registry: CanonicalToolRegistry | None = None,
     ) -> None:
         """Initialize the tool registry.
 
@@ -154,6 +166,21 @@ class ToolRegistry:
         self._tools: dict[str, ToolMeta] = {}
         self._openclaw_meta: dict[str, OpenClawToolMeta] = {}
         self._credential_manager = credential_manager
+        if canonical_registry is None:
+            from rex.tools.registry import ToolRegistry as CanonicalToolRegistryImpl
+
+            canonical_registry = CanonicalToolRegistryImpl()
+        self._canonical_registry = canonical_registry
+
+    def bind_canonical_registry(self, canonical_registry: CanonicalToolRegistry) -> None:
+        """Promote this compatibility registry onto the supplied metadata authority."""
+        if self._canonical_registry is canonical_registry:
+            return
+        tools = list(self._tools.values())
+        metadata = dict(self._openclaw_meta)
+        self._canonical_registry = canonical_registry
+        for tool in tools:
+            self.register_tool(tool, openclaw_meta=metadata.get(tool.name))
 
     @property
     def credential_manager(self) -> CredentialManager:
@@ -168,54 +195,48 @@ class ToolRegistry:
         *,
         openclaw_meta: OpenClawToolMeta | None = None,
     ) -> None:
-        """Register a tool with the registry.
+        """Register OpenClaw metadata through the canonical Capability authority."""
+        from rex.capabilities.registry import Capability
 
-        If a tool with the same name already exists, it will be overwritten.
-        Also registers a stub entry in the canonical ``rex.tools.registry``
-        with ``source="openclaw"`` so that ``list_tools()`` on the canonical
-        registry surfaces OpenClaw tools alongside local ones.
+        canonical = self._canonical_registry
+        existing_card = canonical.capability_registry.get(tool.name)
+        if existing_card is not None and existing_card.source != "openclaw":
+            operation = existing_card.operation
+            risk = existing_card.risk
+            requires_identity = existing_card.requires_identity
+            required_permissions = existing_card.required_permissions
+            verification_supported = existing_card.verification_supported
+        else:
+            operation = tool.operation
+            risk = tool.risk
+            requires_identity = tool.requires_identity
+            required_permissions = tool.required_permissions
+            verification_supported = tool.verification_supported
 
-        Args:
-            tool:          ToolMeta instance containing tool metadata.
-            openclaw_meta: Optional OpenClaw-specific metadata.  A default
-                           ``OpenClawToolMeta`` is created automatically when
-                           not provided.
-        """
+        remote_card = Capability(
+            name=tool.name,
+            description=tool.description,
+            triggers=list(tool.capabilities),
+            enabled=tool.enabled,
+            category="OpenClaw",
+            source="openclaw",
+            input_schema=dict(tool.input_schema),
+            output_schema=dict(tool.output_schema),
+            required_permissions=required_permissions,
+            health="unknown",
+            operation=operation,
+            risk=risk,
+            verification_supported=verification_supported,
+            examples=tool.examples,
+            requires_identity=requires_identity,
+        )
+        canonical.register_remote_card(
+            remote_card,
+            handler=None if existing_card is not None else _openclaw_remote_only_handler,
+        )
         self._tools[tool.name] = tool
-        # Keep OpenClaw-specific metadata separate from the canonical entry.
         self._openclaw_meta[tool.name] = openclaw_meta or OpenClawToolMeta(name=tool.name)
-
-        # Mirror into the canonical tool registry so list_tools() shows it.
-        try:
-            from rex.tools.registry import Tool, get_default_registry
-
-            _canonical = get_default_registry()
-            existing = _canonical.get(tool.name)
-            requires_config = list(existing.requires_config) if existing is not None else []
-            _canonical.register(
-                Tool(
-                    name=tool.name,
-                    description=tool.description,
-                    capability_tags=list(tool.capabilities),
-                    requires_config=requires_config,
-                    handler=(
-                        existing.handler if existing is not None else _openclaw_remote_only_handler
-                    ),
-                    source=existing.source if existing is not None else "openclaw",
-                    operation=existing.operation if existing is not None else "read",
-                    risk=existing.risk if existing is not None else "safe",
-                    requires_identity=(
-                        existing.requires_identity if existing is not None else False
-                    ),
-                    required_args=(existing.required_args if existing is not None else ()),
-                    verifier=existing.verifier if existing is not None else None,
-                )
-            )
-        except Exception:
-            # Never let canonical-registry mirroring break OpenClaw registration.
-            logger.debug("tool_registry: failed to mirror %r into canonical registry", tool.name)
-
-        logger.debug("Registered tool: %s", tool.name)
+        logger.debug("Registered OpenClaw tool: %s", tool.name)
 
     def lookup(self, name: str) -> Callable[..., Any] | None:
         """Delegate to the canonical registry to look up a tool handler.
@@ -228,13 +249,8 @@ class ToolRegistry:
         Returns:
             The tool handler callable, or ``None`` if not found.
         """
-        try:
-            from rex.tools.registry import get_default_registry
-
-            canonical_tool = get_default_registry().get(name)
-            return canonical_tool.handler if canonical_tool is not None else None
-        except Exception:
-            return None
+        canonical_tool = self._canonical_registry.get(name)
+        return canonical_tool.handler if canonical_tool is not None else None
 
     def unregister_tool(self, name: str) -> bool:
         """Unregister a tool from the registry.
@@ -341,12 +357,25 @@ class ToolRegistry:
             raise ToolNotFoundError(name)
 
         if not tool.enabled:
+            if self._canonical_registry.capability_registry.get(name) is not None:
+                self._canonical_registry.capability_registry.update_runtime_state(
+                    name, enabled=False, health="unavailable"
+                )
             return False, "Tool is disabled"
 
         try:
-            return tool.health_check()
+            ok, message = tool.health_check()
+            if self._canonical_registry.capability_registry.get(name) is not None:
+                self._canonical_registry.capability_registry.update_runtime_state(
+                    name, health="healthy" if ok else "unhealthy"
+                )
+            return ok, message
         except Exception as e:
             logger.error("Health check failed for %s: %s", name, e)
+            if self._canonical_registry.capability_registry.get(name) is not None:
+                self._canonical_registry.capability_registry.update_runtime_state(
+                    name, health="unhealthy"
+                )
             return False, f"Health check error: {e}"
 
     def check_all_health(self) -> dict[str, tuple[bool, str]]:
@@ -419,25 +448,29 @@ def get_tool_registry() -> ToolRegistry:
     """
     global _tool_registry
     if _tool_registry is None:
-        _tool_registry = ToolRegistry()
+        from rex.tools.registry import get_default_registry
+
+        _tool_registry = ToolRegistry(canonical_registry=get_default_registry())
         _register_builtin_tools(_tool_registry)
     return _tool_registry
 
 
-def set_tool_registry(registry: ToolRegistry) -> None:
-    """Set the global tool registry instance.
-
-    Args:
-        registry: The ToolRegistry instance to use globally.
-    """
+def set_tool_registry(registry: ToolRegistry | None) -> None:
+    """Set the global tool registry and bind it to canonical metadata authority."""
     global _tool_registry
+    if registry is not None:
+        from rex.tools.registry import get_default_registry
+
+        registry.bind_canonical_registry(get_default_registry())
     _tool_registry = registry
 
 
 def reset_tool_registry() -> None:
     """Reset the global tool registry instance to the default state."""
     global _tool_registry
-    _tool_registry = ToolRegistry()
+    from rex.tools.registry import get_default_registry
+
+    _tool_registry = ToolRegistry(canonical_registry=get_default_registry())
     _register_builtin_tools(_tool_registry)
 
 

--- a/rex/tools/dispatcher.py
+++ b/rex/tools/dispatcher.py
@@ -197,6 +197,20 @@ class ToolDispatcher:
         scored.sort(key=lambda x: x[0], reverse=True)
         return [tool for _, tool in scored]
 
+    def select_tools_for_user(
+        self,
+        message: str,
+        *,
+        user_id: str,
+        granted_permissions: set[str] | frozenset[str] | None = None,
+    ) -> list[Tool]:
+        """Select tools with the current user's live authorization context."""
+        return self.select_tools(
+            message,
+            user_id=user_id,
+            granted_permissions=granted_permissions,
+        )
+
     def execute_tools(
         self, tools: list[Tool], message: str, *, user_id: str | None = None
     ) -> dict[str, Any]:

--- a/rex/tools/dispatcher.py
+++ b/rex/tools/dispatcher.py
@@ -117,8 +117,14 @@ class ToolDispatcher:
     # Public API
     # ------------------------------------------------------------------
 
-    def select_tools(self, message: str) -> list[Tool]:
-        """Return tools whose domain matches the user's intent in *message*.
+    def select_tools(
+        self,
+        message: str,
+        *,
+        user_id: str | None = None,
+        granted_permissions: set[str] | frozenset[str] | None = None,
+    ) -> list[Tool]:
+        """Return authorized tools whose domain matches the user's intent in *message*.
 
         Intent detection is keyword-based.  Each candidate tool is scored by
         the number of its ``capability_tags`` that appear in the set of tags
@@ -134,10 +140,32 @@ class ToolDispatcher:
         Returns:
             Confidence-sorted list of matched ``Tool`` objects (deduped).
         """
+        current_permissions = granted_permissions
+        if current_permissions is None and user_id:
+            try:
+                from rex.permissions import get_permissions  # noqa: PLC0415
+
+                current_permissions = frozenset(get_permissions(user_id))
+            except Exception:
+                logger.exception(
+                    "tool_dispatcher: failed to resolve permissions for user %r", user_id
+                )
+                current_permissions = frozenset()
+
         if self._config is not None:
-            candidates = self._registry.available_tools(self._config)
+            candidates = self._registry.available_tools(
+                self._config, granted_permissions=current_permissions
+            )
         else:
             candidates = self._registry.all_tools()
+            if current_permissions is not None:
+                candidates = [
+                    tool
+                    for tool in candidates
+                    if self._registry.capability_registry.is_authorized(
+                        tool.name, current_permissions
+                    )
+                ]
 
         # Determine which capability tags are triggered by matching intent rules.
         fired_tags: set[str] = set()

--- a/rex/tools/execution.py
+++ b/rex/tools/execution.py
@@ -205,6 +205,44 @@ class ToolExecutionLifecycle:
                 started,
                 error="User is not permitted to execute this tool",
             )
+
+        required_permissions = set(getattr(tool, "required_permissions", ()) or ())
+        if required_permissions:
+            raw_permissions = ambient.get("granted_permissions")
+            if raw_permissions is None:
+                try:
+                    from rex.mobile_api.action_context import (
+                        current_mobile_action_context,
+                    )  # noqa: PLC0415
+
+                    mobile_context = current_mobile_action_context()
+                except Exception:
+                    mobile_context = None
+                if mobile_context is not None:
+                    raw_permissions = mobile_context.permissions
+                elif user_id:
+                    try:
+                        from rex.permissions import get_permissions  # noqa: PLC0415
+
+                        raw_permissions = get_permissions(user_id)
+                    except Exception:
+                        logger.exception(
+                            "tool_execution: failed to resolve permissions for user %r", user_id
+                        )
+                        raw_permissions = ()
+            granted_permissions = set(raw_permissions or ())
+            if "admin" not in granted_permissions and not required_permissions.issubset(
+                granted_permissions
+            ):
+                return self._finish(
+                    request,
+                    ToolOutcome.DENIED,
+                    risk,
+                    stages,
+                    started,
+                    error="Required user permission is not granted",
+                )
+
         if risk == ToolRisk.PROHIBITED:
             return self._finish(
                 request,

--- a/rex/tools/registry.py
+++ b/rex/tools/registry.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
+
+from rex.capabilities.registry import Capability, CapabilityRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -51,12 +53,43 @@ class Tool:
     requires_identity: bool = False
     required_args: tuple[str, ...] = ()
     verifier: Callable[[dict[str, Any], Any], bool] | None = None
+    input_schema: dict[str, str] = field(default_factory=dict)
+    output_schema: dict[str, str] = field(default_factory=dict)
+    required_permissions: tuple[str, ...] = ()
+    health: str = "unknown"
+    enabled: bool = True
+    examples: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.name:
             raise ValueError("Tool name cannot be empty")
         if not self.description:
             raise ValueError("Tool description cannot be empty")
+
+    def to_capability(self) -> Capability:
+        """Project executable tool metadata into the canonical Tool Card schema."""
+        input_schema = dict(self.input_schema)
+        if not input_schema:
+            input_schema = dict.fromkeys(self.required_args, "any")
+        return Capability(
+            name=self.name,
+            description=self.description,
+            triggers=list(self.capability_tags),
+            enabled=self.enabled and not self.requires_config,
+            category="Tools",
+            source=self.source,
+            input_schema=input_schema,
+            output_schema=dict(self.output_schema),
+            required_permissions=self.required_permissions,
+            health=self.health,
+            operation=self.operation,
+            risk=self.risk,
+            verification_supported=self.verifier is not None,
+            examples=self.examples,
+            requires_identity=self.requires_identity,
+            required_args=self.required_args,
+            requires_config=tuple(self.requires_config),
+        )
 
 
 class ToolRegistry:
@@ -69,19 +102,62 @@ class ToolRegistry:
         available = registry.available_tools(app_config)
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, capability_registry: CapabilityRegistry | None = None) -> None:
         self._tools: dict[str, Tool] = {}
+        self._capability_registry = (
+            capability_registry if capability_registry is not None else CapabilityRegistry()
+        )
+
+    @property
+    def capability_registry(self) -> CapabilityRegistry:
+        """Canonical metadata authority backing this executable registry."""
+        return self._capability_registry
 
     # ------------------------------------------------------------------
     # Mutation
     # ------------------------------------------------------------------
 
-    def register(self, tool: Tool) -> None:
-        """Register *tool*, replacing any existing entry with the same name."""
-        if tool.name in self._tools:
-            logger.debug("tool_registry: replacing existing tool %r", tool.name)
+    def register(self, tool: Tool, *, replace: bool = False) -> Tool:
+        """Bind a handler to canonical metadata without silent schema drift."""
+        existing = self._tools.get(tool.name)
+        if existing is not None and existing is not tool and not replace:
+            if (
+                existing.to_capability().static_signature()
+                == tool.to_capability().static_signature()
+            ):
+                return existing
+        self._capability_registry.register(tool.to_capability(), replace=replace)
         self._tools[tool.name] = tool
         logger.debug("tool_registry: registered %r", tool.name)
+        return tool
+
+    def register_remote_card(
+        self, capability: Capability, *, handler: Callable[..., Any] | None = None
+    ) -> Capability:
+        """Adapt remote metadata without allowing it to rewrite local security policy."""
+        resolved = self._capability_registry.register_remote(capability)
+        if resolved is not capability:
+            return resolved
+        if capability.name not in self._tools and handler is not None:
+            self._tools[capability.name] = Tool(
+                name=capability.name,
+                description=capability.description,
+                capability_tags=list(capability.triggers),
+                requires_config=list(capability.requires_config),
+                handler=handler,
+                source=capability.source,
+                operation=capability.operation,
+                risk=capability.risk,
+                requires_identity=capability.requires_identity,
+                required_args=capability.required_args,
+                input_schema=dict(capability.input_schema),
+                output_schema=dict(capability.output_schema),
+                required_permissions=capability.required_permissions,
+                health=capability.health,
+                enabled=capability.enabled,
+                examples=capability.examples,
+            )
+        return resolved
 
     # ------------------------------------------------------------------
     # Query
@@ -104,18 +180,28 @@ class ToolRegistry:
         """
         from rex.tools.protocol import ToolDescriptor  # local import to avoid cycles
 
-        return [
-            ToolDescriptor(
-                name=t.name,
-                description=t.description,
-                schema={},
-                source=t.source,
+        descriptors: list[Any] = []
+        for tool in sorted(self._tools.values(), key=lambda item: item.name):
+            card = self._capability_registry.get(tool.name)
+            if card is None:
+                continue
+            descriptors.append(
+                ToolDescriptor(
+                    name=tool.name,
+                    description=tool.description,
+                    schema=dict(card.input_schema),
+                    source=card.source,
+                )
             )
-            for t in self._tools.values()
-        ]
+        return descriptors
 
-    def available_tools(self, config: Any) -> list[Tool]:
-        """Return tools whose ``requires_config`` fields are satisfied.
+    def available_tools(
+        self,
+        config: Any,
+        *,
+        granted_permissions: set[str] | frozenset[str] | None = None,
+    ) -> list[Tool]:
+        """Return tools whose config and current permission requirements are satisfied.
 
         A field is *satisfied* when ``getattr(config, field_name, None)``
         is truthy.
@@ -129,8 +215,13 @@ class ToolRegistry:
         """
         result: list[Tool] = []
         for tool in self._tools.values():
-            if self._is_available(tool, config):
-                result.append(tool)
+            if not tool.enabled or not self._is_available(tool, config):
+                continue
+            if granted_permissions is not None and not self._capability_registry.is_authorized(
+                tool.name, granted_permissions
+            ):
+                continue
+            result.append(tool)
         return result
 
     # ------------------------------------------------------------------
@@ -199,7 +290,9 @@ def _verify_power_plan(args: dict[str, Any], output: Any) -> bool:
     )
 
 
-def _build_default_registry() -> ToolRegistry:
+def _build_default_registry(
+    *, capability_registry: CapabilityRegistry | None = None
+) -> ToolRegistry:
     """Build and return a ``ToolRegistry`` pre-populated with all Rex tools."""
     # Lazily import so optional dependencies don't block startup.
     from rex.openclaw.tools.calendar_tool import calendar_create
@@ -231,7 +324,7 @@ def _build_default_registry() -> ToolRegistry:
         set_volume,
     )
 
-    registry = ToolRegistry()
+    registry = ToolRegistry(capability_registry=capability_registry)
 
     registry.register(
         Tool(
@@ -272,6 +365,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Send an email to one or more recipients.",
             capability_tags=["email", "messaging", "send"],
             requires_config=["email_accounts"],
+            required_permissions=("email_send",),
             handler=send_email,
             operation="mutation",
             requires_identity=True,
@@ -298,6 +392,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Control smart home devices via Home Assistant.",
             capability_tags=["smart_home", "home_assistant", "iot"],
             requires_config=["ha_base_url", "ha_token"],
+            required_permissions=("ha_control",),
             handler=ha_call_service,
             operation="mutation",
             requires_identity=True,
@@ -311,6 +406,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Send an SMS text message to a phone number.",
             capability_tags=["sms", "messaging", "text"],
             requires_config=[],
+            required_permissions=("sms_send",),
             handler=send_sms,
             operation="mutation",
             requires_identity=True,
@@ -327,6 +423,7 @@ def _build_default_registry() -> ToolRegistry:
             ),
             capability_tags=["file", "filesystem", "local"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=_read_file,
         )
     )
@@ -337,6 +434,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Get OS and hardware information (platform, CPU count, total RAM, boot time).",
             capability_tags=["windows", "diagnostics", "system"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=get_system_info,
         )
     )
@@ -347,6 +445,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Get current CPU usage percentage and frequency.",
             capability_tags=["windows", "diagnostics", "cpu"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=get_cpu_usage,
         )
     )
@@ -357,6 +456,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Get current RAM and swap memory usage statistics.",
             capability_tags=["windows", "diagnostics", "memory", "ram"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=get_memory_usage,
         )
     )
@@ -367,6 +467,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Get disk usage for all mounted partitions.",
             capability_tags=["windows", "diagnostics", "disk", "storage"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=get_disk_usage,
         )
     )
@@ -377,6 +478,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Get battery charge level and charging status.",
             capability_tags=["windows", "diagnostics", "battery"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=get_battery_status,
         )
     )
@@ -387,6 +489,7 @@ def _build_default_registry() -> ToolRegistry:
             description="List running processes sorted by CPU usage.",
             capability_tags=["windows", "diagnostics", "processes"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=list_processes,
         )
     )
@@ -397,6 +500,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Get the current system master volume level (0–100).",
             capability_tags=["windows", "settings", "audio", "volume"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=get_volume,
         )
     )
@@ -407,6 +511,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Set the system master volume level (0–100).",
             capability_tags=["windows", "settings", "audio", "volume"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=set_volume,
             operation="mutation",
             requires_identity=True,
@@ -421,6 +526,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Set the display brightness level (0–100).",
             capability_tags=["windows", "settings", "display", "brightness"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=set_brightness,
             operation="mutation",
             requires_identity=True,
@@ -435,6 +541,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Get the name of the currently active Windows power plan.",
             capability_tags=["windows", "settings", "power"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=get_power_plan,
         )
     )
@@ -445,6 +552,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Switch the active Windows power plan by name (e.g. Balanced, High performance).",
             capability_tags=["windows", "settings", "power"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=set_power_plan,
             operation="mutation",
             requires_identity=True,
@@ -459,6 +567,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Check disk SMART health status and report any failure predictions.",
             capability_tags=["windows", "repair", "disk"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=check_disk_health,
         )
     )
@@ -469,6 +578,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Check for pending Windows updates and list them.",
             capability_tags=["windows", "repair", "update"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=check_windows_update_status,
         )
     )
@@ -479,6 +589,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Flush the Windows DNS resolver cache to fix name-resolution issues.",
             capability_tags=["windows", "repair", "dns", "network"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=flush_dns_cache,
             operation="mutation",
             requires_identity=True,
@@ -494,6 +605,7 @@ def _build_default_registry() -> ToolRegistry:
             ),
             capability_tags=["windows", "repair", "sfc", "system"],
             requires_config=[],
+            required_permissions=("computer_control",),
             handler=run_sfc_scan,
             operation="mutation",
             risk="sensitive",
@@ -508,6 +620,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Play music via Music Assistant. Args: query (str), room (str, optional).",
             capability_tags=["music", "play", "audio", "media"],
             requires_config=["music_assistant_url"],
+            required_permissions=("ha_control",),
             handler=_delegated_handler("music_play"),
             operation="mutation",
             requires_identity=True,
@@ -520,6 +633,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Pause music playback via Music Assistant. Args: room (str, optional).",
             capability_tags=["music", "pause", "audio", "media"],
             requires_config=["music_assistant_url"],
+            required_permissions=("ha_control",),
             handler=_delegated_handler("music_pause"),
             operation="mutation",
             requires_identity=True,
@@ -532,6 +646,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Resume paused music via Music Assistant. Args: room (str, optional).",
             capability_tags=["music", "resume", "audio", "media"],
             requires_config=["music_assistant_url"],
+            required_permissions=("ha_control",),
             handler=_delegated_handler("music_resume"),
             operation="mutation",
             requires_identity=True,
@@ -544,6 +659,7 @@ def _build_default_registry() -> ToolRegistry:
             description="Skip to the next track via Music Assistant. Args: room (str, optional).",
             capability_tags=["music", "skip", "next", "audio", "media"],
             requires_config=["music_assistant_url"],
+            required_permissions=("ha_control",),
             handler=_delegated_handler("music_skip"),
             operation="mutation",
             requires_identity=True,
@@ -559,6 +675,7 @@ def _build_default_registry() -> ToolRegistry:
             ),
             capability_tags=["music", "volume", "audio", "media"],
             requires_config=["music_assistant_url"],
+            required_permissions=("ha_control",),
             handler=_delegated_handler("music_volume"),
             operation="mutation",
             requires_identity=True,
@@ -572,9 +689,25 @@ def _build_default_registry() -> ToolRegistry:
 _default_registry: ToolRegistry | None = None
 
 
-def get_default_registry() -> ToolRegistry:
-    """Return the module-level default ``ToolRegistry`` (lazy init)."""
+def ensure_default_registry(capability_registry: CapabilityRegistry) -> ToolRegistry:
+    """Return the default executable registry bound to *capability_registry*."""
     global _default_registry
-    if _default_registry is None:
-        _default_registry = _build_default_registry()
+    if (
+        _default_registry is None
+        or _default_registry.capability_registry is not capability_registry
+    ):
+        _default_registry = _build_default_registry(capability_registry=capability_registry)
     return _default_registry
+
+
+def get_default_registry() -> ToolRegistry:
+    """Return the default executable registry backed by canonical metadata."""
+    from rex.capabilities.registry import get_capability_registry  # noqa: PLC0415
+
+    return ensure_default_registry(get_capability_registry())
+
+
+def reset_default_registry() -> None:
+    """Reset the executable singleton so tests cannot retain stale metadata."""
+    global _default_registry
+    _default_registry = None

--- a/tests/rex2/test_capability_registry.py
+++ b/tests/rex2/test_capability_registry.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import pytest
+
+from rex.capabilities.registry import (
+    Capability,
+    CapabilityConflictError,
+    CapabilityRegistry,
+    SecurityClassificationError,
+)
+from rex.tools.registry import Tool, ToolRegistry
+
+
+def _handler(**_kwargs):
+    return {"ok": True}
+
+
+def _card(**overrides) -> Capability:
+    values = {
+        "name": "web_lookup",
+        "description": "Search trusted web sources.",
+        "source": "local",
+        "input_schema": {"query": "string"},
+        "output_schema": {"results": "array"},
+        "required_permissions": ("web.read",),
+        "health": "healthy",
+        "operation": "read",
+        "risk": "safe",
+        "verification_supported": True,
+        "examples": ("look up the latest release",),
+        "triggers": ["search", "look up"],
+    }
+    values.update(overrides)
+    return Capability(**values)
+
+
+def test_canonical_card_records_required_metadata_and_legacy_aliases() -> None:
+    card = _card()
+
+    assert card.id == "web_lookup"
+    assert card.source == "local"
+    assert card.input_schema == {"query": "string"}
+    assert card.output_schema == {"results": "array"}
+    assert card.inputs == ["query"]
+    assert card.outputs == ["results"]
+    assert card.required_permissions == ("web.read",)
+    assert card.health == "healthy"
+    assert card.operation == "read"
+    assert card.risk == "safe"
+    assert card.verification_supported is True
+    assert card.examples == ("look up the latest release",)
+
+
+def test_static_security_metadata_is_sealed_but_runtime_state_can_change() -> None:
+    card = _card(enabled=True, health="unknown")
+
+    card.enabled = False
+    card.health = "degraded"
+    assert card.enabled is False
+    assert card.health == "degraded"
+
+    with pytest.raises(AttributeError, match="sealed"):
+        card.risk = "sensitive"
+    with pytest.raises(AttributeError, match="sealed"):
+        card.required_permissions = ()
+
+
+def test_duplicate_id_is_idempotent_only_when_metadata_matches() -> None:
+    registry = CapabilityRegistry()
+    first = _card()
+    registry.register(first)
+    registry.register(_card())
+
+    assert registry.get("web_lookup") is first
+    with pytest.raises(CapabilityConflictError, match="web_lookup"):
+        registry.register(_card(description="Different metadata"))
+
+
+def test_registry_snapshot_is_deterministic() -> None:
+    registry = CapabilityRegistry()
+    registry.register(_card(name="zeta", description="Zeta"))
+    registry.register(_card(name="alpha", description="Alpha"))
+
+    first = registry.metadata_snapshot()
+    second = registry.metadata_snapshot()
+
+    assert first == second
+    assert [item["id"] for item in first] == ["alpha", "zeta"]
+
+
+def test_authorization_is_evaluated_from_current_permissions_each_time() -> None:
+    registry = CapabilityRegistry()
+    registry.register(_card(required_permissions=("web.read", "network.use")))
+
+    assert registry.is_authorized("web_lookup", {"web.read", "network.use"}) is True
+    assert registry.is_authorized("web_lookup", {"web.read"}) is False
+    assert registry.is_authorized("web_lookup", {"web.read", "network.use"}) is True
+
+
+def test_tool_registry_binds_handler_to_canonical_card() -> None:
+    cards = CapabilityRegistry()
+    registry = ToolRegistry(capability_registry=cards)
+    tool = Tool(
+        name="system_read",
+        description="Read system information.",
+        capability_tags=["system", "read"],
+        requires_config=[],
+        handler=_handler,
+        input_schema={"detail": "string"},
+        output_schema={"system": "object"},
+        required_permissions=("system.read",),
+        health="healthy",
+        examples=("show system information",),
+    )
+
+    registry.register(tool)
+    card = cards.get("system_read")
+
+    assert registry.get("system_read") is tool
+    assert card is not None
+    assert card.input_schema == {"detail": "string"}
+    assert card.required_permissions == ("system.read",)
+    assert card.operation == "read"
+    assert card.risk == "safe"
+
+
+def test_tool_duplicate_schema_drift_does_not_silently_replace() -> None:
+    registry = ToolRegistry()
+    registry.register(Tool("dup", "First", [], [], _handler))
+
+    with pytest.raises(CapabilityConflictError, match="dup"):
+        registry.register(Tool("dup", "Second", [], [], _handler))
+
+
+def test_remote_metadata_cannot_weaken_local_security_classification() -> None:
+    cards = CapabilityRegistry()
+    registry = ToolRegistry(capability_registry=cards)
+    registry.register(
+        Tool(
+            name="set_volume",
+            description="Set volume.",
+            capability_tags=["audio"],
+            requires_config=[],
+            handler=_handler,
+            operation="mutation",
+            risk="sensitive",
+            requires_identity=True,
+            required_permissions=("system.write",),
+        )
+    )
+    remote = _card(
+        name="set_volume",
+        description="Remote claims this is harmless.",
+        source="openclaw",
+        operation="read",
+        risk="safe",
+        required_permissions=(),
+        verification_supported=False,
+    )
+
+    with pytest.raises(SecurityClassificationError, match="set_volume"):
+        registry.register_remote_card(remote)
+
+    card = cards.get("set_volume")
+    assert card is not None
+    assert card.source == "local"
+    assert card.operation == "mutation"
+    assert card.risk == "sensitive"
+    assert card.required_permissions == ("system.write",)
+
+
+def test_remote_matching_security_may_not_replace_local_authority() -> None:
+    cards = CapabilityRegistry()
+    registry = ToolRegistry(capability_registry=cards)
+    registry.register(
+        Tool(
+            name="local_read",
+            description="Local description.",
+            capability_tags=["read"],
+            requires_config=[],
+            handler=_handler,
+            required_permissions=("data.read",),
+        )
+    )
+    remote = _card(
+        name="local_read",
+        description="Remote description.",
+        source="openclaw",
+        required_permissions=("data.read",),
+        verification_supported=False,
+    )
+
+    result = registry.register_remote_card(remote)
+
+    assert result.description == "Local description."
+    assert cards.get("local_read") is result
+    assert result.source == "local"
+
+
+def test_selection_filters_by_current_permission_snapshot() -> None:
+    from rex.tools.dispatcher import ToolDispatcher
+
+    cards = CapabilityRegistry()
+    tools = ToolRegistry(capability_registry=cards)
+    tools.register(
+        Tool(
+            name="send_email",
+            description="Send email.",
+            capability_tags=["email"],
+            requires_config=[],
+            handler=lambda **_kwargs: {"ok": True},
+            required_permissions=("email_send",),
+        )
+    )
+    dispatcher = ToolDispatcher(tools)
+    assert dispatcher.select_tools("send email", granted_permissions=frozenset()) == []
+    selected = dispatcher.select_tools("send email", granted_permissions=frozenset({"email_send"}))
+    assert [tool.name for tool in selected] == ["send_email"]
+
+
+def test_execution_rechecks_permission_snapshot() -> None:
+    from rex.tools.dispatcher import ToolDispatcher
+    from rex.tools.execution import ToolOutcome
+
+    calls: list[str] = []
+    tools = ToolRegistry()
+    tools.register(
+        Tool(
+            name="permissioned_read",
+            description="Permissioned read.",
+            capability_tags=["search"],
+            requires_config=[],
+            handler=lambda **_kwargs: calls.append("called") or {"ok": True},
+            required_permissions=("computer_control",),
+        )
+    )
+    dispatcher = ToolDispatcher(tools)
+    denied = dispatcher.dispatch(
+        "permissioned_read",
+        {},
+        {"request_id": "denied", "granted_permissions": frozenset()},
+    )
+    assert denied.status == ToolOutcome.DENIED
+    assert calls == []
+    allowed = dispatcher.dispatch(
+        "permissioned_read",
+        {},
+        {"request_id": "allowed", "granted_permissions": frozenset({"admin"})},
+    )
+    assert allowed.status == ToolOutcome.COMPLETED
+    assert calls == ["called"]
+
+
+def test_default_tool_registry_uses_global_capability_authority() -> None:
+    from rex.capabilities.registry import (
+        get_capability_registry,
+        reset_capability_registry,
+    )
+    from rex.tools.registry import get_default_registry
+
+    reset_capability_registry()
+    cards = get_capability_registry()
+    tools = get_default_registry()
+    assert tools.capability_registry is cards
+    tool_names = {tool.name for tool in tools.all_tools()}
+    card_names = {card.name for card in cards.list(include_disabled=True)}
+    assert tool_names.issubset(card_names)
+    assert "chat" in card_names
+
+
+def test_capability_reset_rebinds_default_tool_registry() -> None:
+    from rex.capabilities.registry import (
+        get_capability_registry,
+        reset_capability_registry,
+    )
+    from rex.tools.registry import get_default_registry
+
+    reset_capability_registry()
+    first_cards = get_capability_registry()
+    first_tools = get_default_registry()
+    reset_capability_registry()
+    second_cards = get_capability_registry()
+    second_tools = get_default_registry()
+    assert second_cards is not first_cards
+    assert second_tools is not first_tools
+    assert second_tools.capability_registry is second_cards
+
+
+def test_openclaw_adapter_cannot_replace_local_security_metadata() -> None:
+    from rex.capabilities.registry import get_capability_registry, reset_capability_registry
+    from rex.openclaw.tool_registry import ToolMeta as OpenClawToolMeta
+    from rex.openclaw.tool_registry import ToolRegistry as OpenClawRegistry
+    from rex.tools.registry import get_default_registry
+
+    reset_capability_registry()
+    cards = get_capability_registry()
+    before = cards.get("send_email")
+    assert before is not None and before.operation == "mutation"
+    OpenClawRegistry(canonical_registry=get_default_registry()).register_tool(
+        OpenClawToolMeta(name="send_email", description="Remote says email is harmless")
+    )
+    after = cards.get("send_email")
+    assert after is before
+    assert after.source == "local"
+    assert after.operation == "mutation"
+    assert after.requires_identity is True
+
+
+def test_unknown_openclaw_tool_defaults_to_conservative_security() -> None:
+    from rex.capabilities.registry import get_capability_registry, reset_capability_registry
+    from rex.openclaw.tool_registry import ToolMeta as OpenClawToolMeta
+    from rex.openclaw.tool_registry import ToolRegistry as OpenClawRegistry
+    from rex.tools.registry import get_default_registry
+
+    reset_capability_registry()
+    cards = get_capability_registry()
+    OpenClawRegistry(canonical_registry=get_default_registry()).register_tool(
+        OpenClawToolMeta(name="remote_unknown", description="Unknown remote tool")
+    )
+    card = cards.get("remote_unknown")
+    assert card is not None
+    assert card.source == "openclaw"
+    assert card.operation == "mutation"
+    assert card.risk == "sensitive"
+    assert card.requires_identity is True
+    assert card.verification_supported is False
+
+
+def test_builtin_tool_cards_use_canonical_permission_vocabulary() -> None:
+    from rex.capabilities.registry import get_capability_registry, reset_capability_registry
+
+    reset_capability_registry()
+    cards = get_capability_registry()
+    expected = {
+        "send_email": ("email_send",),
+        "send_sms": ("sms_send",),
+        "home_assistant_call_service": ("ha_control",),
+        "music_play": ("ha_control",),
+        "file_ops": ("computer_control",),
+        "get_system_info": ("computer_control",),
+        "set_volume": ("computer_control",),
+        "run_sfc_scan": ("computer_control",),
+    }
+    for name, permissions in expected.items():
+        card = cards.get(name)
+        assert card is not None
+        assert card.required_permissions == permissions
+
+
+def test_openclaw_health_evidence_updates_canonical_runtime_state() -> None:
+    from rex.capabilities.registry import CapabilityRegistry
+    from rex.openclaw.tool_registry import ToolMeta as OpenClawToolMeta
+    from rex.openclaw.tool_registry import ToolRegistry as OpenClawRegistry
+    from rex.tools.registry import ToolRegistry as CanonicalToolRegistry
+
+    cards = CapabilityRegistry()
+    canonical = CanonicalToolRegistry(capability_registry=cards)
+    remote = OpenClawRegistry(canonical_registry=canonical)
+    remote.register_tool(
+        OpenClawToolMeta(
+            name="remote_health",
+            description="Remote health test.",
+            health_check=lambda: (False, "gateway unavailable"),
+        )
+    )
+    ok, detail = remote.check_health("remote_health")
+    assert ok is False
+    assert detail == "gateway unavailable"
+    card = cards.get("remote_health")
+    assert card is not None
+    assert card.health == "unhealthy"
+
+
+def test_promoted_openclaw_registry_rebinds_to_global_authority() -> None:
+    from rex.capabilities.registry import get_capability_registry, reset_capability_registry
+    from rex.openclaw.tool_registry import (
+        ToolMeta as OpenClawToolMeta,
+    )
+    from rex.openclaw.tool_registry import (
+        ToolRegistry as OpenClawRegistry,
+    )
+    from rex.openclaw.tool_registry import (
+        set_tool_registry,
+    )
+
+    reset_capability_registry()
+    custom = OpenClawRegistry()
+    custom.register_tool(OpenClawToolMeta(name="promoted_remote", description="Promoted"))
+    set_tool_registry(custom)
+    card = get_capability_registry().get("promoted_remote")
+    assert card is not None
+    assert card.source == "openclaw"

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -56,7 +56,7 @@ class TestCmdTools:
 
     def teardown_method(self):
         """Clean up after each test."""
-        set_tool_registry(None)  # type: ignore
+        set_tool_registry(None)
         set_credential_manager(None)  # type: ignore
 
     def test_cmd_tools_no_tools(self, capsys):
@@ -282,7 +282,7 @@ class TestMainToolsCommand:
 
     def teardown_method(self):
         """Clean up after each test."""
-        set_tool_registry(None)  # type: ignore
+        set_tool_registry(None)
         set_credential_manager(None)  # type: ignore
 
     def test_main_tools_command(self, capsys):
@@ -374,7 +374,7 @@ class TestToolsOutputFormat:
 
     def teardown_method(self):
         """Clean up after each test."""
-        set_tool_registry(None)  # type: ignore
+        set_tool_registry(None)
         set_credential_manager(None)  # type: ignore
 
     def test_output_has_header(self, capsys):

--- a/tests/test_planner_tool_e2e.py
+++ b/tests/test_planner_tool_e2e.py
@@ -118,7 +118,7 @@ def _all_service_patches() -> list:
 def reset_global_registry():
     """Ensure the global registry is reset after each test."""
     yield
-    set_tool_registry(None)  # type: ignore[arg-type]
+    set_tool_registry(None)
 
 
 @pytest.mark.parametrize("tool_name", sorted(EXECUTABLE_TOOLS))

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -406,7 +406,7 @@ class TestGlobalToolRegistry:
 
     def setup_method(self):
         """Reset global state before each test."""
-        set_tool_registry(None)  # type: ignore
+        set_tool_registry(None)
 
     def test_get_tool_registry_returns_singleton(self):
         """Test that get_tool_registry returns singleton with builtin tools."""
@@ -495,7 +495,7 @@ class TestBuiltinTools:
 
     def setup_method(self):
         """Reset global state before each test."""
-        set_tool_registry(None)  # type: ignore
+        set_tool_registry(None)
 
     def test_time_now_tool_registered(self):
         """Test that time_now is registered correctly."""

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -91,7 +91,7 @@ def test_register_replaces_existing() -> None:
     t1 = Tool("t", "first", [], [], _dummy_handler)
     t2 = Tool("t", "second", [], [], _dummy_handler)
     registry.register(t1)
-    registry.register(t2)
+    registry.register(t2, replace=True)
     assert registry.get("t") is t2
 
 
@@ -259,7 +259,11 @@ def test_delegated_music_handler_fails_closed() -> None:
     result = ToolDispatcher(get_default_registry()).dispatch(
         "music_pause",
         {},
-        {"user_id": "james", "request_id": "music-delegation-test"},
+        {
+            "user_id": "james",
+            "request_id": "music-delegation-test",
+            "granted_permissions": frozenset({"ha_control"}),
+        },
     )
 
     assert result.success is False

--- a/tests/test_us021_tool_registry.py
+++ b/tests/test_us021_tool_registry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 
+from rex.capabilities.registry import CapabilityConflictError
 from rex.openclaw.tool_registry import ToolMeta, ToolNotFoundError, ToolRegistry
 
 # ---------------------------------------------------------------------------
@@ -146,32 +147,30 @@ class TestToolMetadataStored:
 
 
 class TestDuplicateToolHandling:
-    def test_registering_same_name_twice_overwrites(self):
-        """Re-registering a tool with the same name replaces the old entry."""
+    def test_registering_same_name_with_different_description_is_rejected(self):
         registry = _make_registry()
         registry.register_tool(ToolMeta(name="dup", description="version one"))
-        registry.register_tool(ToolMeta(name="dup", description="version two"))
-        # Only one entry under the name
-        matches = [t for t in registry.list_tools(include_disabled=True) if t.name == "dup"]
-        assert len(matches) == 1
+        with pytest.raises(CapabilityConflictError, match="dup"):
+            registry.register_tool(ToolMeta(name="dup", description="version two"))
+        assert registry.get_tool("dup").description == "version one"  # type: ignore[union-attr]
 
-    def test_overwrite_updates_description(self):
-        """The second registration's description replaces the first."""
+    def test_schema_drift_does_not_replace_description(self):
         registry = _make_registry()
         registry.register_tool(ToolMeta(name="dup", description="old"))
-        registry.register_tool(ToolMeta(name="dup", description="new"))
-        assert registry.get_tool("dup").description == "new"  # type: ignore[union-attr]
+        with pytest.raises(CapabilityConflictError, match="dup"):
+            registry.register_tool(ToolMeta(name="dup", description="new"))
+        assert registry.get_tool("dup").description == "old"  # type: ignore[union-attr]
 
-    def test_overwrite_updates_capabilities(self):
-        """Re-registering with new capabilities overwrites previous ones."""
+    def test_schema_drift_does_not_expand_capabilities(self):
         registry = _make_registry()
         registry.register_tool(ToolMeta(name="cap_tool", description="cap", capabilities=["read"]))
-        registry.register_tool(
-            ToolMeta(name="cap_tool", description="cap", capabilities=["read", "write"])
-        )
+        with pytest.raises(CapabilityConflictError, match="cap_tool"):
+            registry.register_tool(
+                ToolMeta(name="cap_tool", description="cap", capabilities=["read", "write"])
+            )
         stored = registry.get_tool("cap_tool")
         assert stored is not None
-        assert "write" in stored.capabilities
+        assert stored.capabilities == ["read"]
 
     def test_list_tools_contains_no_duplicates(self):
         """list_tools() never returns the same tool name more than once."""


### PR DESCRIPTION
## US-106

Consolidates one canonical Capability / Tool Card metadata authority across local tools and OpenClaw compatibility adapters.

### What changed
- expands `Capability` into canonical Tool Card metadata with schemas, source, enabled/health evidence, permissions, operation/risk, verification support, descriptions, and examples
- binds the default executable `ToolRegistry` to the same global `CapabilityRegistry`; duplicate/schema drift fails closed unless a migration explicitly opts into replacement
- evaluates current-user permissions at capability selection and rechecks them immediately before execution
- maps built-in tool permissions using the existing Rex permission vocabulary only
- migrates OpenClaw remote metadata and health through canonical cards; local security classification cannot be weakened and unknown remote tools default conservatively
- preserves compatibility callers, including supported `set_tool_registry(None)` resets and canonical rebinding when a custom OpenClaw registry is promoted globally
- updates `CLAUDE.md`, capability-parity documentation, the authoritative PRD, and progress evidence

### Verification
- exact US-106 PRD suite: **57 passed**
- broader registry/planner/tool/TurnEngine/capability/mobile matrix: **437 passed**
- CLI registry compatibility: **22 passed**
- mypy clean on `rex/capabilities` and all additionally changed runtime registry/dispatch/execution modules
- Ruff and Black clean on all touched Python/test files
- `git diff --check` clean
- full local pre-commit suite clean
- remote publication workflow verified compressed patch SHA, raw patch SHA, and exact target Git tree `2e8180a18f6f0758ee441c697d38ed1346cf679b`

The US-106 GitHub-check acceptance criterion remains intentionally unchecked until this exact PR head passes every relevant repository check.