### PR TITLE
feat(routing): add ModelRouter 2.0 fast/deep escalation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -276,7 +276,7 @@
         "filename": "rex/llm_client.py",
         "hashed_secret": "939bb46a04c3640c8c427e92b1b557e882e2d2a0",
         "is_verified": false,
-        "line_number": 732
+        "line_number": 769
       }
     ],
     "rex/woocommerce/config.py": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,12 @@ Deterministic latency baseline (instrumentation/framework evidence only):
 python scripts/rexbench.py --profile baseline --iterations 20 --output docs/performance/rexbench-baseline.json
 ```
 
+ModelRouter 2.0 deterministic routing evidence:
+
+```powershell
+python scripts/rexbench.py --profile model-routing --iterations 8 --output docs/performance/rexbench-model-routing.json
+```
+
 `deterministic_mock` RexBench results never prove live provider, model, network, audio, or hardware latency is within budget. Use `docs/performance.md` and the final live RexBench release gate for production claims.
 
 Electron identity (required before launch):

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -3624,11 +3624,11 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 **Files/areas likely involved:** `rex/model_router.py`, provider strategies, Turn route events, config/UI provider settings, RexBench.
 
 **Acceptance Criteria:**
-- [ ] Routing exposes explicit complexity/confidence/evidence plus chosen fast/deep route in privacy-safe turn metadata.
-- [ ] Low-confidence executive decisions may escalate at most once unless an explicit bounded retry policy says otherwise.
-- [ ] Local-first remains default/configurable; no cloud or paid provider is silently enabled or selected without existing configuration/permission.
-- [ ] Deterministic commands may bypass deep reasoning without bypassing permissions or verification.
-- [ ] Golden tests cover simple command, ambiguous tool choice, complex reasoning, provider outage, and unavailable local model.
+- [x] Routing exposes explicit complexity/confidence/evidence plus chosen fast/deep route in privacy-safe turn metadata.
+- [x] Low-confidence executive decisions may escalate at most once unless an explicit bounded retry policy says otherwise.
+- [x] Local-first remains default/configurable; no cloud or paid provider is silently enabled or selected without existing configuration/permission.
+- [x] Deterministic commands may bypass deep reasoning without bypassing permissions or verification.
+- [x] Golden tests cover simple command, ambiguous tool choice, complex reasoning, provider outage, and unavailable local model.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_model_router_v2.py tests/test_model_router.py -q`; `python scripts/rexbench.py --profile model-routing`.

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -3629,7 +3629,7 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 - [x] Local-first remains default/configurable; no cloud or paid provider is silently enabled or selected without existing configuration/permission.
 - [x] Deterministic commands may bypass deep reasoning without bypassing permissions or verification.
 - [x] Golden tests cover simple command, ambiguous tool choice, complex reasoning, provider outage, and unavailable local model.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_model_router_v2.py tests/test_model_router.py -q`; `python scripts/rexbench.py --profile model-routing`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,6 +115,22 @@ must never expose raw user IDs, prompts, transcripts, memory/facts, credentials,
 tool payloads. Missing or mismatched identity/scope bypasses the cache, and revision-snapshot
 failure falls back to normal uncached context construction.
 
+### ModelRouter 2.0 fast/deep routing
+
+`rex/model_router.py` produces a `ModelRouteDecision` with category, complexity, bounded
+confidence/evidence, fast/deep tier, selected model, escalation count, and fallback reason.
+Routing metadata is content-free and may not include prompts, transcripts, memory, credentials,
+or user identifiers. Local-first policy remains authoritative; `local_only` never silently
+selects a cloud provider.
+
+`LanguageModel` applies a routed model through a request-local `ContextVar` and a synchronized
+strategy cache, so concurrent household turns cannot overwrite the configured base model or one
+another's route. The Assistant emits the decision through canonical TurnEngine route events and
+passes the request-scoped active model into the identity-safe context-cache revision key. Fast
+routes still use the complete intent, permission, action, verification, and response pipeline.
+Provider reliability/cooldown feedback is intentionally layered by US-111 rather than inferred
+from private request content.
+
 ### Action lifecycle and verification
 
 `rex/actions/lifecycle.py` is the canonical action-truth contract used by generic

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2008,4 +2008,4 @@ US-105 implementation evidence:
 - Added a regression test proving a deep-routed turn keys cached context by the active routed model rather than the configured base model.
 - Local evidence: 103 cross-system tests passed; ModelRouter/RexBench focused set passed; Ruff and Black passed; mypy passed for the touched runtime modules.
 - `python scripts/rexbench.py --profile model-routing --iterations 8` passed with privacy-safe deterministic-local evidence.
-- The final GitHub-check criterion remains open until the exact PR head passes the complete repository matrix.
+- Exact implementation head `51d927a70df7c05d82451f8c2a8cdd53817b8a7d` passed CI, Commitlint, Windows Electron Artifact, CodeFactor, pre-commit, hardcoded-secret scan, security audit, lint/format, mypy, GUI checks, and dependency scans on 2026-08-14; US-110 GitHub-check criterion is closed.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2001,3 +2001,11 @@ US-105 implementation evidence:
 - Ruff, Black, and mypy pass on the implemented context/Assistant source at the pre-documentation checkpoint.
 - Full primary marker suite: 8,750 passed / 49 skipped / 0 failed in 504.47s on Windows.
 - US-105's final GitHub-check criterion remains open until its exact story PR head passes the complete repository matrix.
+
+2026-08-14 — US-110 ModelRouter 2.0 local verification
+- Rebased the existing US-110 implementation onto master after US-099 and US-105.
+- Preserved warm-runtime, model-output validation, and identity-safe context-cache behavior while adding request-scoped fast/deep model selection.
+- Added a regression test proving a deep-routed turn keys cached context by the active routed model rather than the configured base model.
+- Local evidence: 103 cross-system tests passed; ModelRouter/RexBench focused set passed; Ruff and Black passed; mypy passed for the touched runtime modules.
+- `python scripts/rexbench.py --profile model-routing --iterations 8` passed with privacy-safe deterministic-local evidence.
+- The final GitHub-check criterion remains open until the exact PR head passes the complete repository matrix.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -103,6 +103,19 @@ class here measures lifecycle behavior only. The report contains timings and non
 runtime identifiers only and never stores request content. Live model, audio, GPU, and device
 latency remains a later release-gate measurement.
 
+## Model-routing profile
+
+US-110 adds a deterministic fast/deep routing profile:
+
+```bash
+python scripts/rexbench.py --profile model-routing --iterations 8
+```
+
+The profile covers simple commands, ambiguous tool choice, complex reasoning, provider outage,
+and an unavailable local model. It validates bounded escalation, route/model selection, and
+privacy-safe timing evidence only. It does not prove live provider quality, availability, cost,
+or latency; US-111 owns provider reliability feedback and routing evaluation evidence.
+
 ## Identity-safe context cache
 
 US-105 caches only deterministic private context fragments that are expensive to rebuild

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from .actions.dispatcher import _UNDO_PATTERN, ActionResult
-from .assistant_errors import IdentityRequiredError
+from .assistant_errors import ConfigurationError, IdentityRequiredError
 from .calendar_service import get_calendar_service
 from .config import Settings, settings
 from .context.revisions import ContextCacheRequest
@@ -25,7 +25,7 @@ from .identity import validate_user_id
 from .latency import LatencyTrace
 from .llm_client import LanguageModel
 from .memory import trim_history
-from .model_router import ModelRouter
+from .model_router import ModelRouteDecision, ModelRouter
 from .plugins import PluginSpec
 from .runtime.events import EventKind, EventObserver, TurnEvent, TurnEventStream
 from .runtime.invocation import current_turn_invocation
@@ -984,13 +984,19 @@ class Assistant:
             return completion
 
         check_cancelled()
-        prev_model = self._begin_request(transcript)
-        latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
+        route_cleanup, route_decision = self._begin_request(transcript)
+        if route_decision is not None and route_decision.model:
+            latency_trace.model = route_decision.model
+        else:
+            latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
         latency_trace.end("routing")
-        turn_events.emit(
-            EventKind.ROUTE_PROGRESS,
-            {"stage": "model_router", "model": latency_trace.model},
-        )
+        route_details: dict[str, object] = {
+            "stage": "model_router",
+            "model": latency_trace.model,
+        }
+        if route_decision is not None:
+            route_details.update(route_decision.to_metadata())
+        turn_events.emit(EventKind.ROUTE_PROGRESS, route_details)
         model_failure_reason: str | None = None
         try:
             check_cancelled()
@@ -1053,7 +1059,7 @@ class Assistant:
             latency_trace.log_summary(logger, event=latency_event)
             raise
         finally:
-            self._end_request(prev_model)
+            self._end_request(route_cleanup)
 
         check_cancelled()
         self._record_completion(transcript, completion, user_id=effective_user_id)
@@ -1116,39 +1122,81 @@ class Assistant:
             on_event=observer,
         )
 
-    def _begin_request(self, transcript: str) -> str | None:
-        """Apply per-request model routing.
+    def _begin_request(
+        self, transcript: str
+    ) -> tuple[Callable[[], None] | None, ModelRouteDecision | None]:
+        """Apply one request-scoped model route and return its cleanup callback."""
+        router = getattr(self, "_router", None)
+        base_model: str | None = getattr(self._llm, "model_name", None)
+        decision: ModelRouteDecision | None = None
+        cleanup: Callable[[], None] | None = None
+        if router is None:
+            return cleanup, decision
 
-        Returns ``prev_model`` for restoration in :meth:`_end_request`.
-        Request identity is intentionally not handled here: it is resolved
-        once in :meth:`generate_reply` and passed explicitly to every
-        component, so overlapping requests for different users can never
-        observe each other's identity (issue #303).
-        """
-        # Model routing: classify the transcript and switch to the best model
-        _router = getattr(self, "_router", None)
-        prev_model: str | None = getattr(self._llm, "model_name", None)
-        if _router is not None:
-            category = _router.classify(transcript)
-            _routing_cfg = getattr(self._settings, "model_routing", None)
-            resolved = _router.resolve_model(category, _routing_cfg)
-            if resolved and resolved != prev_model:
-                logger.debug("model_router: classified as %s, using %s", category, resolved)
-                if hasattr(self._llm, "model_name"):
-                    self._llm.model_name = resolved
-            else:
-                logger.debug(
-                    "model_router: classified as %s, using %s",
-                    category,
-                    prev_model or "default",
+        routing_cfg = getattr(self._settings, "model_routing", None)
+        if isinstance(router, ModelRouter):
+            decision = router.decide(
+                transcript,
+                routing_config=routing_cfg,
+                current_model=base_model or "",
+                routing_mode=str(
+                    getattr(self._settings, "llm_routing_mode", "local_preferred")
+                    or "local_preferred"
+                ),
+                provider=str(
+                    getattr(self._settings, "llm_provider", "")
+                    or getattr(self._llm, "provider", None)
+                    or ""
+                ),
+            )
+            if decision.fallback_reason == "local_only_provider_conflict":
+                raise ConfigurationError(
+                    "llm_routing_mode='local_only' requires a local LLM provider."
                 )
+            if decision.fallback_reason == "cloud_provider_unconfigured":
+                raise ConfigurationError(
+                    "llm_routing_mode='cloud_only' requires an explicitly configured cloud provider."
+                )
+            resolved = decision.model
+            category = decision.category
+        else:
+            category = router.classify(transcript)
+            resolved = router.resolve_model(category, routing_cfg)
 
-        return prev_model
+        if resolved and resolved != base_model:
+            logger.debug("model_router: classified as %s, using %s", category, resolved)
+            supports_scoped_model = callable(
+                getattr(type(self._llm), "set_request_model", None)
+            ) and callable(getattr(type(self._llm), "reset_request_model", None))
+            if supports_scoped_model:
+                set_request_model = self._llm.set_request_model
+                reset_request_model = self._llm.reset_request_model
+                token = set_request_model(resolved)
 
-    def _end_request(self, prev_model: str | None) -> None:
-        """Restore the model name after a request completes."""
-        if prev_model is not None and hasattr(self._llm, "model_name"):
-            self._llm.model_name = prev_model
+                def _reset_scoped_model() -> None:
+                    reset_request_model(token)
+
+                cleanup = _reset_scoped_model
+            elif hasattr(self._llm, "model_name"):
+                self._llm.model_name = resolved
+
+                def _restore_legacy_model() -> None:
+                    self._llm.model_name = base_model
+
+                cleanup = _restore_legacy_model
+        else:
+            logger.debug(
+                "model_router: classified as %s, using %s",
+                category,
+                base_model or "default",
+            )
+        return cleanup, decision
+
+    @staticmethod
+    def _end_request(cleanup: Callable[[], None] | None) -> None:
+        """Restore request-local model state without mutating other turns."""
+        if cleanup is not None:
+            cleanup()
 
     async def _run_plugins(self, transcript: str) -> list[str]:
         from rex.runtime.cancellation import (  # noqa: PLC0415

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -1003,7 +1003,10 @@ class Assistant:
             provider = getattr(self._llm, "provider", None)
             if not isinstance(provider, str) or not provider.strip():
                 provider = str(getattr(self._settings, "llm_provider", None) or "unknown")
-            model_name = getattr(self._llm, "model_name", None)
+            active_model = getattr(self._llm, "active_model_name", None)
+            model_name = active_model() if callable(active_model) else None
+            if not isinstance(model_name, str) or not model_name.strip():
+                model_name = getattr(self._llm, "model_name", None)
             if not isinstance(model_name, str) or not model_name.strip():
                 model_name = str(getattr(self._settings, "llm_model", None) or "unknown")
             cache_request = ContextCacheRequest(

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -894,6 +894,48 @@ class Assistant:
             ),
         )
 
+    def _prepare_model_route(
+        self,
+        transcript: str,
+        *,
+        latency_trace: LatencyTrace,
+        turn_events: TurnEventStream,
+    ) -> tuple[Callable[[], None] | None, ModelRouteDecision | None]:
+        """Apply and publish the request-scoped model route."""
+        route_cleanup, route_decision = self._begin_request(transcript)
+        if route_decision is not None and route_decision.model:
+            latency_trace.model = route_decision.model
+        else:
+            latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
+        latency_trace.end("routing")
+        route_details: dict[str, object] = {
+            "stage": "model_router",
+            "model": latency_trace.model,
+        }
+        if route_decision is not None:
+            route_details.update(route_decision.to_metadata())
+        turn_events.emit(EventKind.ROUTE_PROGRESS, route_details)
+        return route_cleanup, route_decision
+
+    def _context_cache_request(self, turn_context: TurnContext) -> ContextCacheRequest:
+        """Build cache identity from the active request-scoped provider/model."""
+        provider = getattr(self._llm, "provider", None)
+        if not isinstance(provider, str) or not provider.strip():
+            provider = str(getattr(self._settings, "llm_provider", None) or "unknown")
+        active_model = getattr(self._llm, "active_model_name", None)
+        model_name = active_model() if callable(active_model) else None
+        if not isinstance(model_name, str) or not model_name.strip():
+            model_name = getattr(self._llm, "model_name", None)
+        if not isinstance(model_name, str) or not model_name.strip():
+            model_name = str(getattr(self._settings, "llm_model", None) or "unknown")
+        return ContextCacheRequest(
+            user_id=turn_context.user_id if turn_context.scope is TurnScope.USER else None,
+            scope=turn_context.scope,
+            authorization=turn_context.authorization,
+            model_provider=provider,
+            model_name=model_name,
+        )
+
     async def _run_reply_turn(
         self,
         turn_events: TurnEventStream,
@@ -984,38 +1026,15 @@ class Assistant:
             return completion
 
         check_cancelled()
-        route_cleanup, route_decision = self._begin_request(transcript)
-        if route_decision is not None and route_decision.model:
-            latency_trace.model = route_decision.model
-        else:
-            latency_trace.model = str(getattr(self._llm, "model_name", None) or latency_trace.model)
-        latency_trace.end("routing")
-        route_details: dict[str, object] = {
-            "stage": "model_router",
-            "model": latency_trace.model,
-        }
-        if route_decision is not None:
-            route_details.update(route_decision.to_metadata())
-        turn_events.emit(EventKind.ROUTE_PROGRESS, route_details)
+        route_cleanup, _route_decision = self._prepare_model_route(
+            transcript,
+            latency_trace=latency_trace,
+            turn_events=turn_events,
+        )
         model_failure_reason: str | None = None
         try:
             check_cancelled()
-            provider = getattr(self._llm, "provider", None)
-            if not isinstance(provider, str) or not provider.strip():
-                provider = str(getattr(self._settings, "llm_provider", None) or "unknown")
-            active_model = getattr(self._llm, "active_model_name", None)
-            model_name = active_model() if callable(active_model) else None
-            if not isinstance(model_name, str) or not model_name.strip():
-                model_name = getattr(self._llm, "model_name", None)
-            if not isinstance(model_name, str) or not model_name.strip():
-                model_name = str(getattr(self._settings, "llm_model", None) or "unknown")
-            cache_request = ContextCacheRequest(
-                user_id=turn_context.user_id if turn_context.scope is TurnScope.USER else None,
-                scope=turn_context.scope,
-                authorization=turn_context.authorization,
-                model_provider=provider,
-                model_name=model_name,
-            )
+            cache_request = self._context_cache_request(turn_context)
             context = self._get_or_create_context_builder().build(
                 transcript,
                 voice_mode=voice_mode,

--- a/rex/llm_client.py
+++ b/rex/llm_client.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import contextvars
 import json
 import sys
+import threading
 import types as _types
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
@@ -659,11 +661,14 @@ class LanguageModel:
         self._tool_functions: dict[str, Any] = {}  # Map of tool name -> callable
         from rex.runtime.warm import get_global_warm_runtime
 
-        # The first settings-bearing application access establishes process-wide
-        # warm-cache policy; constructing additional model wrappers must not
-        # silently rewrite that shared resource policy.
+        # Establish process-wide warm-cache policy before constructing model strategies.
         get_global_warm_runtime(self.config)
-        self.strategy = self._init_strategy()
+        self._request_model: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+            f"askrex_llm_model_{id(self)}", default=None
+        )
+        self._strategy_lock = threading.Lock()
+        self.strategy = self._init_strategy(self.model_name)
+        self._strategy_cache: dict[str, LLMStrategy] = {self.model_name: self.strategy}
 
     def _ensure_anthropic_client(self) -> Any:
         if self._anthropic_client is not None:
@@ -679,20 +684,19 @@ class LanguageModel:
         self._anthropic_client = Anthropic(api_key=self.anthropic_api_key)
         return self._anthropic_client
 
-    def _init_strategy(self) -> LLMStrategy:
+    def _init_strategy(self, model_name: str | None = None) -> LLMStrategy:
+        model_name = model_name or self.model_name
         if self.provider in {"openai", "openrouter"}:
-            return cast(LLMStrategy, OpenAIStrategy(self.model_name, self._ensure_openai_client))
+            return cast(LLMStrategy, OpenAIStrategy(model_name, self._ensure_openai_client))
 
         if self.provider == "anthropic":
-            return cast(
-                LLMStrategy, AnthropicStrategy(self.model_name, self._ensure_anthropic_client)
-            )
+            return cast(LLMStrategy, AnthropicStrategy(model_name, self._ensure_anthropic_client))
 
         if self.provider == "ollama":
             return cast(
                 LLMStrategy,
                 OllamaStrategy(
-                    self.model_name,
+                    model_name,
                     api_key=self.config.ollama_api_key,
                     base_url=self.config.ollama_base_url,
                     use_cloud=self.config.ollama_use_cloud,
@@ -702,23 +706,49 @@ class LanguageModel:
         strategy_cls = _STRATEGIES.get(self.provider)
         if strategy_cls is None:
             logger.warning("Unknown LLM provider '%s'. Falling back to echo mode.", self.provider)
-            return cast(LLMStrategy, EchoStrategy(self.model_name))
+            return cast(LLMStrategy, EchoStrategy(model_name))
 
         if strategy_cls is TransformersStrategy and not (
             TORCH_AVAILABLE and TRANSFORMERS_AVAILABLE
         ):
             logger.warning(
-                "Transformers missing; using offline fallback for model '%s'.", self.model_name
+                "Transformers missing; using offline fallback for model '%s'.", model_name
             )
-            return cast(LLMStrategy, OfflineTransformersStrategy(self.model_name))
+            return cast(LLMStrategy, OfflineTransformersStrategy(model_name))
 
         try:
-            return cast(LLMStrategy, strategy_cls(self.model_name))
+            return cast(LLMStrategy, strategy_cls(model_name))
         except Exception as exc:
             logger.warning(
                 "LLM backend init failed (%s). Falling back to echo. (%s)", self.provider, exc
             )
-            return cast(LLMStrategy, EchoStrategy(self.model_name))
+            return cast(LLMStrategy, EchoStrategy(model_name))
+
+    def set_request_model(self, model_name: str) -> contextvars.Token[str | None]:
+        """Set a model override for the current request context only."""
+        return self._request_model.set(model_name)
+
+    def reset_request_model(self, token: contextvars.Token[str | None]) -> None:
+        """Restore the previous request-local model override."""
+        self._request_model.reset(token)
+
+    def active_model_name(self) -> str:
+        """Return the request-local model when set, otherwise the configured base model."""
+        return self._request_model.get() or self.model_name
+
+    def _strategy_for_request(self) -> LLMStrategy:
+        model_name = self.active_model_name()
+        cached = self._strategy_cache.get(model_name)
+        if cached is not None:
+            return cached
+        with self._strategy_lock:
+            cached = self._strategy_cache.get(model_name)
+            if cached is None:
+                cached = self._init_strategy(model_name)
+                if hasattr(cached, "tools"):
+                    cached.tools = self._tools
+                self._strategy_cache[model_name] = cached
+            return cached
 
     def _ensure_openai_client(self):
         if self._openai_client is not None:
@@ -832,6 +862,8 @@ class LanguageModel:
         if not prompt_text.strip():
             raise ValueError("Prompt must not be empty.")
 
+        strategy = self._strategy_for_request()
+
         # Derive a stable user key for OpenAI/OpenClaw session persistence.
         _user_key: str | None = None
         if self.provider == "openai":
@@ -848,7 +880,7 @@ class LanguageModel:
                     _tool_extra: dict[str, Any] = {}
                     if _user_key is not None:
                         _tool_extra["user"] = _user_key
-                    result = self.strategy.generate(
+                    result = strategy.generate(
                         prompt_text,
                         config or self.generation,
                         messages=current_messages,
@@ -857,7 +889,7 @@ class LanguageModel:
                     )
                 except TypeError:
                     # Fallback for strategies that don't support tools parameter
-                    result = self.strategy.generate(
+                    result = strategy.generate(
                         prompt_text, config or self.generation, messages=current_messages
                     )
 
@@ -920,7 +952,7 @@ class LanguageModel:
                 extra: dict[str, Any] = {}
                 if _user_key is not None:
                     extra["user"] = _user_key
-                result = self.strategy.generate(
+                result = strategy.generate(
                     prompt_text,
                     config or self.generation,
                     messages=normalized_messages,
@@ -928,7 +960,7 @@ class LanguageModel:
                 )
                 return result.strip() if isinstance(result, str) else str(result).strip()
             except TypeError:
-                result = self.strategy.generate(prompt_text, config or self.generation)
+                result = strategy.generate(prompt_text, config or self.generation)
                 return result.strip() if isinstance(result, str) else str(result).strip()
         except Exception as exc:
             from rex.dep_errors import LMStudioConnectionError, is_connection_error
@@ -968,6 +1000,8 @@ class LanguageModel:
         if not prompt_text.strip():
             raise ValueError("Prompt must not be empty.")
 
+        strategy = self._strategy_for_request()
+
         def _generate_once() -> Iterator[str]:
             if messages is not None:
                 completion = self.generate(messages=normalized_messages, config=generation_config)
@@ -986,7 +1020,7 @@ class LanguageModel:
             if self._tools:
                 extra["tools"] = self._tools
 
-        stream_fn = getattr(self.strategy, "stream", None)
+        stream_fn = getattr(strategy, "stream", None)
         if not callable(stream_fn):
             return _generate_once()
 

--- a/rex/llm_client.py
+++ b/rex/llm_client.py
@@ -734,21 +734,28 @@ class LanguageModel:
 
     def active_model_name(self) -> str:
         """Return the request-local model when set, otherwise the configured base model."""
-        return self._request_model.get() or self.model_name
+        request_model = getattr(self, "_request_model", None)
+        if request_model is None:
+            return self.model_name
+        return request_model.get() or self.model_name
 
     def _strategy_for_request(self) -> LLMStrategy:
         model_name = self.active_model_name()
-        cached = self._strategy_cache.get(model_name)
+        strategy_cache = getattr(self, "_strategy_cache", None)
+        strategy_lock = getattr(self, "_strategy_lock", None)
+        if strategy_cache is None or strategy_lock is None:
+            return self.strategy
+        cached = strategy_cache.get(model_name)
         if cached is not None:
-            return cached
-        with self._strategy_lock:
-            cached = self._strategy_cache.get(model_name)
+            return cast(LLMStrategy, cached)
+        with strategy_lock:
+            cached = strategy_cache.get(model_name)
             if cached is None:
                 cached = self._init_strategy(model_name)
                 if hasattr(cached, "tools"):
                     cached.tools = self._tools
-                self._strategy_cache[model_name] = cached
-            return cached
+                strategy_cache[model_name] = cached
+            return cast(LLMStrategy, cached)
 
     def _ensure_openai_client(self):
         if self._openai_client is not None:

--- a/rex/model_router.py
+++ b/rex/model_router.py
@@ -18,6 +18,7 @@ import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from enum import StrEnum, auto
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,32 @@ class TaskCategory(StrEnum):
     vision = auto()
     fast = auto()
     default = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class ModelRouteDecision:
+    """Privacy-safe explanation of one fast/deep model-routing decision."""
+
+    category: TaskCategory
+    complexity: str
+    confidence: float
+    evidence: tuple[str, ...]
+    tier: str
+    model: str
+    escalation_count: int = 0
+    fallback_reason: str | None = None
+
+    def to_metadata(self) -> dict[str, object]:
+        return {
+            "category": str(self.category),
+            "complexity": self.complexity,
+            "confidence": round(self.confidence, 3),
+            "evidence": list(self.evidence),
+            "route": self.tier,
+            "model": self.model,
+            "escalation_count": self.escalation_count,
+            "fallback_reason": self.fallback_reason,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +117,15 @@ _SEARCH_PATTERNS: Sequence[str] = [
     r"\bgoogle\b",
     r"\bwikipedia\b",
 ]
+
+_AMBIGUOUS_TOOL_PATTERNS: Sequence[str] = [
+    r"\bwhichever\s+tool\b",
+    r"\bwhatever\s+tool\b",
+    r"\buse\s+(?:a|some)\s+tool\b",
+    r"\bchoose\s+(?:the\s+)?(?:right|best)\s+tool\b",
+]
+
+_CLOUD_PROVIDERS = frozenset({"openai", "openrouter", "anthropic"})
 
 _VISION_PATTERNS: Sequence[str] = [
     r"\bimage\b",
@@ -341,6 +377,147 @@ class ModelRouter:
         return default
 
     # ------------------------------------------------------------------
+    # ModelRouter 2.0 decision contract (US-110)
+    # ------------------------------------------------------------------
+
+    _LOW_CONFIDENCE_THRESHOLD = 0.60
+
+    def decide(
+        self,
+        message: str,
+        *,
+        routing_config: object = None,
+        current_model: str = "",
+        requires_tools: bool = False,
+        tool_choice_confidence: float | None = None,
+        deep_provider_available: bool = True,
+        routing_mode: str = "local_preferred",
+        provider: str = "",
+    ) -> ModelRouteDecision:
+        """Choose a fast/deep route and return bounded, privacy-safe evidence."""
+        category = self.classify(message)
+        evidence: list[str] = []
+        estimated_tokens = len(message.split()) * 1.3
+        ambiguous_tool_request = _matches_any(message, _AMBIGUOUS_TOOL_PATTERNS)
+        if ambiguous_tool_request:
+            requires_tools = True
+            evidence.append("ambiguous_tool_request")
+
+        if category is TaskCategory.fast:
+            complexity = "simple"
+            confidence = 0.98
+            evidence.append("fast_pattern")
+        elif category in {
+            TaskCategory.coding,
+            TaskCategory.reasoning,
+            TaskCategory.search,
+            TaskCategory.vision,
+        }:
+            complexity = "complex"
+            confidence = 0.90
+            evidence.append(f"category_{category}")
+        else:
+            confidence = 0.80
+            if requires_tools or estimated_tokens >= self._SIMPLE_TOKEN_THRESHOLD:
+                complexity = "complex"
+            else:
+                complexity = "moderate"
+            evidence.append("no_category_match")
+
+        if requires_tools:
+            complexity = "complex"
+            evidence.append("tools_required")
+        if ambiguous_tool_request and tool_choice_confidence is None:
+            tool_choice_confidence = 0.40
+        if tool_choice_confidence is not None:
+            confidence = max(0.0, min(1.0, float(tool_choice_confidence)))
+            if confidence < self._LOW_CONFIDENCE_THRESHOLD:
+                evidence.append("tool_choice_low_confidence")
+
+        config = routing_config
+        default_model = (getattr(config, "default", "") or "") if config is not None else ""
+        fast_model = (getattr(config, "fast", "") or "") if config is not None else ""
+        fast_model = fast_model or default_model or current_model
+
+        category_model = ""
+        if config is not None and category not in {TaskCategory.fast, TaskCategory.default}:
+            category_model = getattr(config, str(category), "") or ""
+        reasoning_model = (getattr(config, "reasoning", "") or "") if config is not None else ""
+        deep_model = category_model or reasoning_model or default_model
+
+        low_confidence = confidence < self._LOW_CONFIDENCE_THRESHOLD
+        wants_deep = complexity == "complex" or low_confidence
+        escalation_count = 1 if low_confidence and wants_deep else 0
+
+        normalized_mode = (
+            routing_mode
+            if routing_mode in {"local_preferred", "local_only", "cloud_only"}
+            else "local_preferred"
+        )
+        normalized_provider = provider.strip().lower()
+        provider_is_cloud = normalized_provider in _CLOUD_PROVIDERS
+        policy_conflict: str | None = None
+        if normalized_mode == "local_only" and provider_is_cloud:
+            policy_conflict = "local_only_provider_conflict"
+        elif normalized_mode == "cloud_only" and normalized_provider and not provider_is_cloud:
+            policy_conflict = "cloud_provider_unconfigured"
+
+        if policy_conflict is not None:
+            evidence.append(policy_conflict)
+            return ModelRouteDecision(
+                category=category,
+                complexity=complexity,
+                confidence=confidence,
+                evidence=tuple(dict.fromkeys(evidence)),
+                tier="fast",
+                model=current_model or fast_model,
+                escalation_count=0,
+                fallback_reason=policy_conflict,
+            )
+
+        if not wants_deep:
+            return ModelRouteDecision(
+                category=category,
+                complexity=complexity,
+                confidence=confidence,
+                evidence=tuple(dict.fromkeys(evidence)),
+                tier="fast",
+                model=fast_model,
+            )
+
+        fallback_reason: str | None = None
+        if not deep_provider_available:
+            fallback_reason = "deep_provider_unavailable"
+        elif not deep_model or deep_model == fast_model:
+            fallback_reason = "deep_model_unconfigured"
+        elif not self._is_available(deep_model):
+            fallback_reason = "deep_model_unavailable"
+
+        if fallback_reason is not None:
+            evidence.append(fallback_reason)
+            return ModelRouteDecision(
+                category=category,
+                complexity=complexity,
+                confidence=confidence,
+                evidence=tuple(dict.fromkeys(evidence)),
+                tier="fast",
+                model=fast_model or current_model,
+                escalation_count=min(escalation_count, 1),
+                fallback_reason=fallback_reason,
+            )
+
+        evidence.append("deep_route_selected")
+        return ModelRouteDecision(
+            category=category,
+            complexity=complexity,
+            confidence=confidence,
+            evidence=tuple(dict.fromkeys(evidence)),
+            tier="deep",
+            model=deep_model,
+            escalation_count=min(escalation_count, 1),
+        )
+
+    # ------------------------------------------------------------------
     # Smart local/cloud routing (US-044)
     # ------------------------------------------------------------------
 
@@ -410,11 +587,10 @@ class ModelRouter:
                 return local_model
             logger.warning(
                 "model_router: local_only mode but local model %r is unavailable; "
-                "falling back to cloud model %r",
+                "cloud fallback is disabled by policy",
                 local_model,
-                cloud_model,
             )
-            return cloud_model
+            return local_model
 
         # local_preferred
         complexity = self.estimate_complexity(message, requires_tools=requires_tools)

--- a/rex/model_router.py
+++ b/rex/model_router.py
@@ -382,6 +382,147 @@ class ModelRouter:
 
     _LOW_CONFIDENCE_THRESHOLD = 0.60
 
+    def _decision_signals(
+        self,
+        message: str,
+        *,
+        requires_tools: bool,
+        tool_choice_confidence: float | None,
+    ) -> tuple[TaskCategory, str, float, list[str]]:
+        """Derive bounded, content-free routing signals from one request."""
+        category = self.classify(message)
+        evidence: list[str] = []
+        ambiguous_tool_request = _matches_any(message, _AMBIGUOUS_TOOL_PATTERNS)
+        effective_requires_tools = requires_tools or ambiguous_tool_request
+        if ambiguous_tool_request:
+            evidence.append("ambiguous_tool_request")
+
+        complexity, confidence = self._base_complexity_confidence(
+            category,
+            message,
+            requires_tools=effective_requires_tools,
+            evidence=evidence,
+        )
+        if effective_requires_tools:
+            complexity = "complex"
+            evidence.append("tools_required")
+        confidence = self._apply_tool_confidence(
+            confidence,
+            ambiguous_tool_request=ambiguous_tool_request,
+            tool_choice_confidence=tool_choice_confidence,
+            evidence=evidence,
+        )
+        return category, complexity, confidence, evidence
+
+    def _base_complexity_confidence(
+        self,
+        category: TaskCategory,
+        message: str,
+        *,
+        requires_tools: bool,
+        evidence: list[str],
+    ) -> tuple[str, float]:
+        if category is TaskCategory.fast:
+            evidence.append("fast_pattern")
+            return "simple", 0.98
+        if category in {
+            TaskCategory.coding,
+            TaskCategory.reasoning,
+            TaskCategory.search,
+            TaskCategory.vision,
+        }:
+            evidence.append(f"category_{category}")
+            return "complex", 0.90
+        evidence.append("no_category_match")
+        return self.estimate_complexity(message, requires_tools=requires_tools), 0.80
+
+    def _apply_tool_confidence(
+        self,
+        confidence: float,
+        *,
+        ambiguous_tool_request: bool,
+        tool_choice_confidence: float | None,
+        evidence: list[str],
+    ) -> float:
+        effective_confidence = tool_choice_confidence
+        if ambiguous_tool_request and effective_confidence is None:
+            effective_confidence = 0.40
+        if effective_confidence is None:
+            return confidence
+        bounded = max(0.0, min(1.0, float(effective_confidence)))
+        if bounded < self._LOW_CONFIDENCE_THRESHOLD:
+            evidence.append("tool_choice_low_confidence")
+        return bounded
+
+    @staticmethod
+    def _configured_models(
+        routing_config: object,
+        category: TaskCategory,
+        current_model: str,
+    ) -> tuple[str, str]:
+        config = routing_config
+        default_model = (getattr(config, "default", "") or "") if config is not None else ""
+        fast_model = (getattr(config, "fast", "") or "") if config is not None else ""
+        fast_model = fast_model or default_model or current_model
+        category_model = ""
+        if config is not None and category not in {TaskCategory.fast, TaskCategory.default}:
+            category_model = getattr(config, str(category), "") or ""
+        reasoning_model = (getattr(config, "reasoning", "") or "") if config is not None else ""
+        return fast_model, category_model or reasoning_model or default_model
+
+    @staticmethod
+    def _routing_policy_conflict(routing_mode: str, provider: str) -> str | None:
+        normalized_mode = (
+            routing_mode
+            if routing_mode in {"local_preferred", "local_only", "cloud_only"}
+            else "local_preferred"
+        )
+        normalized_provider = provider.strip().lower()
+        provider_is_cloud = normalized_provider in _CLOUD_PROVIDERS
+        if normalized_mode == "local_only" and provider_is_cloud:
+            return "local_only_provider_conflict"
+        if normalized_mode == "cloud_only" and normalized_provider and not provider_is_cloud:
+            return "cloud_provider_unconfigured"
+        return None
+
+    def _deep_fallback_reason(
+        self,
+        *,
+        deep_provider_available: bool,
+        deep_model: str,
+        fast_model: str,
+    ) -> str | None:
+        if not deep_provider_available:
+            return "deep_provider_unavailable"
+        if not deep_model or deep_model == fast_model:
+            return "deep_model_unconfigured"
+        if not self._is_available(deep_model):
+            return "deep_model_unavailable"
+        return None
+
+    @staticmethod
+    def _decision(
+        *,
+        category: TaskCategory,
+        complexity: str,
+        confidence: float,
+        evidence: list[str],
+        tier: str,
+        model: str,
+        escalation_count: int = 0,
+        fallback_reason: str | None = None,
+    ) -> ModelRouteDecision:
+        return ModelRouteDecision(
+            category=category,
+            complexity=complexity,
+            confidence=confidence,
+            evidence=tuple(dict.fromkeys(evidence)),
+            tier=tier,
+            model=model,
+            escalation_count=min(escalation_count, 1),
+            fallback_reason=fallback_reason,
+        )
+
     def decide(
         self,
         message: str,
@@ -395,126 +536,65 @@ class ModelRouter:
         provider: str = "",
     ) -> ModelRouteDecision:
         """Choose a fast/deep route and return bounded, privacy-safe evidence."""
-        category = self.classify(message)
-        evidence: list[str] = []
-        estimated_tokens = len(message.split()) * 1.3
-        ambiguous_tool_request = _matches_any(message, _AMBIGUOUS_TOOL_PATTERNS)
-        if ambiguous_tool_request:
-            requires_tools = True
-            evidence.append("ambiguous_tool_request")
-
-        if category is TaskCategory.fast:
-            complexity = "simple"
-            confidence = 0.98
-            evidence.append("fast_pattern")
-        elif category in {
-            TaskCategory.coding,
-            TaskCategory.reasoning,
-            TaskCategory.search,
-            TaskCategory.vision,
-        }:
-            complexity = "complex"
-            confidence = 0.90
-            evidence.append(f"category_{category}")
-        else:
-            confidence = 0.80
-            if requires_tools or estimated_tokens >= self._SIMPLE_TOKEN_THRESHOLD:
-                complexity = "complex"
-            else:
-                complexity = "moderate"
-            evidence.append("no_category_match")
-
-        if requires_tools:
-            complexity = "complex"
-            evidence.append("tools_required")
-        if ambiguous_tool_request and tool_choice_confidence is None:
-            tool_choice_confidence = 0.40
-        if tool_choice_confidence is not None:
-            confidence = max(0.0, min(1.0, float(tool_choice_confidence)))
-            if confidence < self._LOW_CONFIDENCE_THRESHOLD:
-                evidence.append("tool_choice_low_confidence")
-
-        config = routing_config
-        default_model = (getattr(config, "default", "") or "") if config is not None else ""
-        fast_model = (getattr(config, "fast", "") or "") if config is not None else ""
-        fast_model = fast_model or default_model or current_model
-
-        category_model = ""
-        if config is not None and category not in {TaskCategory.fast, TaskCategory.default}:
-            category_model = getattr(config, str(category), "") or ""
-        reasoning_model = (getattr(config, "reasoning", "") or "") if config is not None else ""
-        deep_model = category_model or reasoning_model or default_model
-
+        category, complexity, confidence, evidence = self._decision_signals(
+            message,
+            requires_tools=requires_tools,
+            tool_choice_confidence=tool_choice_confidence,
+        )
+        fast_model, deep_model = self._configured_models(routing_config, category, current_model)
         low_confidence = confidence < self._LOW_CONFIDENCE_THRESHOLD
         wants_deep = complexity == "complex" or low_confidence
         escalation_count = 1 if low_confidence and wants_deep else 0
 
-        normalized_mode = (
-            routing_mode
-            if routing_mode in {"local_preferred", "local_only", "cloud_only"}
-            else "local_preferred"
-        )
-        normalized_provider = provider.strip().lower()
-        provider_is_cloud = normalized_provider in _CLOUD_PROVIDERS
-        policy_conflict: str | None = None
-        if normalized_mode == "local_only" and provider_is_cloud:
-            policy_conflict = "local_only_provider_conflict"
-        elif normalized_mode == "cloud_only" and normalized_provider and not provider_is_cloud:
-            policy_conflict = "cloud_provider_unconfigured"
-
+        policy_conflict = self._routing_policy_conflict(routing_mode, provider)
         if policy_conflict is not None:
             evidence.append(policy_conflict)
-            return ModelRouteDecision(
+            return self._decision(
                 category=category,
                 complexity=complexity,
                 confidence=confidence,
-                evidence=tuple(dict.fromkeys(evidence)),
+                evidence=evidence,
                 tier="fast",
                 model=current_model or fast_model,
-                escalation_count=0,
                 fallback_reason=policy_conflict,
             )
-
         if not wants_deep:
-            return ModelRouteDecision(
+            return self._decision(
                 category=category,
                 complexity=complexity,
                 confidence=confidence,
-                evidence=tuple(dict.fromkeys(evidence)),
+                evidence=evidence,
                 tier="fast",
                 model=fast_model,
             )
 
-        fallback_reason: str | None = None
-        if not deep_provider_available:
-            fallback_reason = "deep_provider_unavailable"
-        elif not deep_model or deep_model == fast_model:
-            fallback_reason = "deep_model_unconfigured"
-        elif not self._is_available(deep_model):
-            fallback_reason = "deep_model_unavailable"
-
+        fallback_reason = self._deep_fallback_reason(
+            deep_provider_available=deep_provider_available,
+            deep_model=deep_model,
+            fast_model=fast_model,
+        )
         if fallback_reason is not None:
             evidence.append(fallback_reason)
-            return ModelRouteDecision(
+            return self._decision(
                 category=category,
                 complexity=complexity,
                 confidence=confidence,
-                evidence=tuple(dict.fromkeys(evidence)),
+                evidence=evidence,
                 tier="fast",
                 model=fast_model or current_model,
-                escalation_count=min(escalation_count, 1),
+                escalation_count=escalation_count,
                 fallback_reason=fallback_reason,
             )
 
         evidence.append("deep_route_selected")
-        return ModelRouteDecision(
+        return self._decision(
             category=category,
             complexity=complexity,
             confidence=confidence,
-            evidence=tuple(dict.fromkeys(evidence)),
+            evidence=evidence,
             tier="deep",
             model=deep_model,
-            escalation_count=min(escalation_count, 1),
+            escalation_count=escalation_count,
         )
 
     # ------------------------------------------------------------------

--- a/scripts/rexbench.py
+++ b/scripts/rexbench.py
@@ -593,7 +593,6 @@ def run_warm_runtime(iterations: int) -> dict:
     return build_report(samples, profile="warm-runtime")
 
 
-
 def run_model_routing(iterations: int) -> dict:
     if iterations < 1:
         raise ValueError("iterations must be at least 1")
@@ -608,7 +607,6 @@ def run_model_routing(iterations: int) -> dict:
     router = ModelRouter()
     samples: list[BenchmarkSample] = []
     scenarios = (
-
         ("simple_command", "Hello", {}, {"fast-local", "deep-local"}, "fast", "fast-local"),
         (
             "ambiguous_tool_choice",
@@ -626,7 +624,6 @@ def run_model_routing(iterations: int) -> dict:
             "deep",
             "deep-local",
         ),
-
         (
             "provider_outage",
             "Analyze the tradeoffs in this architecture.",
@@ -668,17 +665,23 @@ def run_model_routing(iterations: int) -> dict:
                     request_class=request_class,
                     warm_state="warm",
                     evidence_class="deterministic_local",
-
                     stages_ms={"routing": elapsed_ms, "total": elapsed_ms},
                 )
             )
     return build_report(samples, profile="model-routing")
 
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--profile",
-        choices=("baseline", "capability-retrieval", "parallel-actions", "warm-runtime", "model-routing"),
+        choices=(
+            "baseline",
+            "capability-retrieval",
+            "parallel-actions",
+            "warm-runtime",
+            "model-routing",
+        ),
         default="baseline",
     )
     parser.add_argument("--iterations", type=int, default=8)

--- a/scripts/rexbench.py
+++ b/scripts/rexbench.py
@@ -593,11 +593,92 @@ def run_warm_runtime(iterations: int) -> dict:
     return build_report(samples, profile="warm-runtime")
 
 
+
+def run_model_routing(iterations: int) -> dict:
+    if iterations < 1:
+        raise ValueError("iterations must be at least 1")
+    routing = SimpleNamespace(
+        default="fast-local",
+        fast="fast-local",
+        coding="deep-local",
+        reasoning="deep-local",
+        search="deep-local",
+        vision="deep-local",
+    )
+    router = ModelRouter()
+    samples: list[BenchmarkSample] = []
+    scenarios = (
+
+        ("simple_command", "Hello", {}, {"fast-local", "deep-local"}, "fast", "fast-local"),
+        (
+            "ambiguous_tool_choice",
+            "Use whichever tool makes sense to handle that.",
+            {},
+            {"fast-local", "deep-local"},
+            "deep",
+            "deep-local",
+        ),
+        (
+            "complex_reasoning",
+            "Analyze the tradeoffs and plan a complex migration strategy.",
+            {},
+            {"fast-local", "deep-local"},
+            "deep",
+            "deep-local",
+        ),
+
+        (
+            "provider_outage",
+            "Analyze the tradeoffs in this architecture.",
+            {"deep_provider_available": False},
+            {"fast-local", "deep-local"},
+            "fast",
+            "fast-local",
+        ),
+        (
+            "unavailable_local_model",
+            "Analyze a complex migration plan.",
+            {},
+            {"fast-local"},
+            "fast",
+            "fast-local",
+        ),
+    )
+    for request_class, message, kwargs, available, expected_tier, expected_model in scenarios:
+        for _ in range(iterations):
+            router._available_ollama_models = set(available)
+
+            started = time.perf_counter_ns()
+            decision = router.decide(
+                message,
+                routing_config=routing,
+                current_model="fast-local",
+                **kwargs,
+            )
+            elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+            if decision.tier != expected_tier or decision.model != expected_model:
+                raise RuntimeError(
+                    f"model-routing correctness failed for {request_class}: "
+                    f"{decision.tier}/{decision.model}"
+                )
+            if decision.escalation_count > 1:
+                raise RuntimeError(f"model-routing escalation exceeded bound for {request_class}")
+            samples.append(
+                BenchmarkSample(
+                    request_class=request_class,
+                    warm_state="warm",
+                    evidence_class="deterministic_local",
+
+                    stages_ms={"routing": elapsed_ms, "total": elapsed_ms},
+                )
+            )
+    return build_report(samples, profile="model-routing")
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--profile",
-        choices=("baseline", "capability-retrieval", "parallel-actions", "warm-runtime"),
+        choices=("baseline", "capability-retrieval", "parallel-actions", "warm-runtime", "model-routing"),
         default="baseline",
     )
     parser.add_argument("--iterations", type=int, default=8)
@@ -610,6 +691,8 @@ def main() -> int:
         report = run_parallel_actions(args.iterations)
     elif args.profile == "warm-runtime":
         report = run_warm_runtime(args.iterations)
+    elif args.profile == "model-routing":
+        report = run_model_routing(args.iterations)
     else:
         report = run_baseline(args.iterations)
     encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"

--- a/tests/rex2/test_model_router_v2.py
+++ b/tests/rex2/test_model_router_v2.py
@@ -284,3 +284,76 @@ def test_local_only_policy_refuses_override_when_active_provider_is_cloud():
     assert decision.model == "gpt-fast"
     assert decision.tier == "fast"
     assert decision.fallback_reason == "local_only_provider_conflict"
+
+
+def test_context_cache_uses_request_scoped_routed_model() -> None:
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from rex.actions.dispatcher import ActionResult
+    from rex.assistant import Assistant
+    from rex.config import AppConfig
+    from rex.intent.router import IntentResult
+    from rex.response.builder import FinalResponse
+
+    config = _routing()
+    assistant = Assistant.__new__(Assistant)
+    assistant._settings = SimpleNamespace(
+        max_memory_items=50,
+        persist_history=False,
+        followups_enabled=False,
+        model_routing=config,
+        transcripts_enabled=False,
+        llm_provider="echo",
+        llm_model="fast-local",
+        llm_routing_mode="local_preferred",
+        llm=None,
+    )
+    assistant._user_id = "james"
+    assistant._histories = {}
+    assistant._history_limit = 50
+    assistant._plugins = []
+    assistant._history_store = None
+    assistant._followup_engine = None
+    assistant._followup_sessions = set()
+    assistant._followup_bootstrap_pending = False
+    assistant._pending_followups = {}
+    assistant._response_cache = None
+    assistant._ha_bridge = None
+    assistant._suggestion_engine = None
+    assistant._pattern_entries = {}
+    assistant._llm = LanguageModel(AppConfig(llm_provider="echo", llm_model="fast-local"))
+    assistant._router = _router(config, {"fast-local", "deep-local"})
+
+    intent_router = MagicMock()
+    intent_router.route.return_value = IntentResult(handled=False, response=None, intent_type=None)
+    assistant._intent_router = intent_router
+    assistant._context_builder = MagicMock()
+    assistant._context_builder.build.return_value = SimpleNamespace(
+        messages=[], prompt="prompt", system_prompt="system"
+    )
+    assistant._response_builder = MagicMock()
+    assistant._response_builder.check_cache.return_value = None
+    assistant._response_builder.build.return_value = FinalResponse(
+        text="deep reply", tts_text="deep reply"
+    )
+    assistant._turn_events = []
+    assistant._turn_event_observer = assistant._turn_events.append
+    assistant._log_turn = MagicMock()
+
+    async def dispatch(*_args, **_kwargs):
+        return ActionResult(success=True, response="deep reply")
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+
+    asyncio.run(
+        assistant.generate_reply(
+            "Analyze the tradeoffs in this complex migration.", active_user_id="james"
+        )
+    )
+
+    cache_request = assistant._context_builder.build.call_args.kwargs["cache_request"]
+    assert cache_request.model_provider == "echo"
+    assert cache_request.model_name == "deep-local"
+    assert assistant._llm.model_name == "fast-local"

--- a/tests/rex2/test_model_router_v2.py
+++ b/tests/rex2/test_model_router_v2.py
@@ -1,0 +1,286 @@
+"""Golden tests for US-110 ModelRouter 2.0 fast/deep routing."""
+
+from types import SimpleNamespace
+
+from rex.llm_client import LanguageModel
+from rex.model_router import ModelRouter
+
+
+def _routing(**overrides):
+    values = {
+        "default": "fast-local",
+        "fast": "fast-local",
+        "coding": "",
+        "reasoning": "deep-local",
+        "search": "",
+        "vision": "",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _router(config=None, available=None):
+    router = ModelRouter()
+    router._available_ollama_models = set(available or ())
+    return router
+
+
+def test_simple_command_uses_fast_route_with_explicit_evidence():
+    config = _routing()
+    router = _router(config, {"fast-local", "deep-local"})
+
+    decision = router.decide("Hello", routing_config=config, current_model="fast-local")
+
+    assert decision.tier == "fast"
+    assert decision.complexity == "simple"
+    assert decision.confidence >= 0.9
+    assert decision.model == "fast-local"
+    assert decision.escalation_count == 0
+    assert decision.evidence
+
+
+def test_ambiguous_tool_choice_escalates_once_to_deep():
+    config = _routing()
+    router = _router(config, {"fast-local", "deep-local"})
+
+    decision = router.decide(
+        "Use whichever tool makes sense to handle that.",
+        routing_config=config,
+        current_model="fast-local",
+    )
+
+    assert decision.tier == "deep"
+    assert decision.model == "deep-local"
+    assert decision.confidence < 0.6
+    assert decision.escalation_count == 1
+    assert "tool_choice_low_confidence" in decision.evidence
+
+
+def test_complex_reasoning_routes_directly_to_deep_model():
+    config = _routing()
+    router = _router(config, {"fast-local", "deep-local"})
+
+    decision = router.decide(
+        "Analyze the tradeoffs and plan a complex multi-step migration strategy.",
+        routing_config=config,
+        current_model="fast-local",
+    )
+
+    assert decision.tier == "deep"
+    assert decision.complexity == "complex"
+    assert decision.model == "deep-local"
+    assert decision.escalation_count == 0
+    assert "category_reasoning" in decision.evidence
+
+
+def test_deep_provider_outage_falls_back_to_fast_without_retry_loop():
+    config = _routing()
+    router = _router(config, {"fast-local", "deep-local"})
+
+    decision = router.decide(
+        "Analyze the tradeoffs in this architecture.",
+        routing_config=config,
+        current_model="fast-local",
+        deep_provider_available=False,
+    )
+
+    assert decision.tier == "fast"
+    assert decision.model == "fast-local"
+    assert decision.fallback_reason == "deep_provider_unavailable"
+    assert decision.escalation_count <= 1
+
+
+def test_unavailable_local_deep_model_falls_back_to_available_fast_model():
+    config = _routing()
+    router = _router(config, {"fast-local"})
+
+    decision = router.decide(
+        "Analyze a complex migration plan.",
+        routing_config=config,
+        current_model="fast-local",
+    )
+
+    assert decision.tier == "fast"
+    assert decision.model == "fast-local"
+    assert decision.fallback_reason == "deep_model_unavailable"
+    assert "deep_model_unavailable" in decision.evidence
+
+
+def test_route_metadata_is_privacy_safe_and_bounded():
+    config = _routing()
+    router = _router(config, {"fast-local", "deep-local"})
+    private_marker = "PRIVATE-USER-CONTENT-MARKER"
+
+    decision = router.decide(
+        f"Analyze {private_marker} and compare the tradeoffs.",
+        routing_config=config,
+        current_model="fast-local",
+    )
+    metadata = decision.to_metadata()
+
+    assert set(metadata) == {
+        "category",
+        "complexity",
+        "confidence",
+        "evidence",
+        "route",
+        "model",
+        "escalation_count",
+        "fallback_reason",
+    }
+    assert private_marker not in repr(metadata)
+    assert all(len(code) <= 64 for code in metadata["evidence"])
+
+
+def test_request_model_selection_is_context_local_across_workers():
+    import contextvars
+    from concurrent.futures import ThreadPoolExecutor
+
+    from rex.config import AppConfig
+
+    model = LanguageModel(AppConfig(llm_provider="echo", llm_model="base-local"))
+
+    token = model.set_request_model("deep-a")
+    context_a = contextvars.copy_context()
+    model.reset_request_model(token)
+    token = model.set_request_model("deep-b")
+    context_b = contextvars.copy_context()
+    model.reset_request_model(token)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(context_a.run, model.generate, "hello")
+        second = pool.submit(context_b.run, model.generate, "hello")
+        results = {first.result(), second.result()}
+
+    assert results == {"[deep-a] hello", "[deep-b] hello"}
+    assert model.model_name == "base-local"
+    assert model.strategy.model_name == "base-local"
+
+
+def test_local_only_mode_never_silently_falls_back_to_cloud():
+    router = ModelRouter()
+    router._available_ollama_models = set()
+
+    result = router.route(
+        "Hello",
+        local_model="missing-local",
+        cloud_model="gpt-5",
+        routing_mode="local_only",
+    )
+
+    assert result == "missing-local"
+
+
+def test_turn_event_exposes_privacy_safe_model_route_metadata():
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from rex.actions.dispatcher import ActionResult
+    from rex.assistant import Assistant
+    from rex.intent.router import IntentResult
+    from rex.response.builder import FinalResponse
+    from rex.runtime.events import EventKind
+
+    private_marker = "PRIVATE-TURN-CONTENT-MARKER"
+    config = _routing()
+    assistant = Assistant.__new__(Assistant)
+    assistant._settings = SimpleNamespace(
+        max_memory_items=50,
+        persist_history=False,
+        followups_enabled=False,
+        model_routing=config,
+        transcripts_enabled=False,
+        llm_provider="ollama",
+        llm_model="fast-local",
+        llm_routing_mode="local_preferred",
+        llm=None,
+    )
+    assistant._user_id = "james"
+    assistant._histories = {}
+    assistant._history_limit = 50
+    assistant._plugins = []
+    assistant._history_store = None
+    assistant._followup_engine = None
+    assistant._followup_sessions = set()
+    assistant._followup_bootstrap_pending = False
+    assistant._pending_followups = {}
+    assistant._response_cache = None
+    assistant._ha_bridge = None
+    assistant._suggestion_engine = None
+    assistant._pattern_entries = {}
+    assistant._llm = MagicMock()
+    assistant._llm.model_name = "fast-local"
+    assistant._router = _router(config, {"fast-local", "deep-local"})
+
+    intent_router = MagicMock()
+    intent_router.route.return_value = IntentResult(handled=False, response=None, intent_type=None)
+    assistant._intent_router = intent_router
+    assistant._context_builder = MagicMock()
+    assistant._context_builder.build.return_value = SimpleNamespace(
+        messages=[], prompt="prompt", system_prompt="system"
+    )
+    assistant._response_builder = MagicMock()
+    assistant._response_builder.check_cache.return_value = None
+    assistant._response_builder.build.return_value = FinalResponse(
+        text="deep reply", tts_text="deep reply"
+    )
+    assistant._turn_events = []
+    assistant._turn_event_observer = assistant._turn_events.append
+    assistant._log_turn = MagicMock()
+
+    async def dispatch(*_args, **_kwargs):
+        return ActionResult(success=True, response="deep reply")
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+
+    asyncio.run(
+        assistant.generate_reply(
+            f"Analyze {private_marker} and compare the tradeoffs.", active_user_id="james"
+        )
+    )
+
+    route_event = next(
+        event
+        for event in assistant._turn_events
+        if event.kind is EventKind.ROUTE_PROGRESS and event.details.get("stage") == "model_router"
+    )
+    assert route_event.details["route"] == "deep"
+    assert route_event.details["complexity"] == "complex"
+    assert route_event.details["confidence"] >= 0.9
+    assert route_event.details["model"] == "deep-local"
+    assert route_event.details["evidence"]
+    assert private_marker not in repr(dict(route_event.details))
+    assert assistant._llm.model_name == "fast-local"
+
+
+def test_unmatched_ordinary_request_stays_fast_without_low_confidence_signal():
+    config = _routing()
+    router = _router(config, {"fast-local", "deep-local"})
+
+    decision = router.decide(
+        "Tell me something interesting about octopuses.",
+        routing_config=config,
+        current_model="fast-local",
+    )
+
+    assert decision.tier == "fast"
+    assert decision.model == "fast-local"
+    assert decision.confidence >= 0.6
+
+
+def test_local_only_policy_refuses_override_when_active_provider_is_cloud():
+    config = _routing(reasoning="gpt-deep")
+    router = ModelRouter()
+
+    decision = router.decide(
+        "Analyze the tradeoffs.",
+        routing_config=config,
+        current_model="gpt-fast",
+        routing_mode="local_only",
+        provider="openai",
+    )
+
+    assert decision.model == "gpt-fast"
+    assert decision.tier == "fast"
+    assert decision.fallback_reason == "local_only_provider_conflict"

--- a/tests/test_model_routing_integration.py
+++ b/tests/test_model_routing_integration.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 
+import pytest
+
 import rex.assistant as assistant_module
+from rex.assistant_errors import ConfigurationError
 from rex.model_router import ModelRouter
 
 # ---------------------------------------------------------------------------
@@ -40,6 +43,7 @@ class _SettingsStub:
     ha_token: str | None = None
     user_id: str = "test"
     active_profile: str = "default"
+    llm_routing_mode: str = "local_preferred"
     model_routing: _ModelRoutingStub = field(
         default_factory=lambda: _ModelRoutingStub(
             default="default-model",
@@ -58,10 +62,19 @@ class _CapturingLLM:
 
     def __init__(self):
         self.model_name = "stub-model"
+        self._request_model: str | None = None
         self.calls: list[str] = []
 
+    def set_request_model(self, model_name: str):
+        previous = self._request_model
+        self._request_model = model_name
+        return previous
+
+    def reset_request_model(self, token) -> None:
+        self._request_model = token
+
     def generate(self, prompt, config=None):
-        self.calls.append(self.model_name)
+        self.calls.append(self._request_model or self.model_name)
         return "stub reply"
 
 
@@ -233,3 +246,25 @@ def test_no_network_call_for_openai_models(monkeypatch):
     )
 
     assert not fetch_called, "Ollama was probed even though all routing targets are OpenAI models"
+
+
+def test_local_only_mode_is_passed_to_model_router(monkeypatch):
+    settings = _SettingsStub(
+        llm_provider="openai",
+        llm_routing_mode="local_only",
+        model_routing=_ModelRoutingStub(
+            default="gpt-fast",
+            reasoning="gpt-deep",
+            fast="gpt-fast",
+        ),
+    )
+    llm = _CapturingLLM()
+    llm.model_name = "gpt-fast"
+    a = _make_assistant(monkeypatch, settings, llm, available_models=set())
+
+    with pytest.raises(ConfigurationError, match="local_only"):
+        asyncio.run(a.generate_reply("Analyze the tradeoffs."))
+
+    assert llm.calls == []
+    assert llm.model_name == "gpt-fast"
+    assert llm._request_model is None

--- a/tests/test_rexbench.py
+++ b/tests/test_rexbench.py
@@ -198,3 +198,42 @@ def test_warm_runtime_cli_compares_cold_and_warm_without_private_payloads(tmp_pa
     encoded = output.read_text(encoding="utf-8").lower()
     for forbidden in ("prompt", "transcript", "memory_content", "credential", "user_id"):
         assert forbidden not in encoded
+
+
+def test_model_routing_cli_emits_golden_privacy_safe_profile(tmp_path) -> None:
+    output = tmp_path / "model-routing.json"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/rexbench.py",
+            "--profile",
+            "model-routing",
+            "--iterations",
+            "2",
+            "--output",
+            str(output),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["profile"] == "model-routing"
+    assert set(report["results"]) == {
+        "simple_command",
+        "ambiguous_tool_choice",
+        "complex_reasoning",
+        "provider_outage",
+        "unavailable_local_model",
+    }
+    for request_class in report["results"].values():
+        assert set(request_class) == {"warm"}
+        bucket = request_class["warm"]
+        assert bucket["evidence_class"] == "deterministic_local"
+        assert set(bucket["stages_ms"]) == {"routing", "total"}
+    encoded = output.read_text(encoding="utf-8").lower()
+    for forbidden in ("prompt", "transcript", "memory_content", "credential", "user_id"):
+        assert forbidden not in encoded

--- a/tests/test_us044_smart_routing.py
+++ b/tests/test_us044_smart_routing.py
@@ -78,12 +78,12 @@ class TestLocalOnlyMode:
             )
         assert result == LOCAL
 
-    def test_local_unavailable_falls_back_to_cloud(self, router):
+    def test_local_unavailable_stays_local_by_policy(self, router):
         with patch.object(router, "_is_available", return_value=False):
             result = router.route(
                 "Hello", local_model=LOCAL, cloud_model=CLOUD, routing_mode="local_only"
             )
-        assert result == CLOUD
+        assert result == LOCAL
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add privacy-safe ModelRouter 2.0 fast/deep decisions with explicit complexity, confidence, evidence, and bounded escalation
- keep local-first/local-only policy fail-closed so routing never silently enables cloud or paid providers
- make routed model selection request-local and concurrency-safe without mutating the configured base model
- key identity-safe context caching by the actual active routed model
- add deterministic ModelRouter golden coverage and a `model-routing` RexBench profile
- preserve minimal/legacy LanguageModel shells used by friendly-error and compatibility paths

## Validation
- full release marker: 8,764 passed / 49 skipped / 0 failed
- 103 cross-system ModelRouter/context-cache/warm-runtime/TurnEngine tests passed
- 66 focused routing/LLM/friendly-error regression tests passed
- `python scripts/rexbench.py --profile model-routing --iterations 8` passed
- Ruff, Black, and mypy passed on touched runtime modules
- `python scripts/security_audit.py --release-gate` passed

US-110 in `PRD-production-readiness.md`.