### PR TITLE
fix(ai): fail closed on incoherent model output

### DIFF
--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -86,7 +86,8 @@ Use this order for task selection after the reconciliation above. Select the fir
 53. `US-091`
 54. `US-092`
 55. `US-093`
-56. `US-118`
+56. `US-119`
+57. `US-118`
 
 **Dependency/security notes:** TurnEngine work must preserve the already-implemented explicit, fail-closed user identity contract from its first event. US-087 later proves the broader user/household model and James/Cole concurrency invariants. OpenClaw metadata never widens local authority. Mobile remains desktop-paired and least-privilege. All benchmark evidence must label whether it is deterministic/mock, local source runtime, live provider, packaged Windows artifact, or physical hardware/device.
 
@@ -2627,7 +2628,7 @@ cd gui && npm run typecheck && npm run build
 - [x] A profiling command or harness summarizes timings.
 - [x] Optimization stories are opened or blockers documented for any stage over budget.
 - [x] Tests cover timing event emission with mocked stages.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 - [x] A checked-in RexBench baseline reports cold and warm p50/p95 for typed chat, voice, read-only tool, mutating tool, and unavailable-capability request classes.
 - [x] Baseline stages separately report routing, first token, tool execution, STT, first audio, completion, and total latency where applicable.
@@ -2663,15 +2664,15 @@ python scripts/rexbench.py --profile baseline --iterations 20 --output docs/perf
 **Implementation notes:** Keep validation conservative and deterministic. Detect clear bad-output patterns such as extreme repetition, non-language token floods, impossible length spikes, or provider error text routed as answer text. Do not censor normal long answers.
 
 **Acceptance Criteria:**
-- [ ] Obvious incoherent output is converted into a clear provider/model failure response.
-- [ ] Logs include provider, model, route, output length, and failure reason without logging secrets.
-- [ ] Text and voice paths both use the fail-safe.
-- [ ] The UI distinguishes model failure from normal answer refusal.
-- [ ] Tests use mocked bad output and verify no gibberish is returned to the user.
+- [x] Obvious incoherent output is converted into a clear provider/model failure response.
+- [x] Logs include provider, model, route, output length, and failure reason without logging secrets.
+- [x] Text and voice paths both use the fail-safe.
+- [x] The UI distinguishes model failure from normal answer refusal.
+- [x] Tests use mocked bad output and verify no gibberish is returned to the user.
 - [ ] All relevant GitHub checks pass.
 
-- [ ] Output validation runs on the canonical turn-completion path so streaming and non-streaming turns enforce identical safety/coherence rules.
-- [ ] Any response produced after model escalation is independently validated before it can become the terminal user response.
+- [x] Output validation runs on the canonical turn-completion path so streaming and non-streaming turns enforce identical safety/coherence rules.
+- [x] Any response produced after model escalation is independently validated before it can become the terminal user response.
 
 **Validation commands:**
 ```bash
@@ -3787,6 +3788,31 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 **Validation commands:** `pytest tests/rex2/test_forge_promotion.py tests/rex2/test_forge_rollback.py -q`.
 
 **Risk notes:** Approval is a grant to a specific package digest, not blanket trust in Forge.
+
+### US-119: Require absolute venv Python paths for Windows service registration
+
+**Priority:** P0 | **Workstream:** Windows / Installer / Service Reliability | **Dependencies:** Must complete before US-118.
+
+**Description:** Audit every Windows installer, service-registration path, and service startup wrapper so persisted Windows services always reference a fully qualified venv Python executable instead of a current-directory-relative path.
+
+**Why it matters:** A Windows audit found a RexSpeak service configured with a relative venv Python path. The local machine was repaired manually, but repo automation must not be able to recreate the defect after reinstall, upgrade, service re-registration, or deployment from a different working directory.
+
+**Files/areas likely involved:** `Start-RexSpeak.ps1`, `install.ps1`, `node_installers/install_windows.ps1`, `rex/windows_service.py`, any additional `New-Service` / `sc.exe create` / pywin32 `HandleCommandLine` / service ImagePath writers discovered by repo-wide audit, and their tests/docs.
+
+**Acceptance Criteria:**
+- [ ] Repo-wide audit identifies every Windows service installer, registration script, and service startup wrapper that can influence the executable path persisted for Rex/AskRex/RexSpeak services.
+- [ ] Every persisted service executable/ImagePath uses a normalized absolute path to the intended venv Python executable; no service registration may persist `.\\.venv\\Scripts\\python.exe`, `venv\\Scripts\\python.exe`, or any other cwd-relative Python path.
+- [ ] `Start-RexSpeak.ps1` and equivalent Windows launch wrappers resolve paths from `$PSScriptRoot` or another canonical absolute repo/install root rather than the caller's current working directory.
+- [ ] Installers normalize user-supplied roots (including relative `$RexRoot` values) to absolute paths before constructing venv/service paths and fail closed if the resolved Python executable does not exist.
+- [ ] Service command construction correctly quotes absolute paths containing spaces and preserves arguments without changing service behavior.
+- [ ] Regression tests cover an install root containing spaces, a relative input root, and service registration invoked from a working directory different from the repo/install directory.
+- [ ] Windows service tests verify the exact executable path that would be persisted/registered is absolute and points to the expected venv interpreter.
+- [ ] Relevant installer/service documentation and `CLAUDE.md` are updated if commands, scripts, or service-registration behavior changes.
+- [ ] All relevant GitHub checks pass.
+
+**Validation commands:** `pytest tests/test_windows_service.py tests/test_install_scripts.py -q`; run the Windows installer/service dry-run tests from a non-repo working directory and assert the emitted service Python path is absolute; repo-wide search confirms no Windows service-registration path persists a relative venv interpreter.
+
+**Risk notes:** The already-repaired local Windows service is not evidence that repo automation is safe. The repository must prevent reintroduction on reinstall, upgrade, or another machine.
 
 ### US-118: Run final RexBench production-readiness gate
 

--- a/bridge/rex_chat_stream_bridge.py
+++ b/bridge/rex_chat_stream_bridge.py
@@ -3,6 +3,7 @@
 Reads JSON from stdin:  {"message": "<text>"}
 Writes NDJSON to stdout, one JSON object per line:
   {"type": "token", "token": "<text>"}   – a chunk of the LLM response
+  {"type": "status", "status": "<kind>"} – non-terminal response status
   {"type": "done"}                        – stream complete (last line)
   {"type": "error", "error": "<text>"}   – error; process exits 1
 
@@ -51,6 +52,7 @@ def main() -> None:
         from rex.identity import validate_user_id  # type: ignore[import]
         from rex.logging_utils import configure_logging  # type: ignore[import]
         from rex.plugins import load_plugins, shutdown_plugins  # type: ignore[import]
+        from rex.runtime.events import EventKind  # type: ignore[import]
         from rex.runtime.invocation import turn_invocation  # type: ignore[import]
         from rex.runtime.turn import TurnSource  # type: ignore[import]
         from rex.services import initialize_services  # type: ignore[import]
@@ -65,6 +67,16 @@ def main() -> None:
             plugins=plugin_specs,
             user_id=validate_user_id(user_id),
         )
+
+        def observe_turn(event) -> None:  # noqa: ANN001
+            if (
+                event.kind is EventKind.RESPONSE_PROGRESS
+                and event.details.get("stage") == "output_validation"
+                and event.details.get("status") == "model_failure"
+            ):
+                emit({"type": "status", "status": "model_failure"})
+
+        assistant._turn_event_observer = observe_turn
         try:
             # Electron owns transport and provenance only; Assistant owns the brain.
             with turn_invocation(TurnSource.ELECTRON):

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -1886,3 +1886,27 @@ Local US-108 evidence:
 - Final action-graph/lifecycle/turn-cancellation/tool-execution/dispatcher/RexBench compatibility matrix -> 72 passed.
 - Black and Ruff pass on all touched runtime/test/benchmark files; mypy passes for the action graph/executor; compileall, full pre-commit/detect-secrets, and `git diff --check` pass.
 - US-108 final GitHub-check criterion remains open until its own immutable PR head passes the complete repository matrix.
+
+
+2026-08-13 - US-075 final GitHub evidence and US-076 incoherent-output fail-safe
+
+Remote US-075 evidence:
+- PR #374 passed all 18 relevant repository checks before merge: CodeFactor, GitGuardian, Python 3.11 Tests & Coverage, installed Windows Electron artifact, Ruff/Black, mypy, GUI lint/typecheck/build/Vitest, dependency audits, security audit, hardcoded-secret scan, pre-commit, wheel contents, raw-API guard, and commitlint.
+- US-075's previously stale final GitHub-check criterion is therefore closed in this US-076 tracking update.
+
+US-076 implementation:
+- Added conservative terminal model-output validation for empty/silence responses, known provider-error answer text, extreme length, and unmistakable repetition/symbol floods.
+- Validation is scoped by `ActionResult.model_generated`; deterministic skill/tool/HA responses are not reclassified. Model responses, including tool-result re-prompts/post-processing, remain model-backed through the terminal validation boundary.
+- The shared Assistant/TurnEngine completion path validates before ResponseBuilder/cache, history, streamed sentence delivery, and voice/TTS delivery. Invalid output is replaced with a fixed safe failure and the turn ends in the canonical `FAILED` terminal state with `failure_kind=model_failure`.
+- Failure diagnostics log provider, model, route, output length, and bounded reason only; prompt/transcript/output content and credentials are not logged.
+- Electron bridge/main/preload/ChatPage propagate a typed `model_failure` status separately from transport errors; MessageList visibly labels model failure while normal refusals remain ordinary Rex messages.
+- Codex independent review found no blocker/high-severity issue. Its two medium findings were fixed by making repetition tokenization Unicode-aware and raising repetition/symbol thresholds so bounded repeated test data, separators, and emoji are not falsely rejected. Its low test-coverage finding was addressed with real ActionDispatcher provenance/re-prompt tests plus status-channel and listener-cleanup coverage.
+
+Local US-076 evidence:
+- TDD red phase reproduced raw repetition reaching users and missing Electron model-failure status before implementation; reviewer-follow-up red tests reproduced bounded-output false positives and Unicode repetition bypass before the threshold/tokenizer fixes.
+- `pytest tests/rex2/test_model_output_validation.py tests/rex2/test_generate_reply_turn_engine.py tests/rex2/test_stream_turn_parity.py tests/test_llm_client.py tests/test_assistant.py -q` -> 105 passed, with two pre-existing root-shim deprecation warnings only.
+- Full GUI Vitest suite -> 118 passed; targeted model-failure/preload regression -> 7 passed; `npm run typecheck` and `npm run build` pass.
+- Ruff, Black, and mypy pass on all touched Python runtime/test files; `git diff --check` is clean at the reviewed implementation stage.
+- US-076 GitHub checks remain pending until this story PR is published; its final PRD checkbox intentionally remains open.
+- Codex focused follow-up review found only one remaining test-strength issue: listener cleanup needed to prove removal of the exact registered callback. The assertion was tightened accordingly and the targeted GUI regression/typecheck rerun passed.
+- Full local CI-marker compatibility sweep (`pytest -m "not slow and not audio and not gpu" -q`) -> 8,675 passed, 48 skipped, 315 warnings, 0 failed; pytest exited 0. Post-pytest Torch shutdown logging attempted to write to a closed capture stream, but did not change the successful process exit.

--- a/gui/src/components/chat/MessageList.modelFailure.test.tsx
+++ b/gui/src/components/chat/MessageList.modelFailure.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { MessageList } from './MessageList'
+
+
+describe('chat model failure status', () => {
+  it('labels a model failure separately from a normal assistant refusal', () => {
+    const failed = renderToStaticMarkup(
+      React.createElement(MessageList, {
+        messages: [
+          {
+            id: 'failed',
+            role: 'rex',
+            content: "I couldn't produce a reliable response from the selected model. Please try again.",
+            timestamp: new Date(0),
+            status: 'model_failure',
+          },
+        ],
+      })
+    )
+    const refused = renderToStaticMarkup(
+      React.createElement(MessageList, {
+        messages: [
+          {
+            id: 'refused',
+            role: 'rex',
+            content: "I can't help with that request.",
+            timestamp: new Date(0),
+          },
+        ],
+      })
+    )
+    expect(failed).toContain('Model failure')
+    expect(failed).toContain('role="status"')
+    expect(refused).not.toContain('Model failure')
+  })
+})

--- a/gui/src/components/chat/MessageList.tsx
+++ b/gui/src/components/chat/MessageList.tsx
@@ -12,6 +12,7 @@ export interface Message {
   content: string
   timestamp: Date
   streaming?: boolean
+  status?: 'model_failure'
   attachments?: MessageAttachment[]
 }
 
@@ -175,6 +176,14 @@ export const MessageList: React.FC<MessageListProps> = ({ messages }) => {
             )}
             {msg.role === 'rex' ? (
               <>
+                {msg.status === 'model_failure' && (
+                  <div
+                    role="status"
+                    className="mb-1 text-xs font-medium text-danger"
+                  >
+                    Model failure
+                  </div>
+                )}
                 {msg.streaming && msg.content.trim() === '' ? (
                   <span role="status" aria-live="polite" className="inline-flex items-center gap-1 text-text-secondary">
                     Rex is thinking

--- a/gui/src/main/handlers/chat.ts
+++ b/gui/src/main/handlers/chat.ts
@@ -211,6 +211,12 @@ export function registerChatHandlers(session: ElectronSessionIdentity): void {
       }
     }
 
+    function sendStatus(status: string): void {
+      if (!event.sender.isDestroyed()) {
+        event.sender.send('rex:chatStatus', { streamId, status })
+      }
+    }
+
     function sendDone(): void {
       if (!sentFinal) {
         sentFinal = true
@@ -244,10 +250,13 @@ export function registerChatHandlers(session: ElectronSessionIdentity): void {
           const obj = JSON.parse(trimmed) as {
             type: string
             token?: string
+            status?: string
             error?: string
           }
           if (obj.type === 'token' && obj.token !== undefined) {
             sendToken(obj.token)
+          } else if (obj.type === 'status' && obj.status !== undefined) {
+            sendStatus(obj.status)
           } else if (obj.type === 'done') {
             sendDone()
           } else if (obj.type === 'error') {
@@ -267,9 +276,11 @@ export function registerChatHandlers(session: ElectronSessionIdentity): void {
           const obj = JSON.parse(lineBuffer.trim()) as {
             type: string
             token?: string
+            status?: string
             error?: string
           }
           if (obj.type === 'token' && obj.token !== undefined) sendToken(obj.token)
+          else if (obj.type === 'status' && obj.status !== undefined) sendStatus(obj.status)
           else if (obj.type === 'done') sendDone()
           else if (obj.type === 'error') sendError(obj.error ?? 'Streaming error')
         } catch {

--- a/gui/src/pages/ChatPage.tsx
+++ b/gui/src/pages/ChatPage.tsx
@@ -99,18 +99,31 @@ export function ChatPage(): React.ReactElement {
       try {
         let receivedToken = false
         let replyText = ''
-        await window.rex.sendChatStream(augmentedText, (token) => {
-          replyText += token
-          const safeReplyText = sanitizeAssistantText(replyText)
-          setMessages((prev) =>
-            prev.map((m) =>
-              m.id === rexMsgId
-                ? { ...m, content: safeReplyText }
-                : m
+        await window.rex.sendChatStream(
+          augmentedText,
+          (token) => {
+            replyText += token
+            const safeReplyText = sanitizeAssistantText(replyText)
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === rexMsgId
+                  ? { ...m, content: safeReplyText }
+                  : m
+              )
             )
-          )
-          receivedToken = true
-        })
+            receivedToken = true
+          },
+          undefined,
+          (status) => {
+            if (status === 'model_failure') {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === rexMsgId ? { ...m, status: 'model_failure' } : m
+                )
+              )
+            }
+          }
+        )
         // Finalize: remove streaming cursor
         setMessages((prev) =>
           prev.map((m) =>

--- a/gui/src/preload/index.ts
+++ b/gui/src/preload/index.ts
@@ -44,6 +44,7 @@ import type {
   SetupCompleteResponse,
   IntegrationConnectionStatus,
   ChatStreamCancelHandle,
+  ChatStreamStatus,
   VoiceStartOptions,
   PairingResponse,
   ProfileOperationResponse
@@ -52,13 +53,20 @@ import type {
 function makeSendChatStream(
   message: string,
   onToken: (token: string) => void,
-  cancel?: ChatStreamCancelHandle
+  cancel?: ChatStreamCancelHandle,
+  onStatus?: (status: ChatStreamStatus) => void
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const streamId = `${Date.now()}-${Math.random()}`
 
     function tokenHandler(_e: unknown, data: { streamId: string; token: string }): void {
       if (data.streamId === streamId) onToken(data.token)
+    }
+    function statusHandler(
+      _e: unknown,
+      data: { streamId: string; status: ChatStreamStatus }
+    ): void {
+      if (data.streamId === streamId) onStatus?.(data.status)
     }
     function doneHandler(_e: unknown, data: { streamId: string }): void {
       if (data.streamId === streamId) {
@@ -75,6 +83,7 @@ function makeSendChatStream(
 
     function cleanup(): void {
       ipcRenderer.removeListener('rex:chatToken', tokenHandler)
+      ipcRenderer.removeListener('rex:chatStatus', statusHandler)
       ipcRenderer.removeListener('rex:chatDone', doneHandler)
       ipcRenderer.removeListener('rex:chatError', errorHandler)
       if (typeof cancel?.offAbort === 'function') cancel.offAbort(abortHandler)
@@ -87,6 +96,7 @@ function makeSendChatStream(
     }
 
     ipcRenderer.on('rex:chatToken', tokenHandler)
+    ipcRenderer.on('rex:chatStatus', statusHandler)
     ipcRenderer.on('rex:chatDone', doneHandler)
     ipcRenderer.on('rex:chatError', errorHandler)
     // Defensive: a malformed cancel handle (e.g. a raw AbortSignal-shaped

--- a/gui/src/types/ipc.ts
+++ b/gui/src/types/ipc.ts
@@ -664,12 +664,15 @@ export interface ChatStreamCancelHandle {
   offAbort: (cb: () => void) => void
 }
 
+export type ChatStreamStatus = 'model_failure'
+
 export interface RexAPI {
   sendChat: (message: string) => Promise<string>
   sendChatStream: (
     message: string,
     onToken: (token: string) => void,
-    cancel?: ChatStreamCancelHandle
+    cancel?: ChatStreamCancelHandle,
+    onStatus?: (status: ChatStreamStatus) => void
   ) => Promise<void>
   getStatus: () => Promise<StatusResponse>
   onStatusChange: (cb: (status: string) => void) => (() => void)

--- a/gui/tests/holdToTalk.test.ts
+++ b/gui/tests/holdToTalk.test.ts
@@ -28,6 +28,10 @@ describe('Hold-to-Talk production path', () => {
     const preload = readFileSync(join(__dirname, '../src/preload/index.ts'), 'utf8')
     expect(chatHandler).toContain("ipcMain.handle('rex:cancelChatStream'")
     expect(preload).toContain("ipcRenderer.invoke('rex:cancelChatStream'")
+    expect(chatHandler).toContain("obj.type === 'status'")
+    expect(chatHandler).toContain("'rex:chatStatus'")
+    const chatPage = readFileSync(join(__dirname, '../src/pages/ChatPage.tsx'), 'utf8')
+    expect(chatPage).toContain("status: 'model_failure'")
   })
 })
 
@@ -48,7 +52,8 @@ type ExposedRexAPI = {
   sendChatStream: (
     message: string,
     onToken: (token: string) => void,
-    cancel?: unknown
+    cancel?: unknown,
+    onStatus?: (status: string) => void
   ) => Promise<void>
 }
 
@@ -103,6 +108,29 @@ describe('sendChatStream cancel handle (contextBridge-safe)', () => {
     await expect(
       sendChatStream('hello', () => {}, buildCancelHandle(controller))
     ).resolves.toBeUndefined()
+  })
+
+  it('forwards model failure status without turning it into a transport error', async () => {
+    await import('../src/preload/index')
+    const { sendChatStream } = exposed.rex as ExposedRexAPI
+    const statuses: string[] = []
+    invoke.mockImplementation((channel: string, payload?: { streamId: string }) => {
+      if (channel === 'rex:startChatStream' && payload) {
+        queueMicrotask(() => {
+          listeners['rex:chatStatus']?.(null, { streamId: payload.streamId, status: 'model_failure' })
+          listeners['rex:chatDone']?.(null, { streamId: payload.streamId })
+        })
+      }
+      return Promise.resolve()
+    })
+
+    const promise = sendChatStream('hello', () => {}, undefined, (status) => statuses.push(status))
+    const statusHandler = listeners['rex:chatStatus']
+    expect(statusHandler).toEqual(expect.any(Function))
+    await promise
+
+    expect(statuses).toEqual(['model_failure'])
+    expect(removeListener).toHaveBeenCalledWith('rex:chatStatus', statusHandler)
   })
 
   it('does not throw when the cancel argument has lost its methods crossing the bridge (regression for the original crash)', async () => {

--- a/gui/vitest.config.ts
+++ b/gui/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'src/**/*.test.tsx'],
   },
 })

--- a/rex/actions/dispatcher.py
+++ b/rex/actions/dispatcher.py
@@ -40,6 +40,7 @@ class ActionResult:
     response: str
     actions_taken: list[str] = field(default_factory=list)
     error: str | None = None
+    model_generated: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -342,6 +343,7 @@ class ActionDispatcher:
                 )
 
         completion: str | None = None
+        model_generated = False
 
         # 7. HA command routing (including undo and proactive suggestion injection)
         if (
@@ -402,6 +404,7 @@ class ActionDispatcher:
 
         # 8. LLM call (if no pre-LLM handler produced a completion)
         if completion is None:
+            model_generated = True
             # Rebuild context with tool_context if auto-dispatch populated it.
             if _tool_context:
                 ctx = self._context_builder.build(
@@ -479,4 +482,5 @@ class ActionDispatcher:
             success=True,
             response=completion,
             actions_taken=["llm"] if not completion else ["dispatch"],
+            model_generated=model_generated,
         )

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
-from .actions.dispatcher import _UNDO_PATTERN
+from .actions.dispatcher import _UNDO_PATTERN, ActionResult
 from .assistant_errors import IdentityRequiredError
 from .calendar_service import get_calendar_service
 from .config import Settings, settings
@@ -693,6 +693,52 @@ class Assistant:
         finally:
             latency_trace.end("tool")
 
+    def _validate_model_response(
+        self,
+        result: ActionResult,
+        *,
+        turn_events: TurnEventStream,
+        route: str,
+    ) -> str | None:
+        """Return a failure reason when a model-backed response is clearly invalid."""
+        if not result.model_generated:
+            return None
+
+        from rex.response.validation import (  # noqa: PLC0415
+            MODEL_FAILURE_MESSAGE,
+            validate_model_output,
+        )
+
+        response = result.response
+        validation = validate_model_output(response)
+        if validation.valid:
+            turn_events.emit(
+                EventKind.RESPONSE_PROGRESS,
+                {"stage": "output_validation", "status": "passed"},
+            )
+            return None
+
+        provider, model = self._latency_provider_model()
+        reason = validation.reason or "invalid_output"
+        logger.warning(
+            "model_output_validation_failed provider=%s model=%s route=%s output_length=%d reason=%s",
+            provider,
+            model,
+            route,
+            len(response),
+            reason,
+        )
+        result.response = MODEL_FAILURE_MESSAGE
+        turn_events.emit(
+            EventKind.RESPONSE_PROGRESS,
+            {
+                "stage": "output_validation",
+                "status": "model_failure",
+                "reason": reason,
+            },
+        )
+        return reason
+
     async def _deliver_safe_response(
         self,
         text: str,
@@ -905,6 +951,7 @@ class Assistant:
             EventKind.ROUTE_PROGRESS,
             {"stage": "model_router", "model": latency_trace.model},
         )
+        model_failure_reason: str | None = None
         try:
             check_cancelled()
             context = self._get_or_create_context_builder().build(
@@ -927,16 +974,24 @@ class Assistant:
                 turn_events=turn_events,
             )
             check_cancelled()
+            model_failure_reason = self._validate_model_response(
+                result,
+                turn_events=turn_events,
+                route=intent.intent_type or "action_dispatch",
+            )
             latency_trace.start("completion")
-            final = self._get_or_create_response_builder().build(
-                result, context, transcript=transcript, user_id=effective_user_id
-            )
-            check_cancelled()
-            completion = final.text
-            turn_events.emit(
-                EventKind.RESPONSE_PROGRESS,
-                {"stage": "response_builder", "status": "completed"},
-            )
+            if model_failure_reason is None:
+                final = self._get_or_create_response_builder().build(
+                    result, context, transcript=transcript, user_id=effective_user_id
+                )
+                check_cancelled()
+                completion = final.text
+                turn_events.emit(
+                    EventKind.RESPONSE_PROGRESS,
+                    {"stage": "response_builder", "status": "completed"},
+                )
+            else:
+                completion = str(result.response)
         except Exception:
             latency_trace.finish()
             latency_trace.log_summary(logger, event=latency_event)
@@ -958,10 +1013,18 @@ class Assistant:
             latency_trace=latency_trace,
             stream_started_ns=stream_started_ns,
         )
+        if model_failure_reason is not None:
+            turn_events.finish(
+                EventKind.FAILED,
+                {
+                    "failure_kind": "model_failure",
+                    "reason": model_failure_reason,
+                },
+            )
         latency_trace.end("completion")
         latency_trace.finish()
         latency_trace.log_summary(logger, event=latency_event)
-        return cast(str, completion)
+        return completion
 
     async def generate_reply(
         self,

--- a/rex/response/validation.py
+++ b/rex/response/validation.py
@@ -1,0 +1,74 @@
+"""Conservative validation for terminal assistant output."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+
+MODEL_FAILURE_MESSAGE = (
+    "I couldn't produce a reliable response from the selected model. " "Please try again."
+)
+_MAX_OUTPUT_CHARS = 120_000
+_TOKEN_RE = re.compile(r"[\w'-]+", re.UNICODE)
+_REPEAT_TOKEN_MIN_COUNT = 200
+_REPEAT_TOKEN_DOMINANCE = 0.85
+_REPEAT_LINE_MIN_COUNT = 20
+_REPEAT_LINE_DOMINANCE = 0.85
+_PROVIDER_ERROR_PATTERNS = (
+    re.compile(
+        r'^\s*error\s+code\s*:\s*(?:4\d\d|5\d\d)\b.*["\']error["\']\s*:',
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(
+        r"^\s*(?:openai|anthropic|ollama|provider|upstream)\s+(?:api\s+)?error\s*:",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*\[Ollama:\s+(?:connection failed\b|model\b.+\bnot found\b|unexpected error:).+\]\s*$",
+        re.IGNORECASE | re.DOTALL,
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OutputValidation:
+    valid: bool
+    reason: str | None = None
+
+
+def validate_model_output(text: str) -> OutputValidation:
+    """Reject only unmistakable provider/model failure shapes."""
+    stripped = text.strip()
+    if not stripped:
+        return OutputValidation(False, "empty_output")
+    if stripped.casefold() == "(silence)":
+        return OutputValidation(False, "empty_model_content")
+    if len(text) > _MAX_OUTPUT_CHARS:
+        return OutputValidation(False, "output_length_spike")
+    if any(pattern.search(text) for pattern in _PROVIDER_ERROR_PATTERNS):
+        return OutputValidation(False, "provider_error_payload")
+    if re.search(r"(.)\1{511,}", text, re.DOTALL):
+        return OutputValidation(False, "repeated_character_flood")
+
+    if len(text) >= 2_000:
+        alnum_ratio = sum(char.isalnum() for char in text) / len(text)
+        if alnum_ratio < 0.05:
+            return OutputValidation(False, "non_language_symbol_flood")
+
+    tokens = [token.casefold() for token in _TOKEN_RE.findall(text)]
+    if len(tokens) >= _REPEAT_TOKEN_MIN_COUNT:
+        _token, count = Counter(tokens).most_common(1)[0]
+        if count / len(tokens) >= _REPEAT_TOKEN_DOMINANCE:
+            return OutputValidation(False, "repeated_token_flood")
+
+    lines = [line.strip().casefold() for line in text.splitlines() if line.strip()]
+    if len(lines) >= _REPEAT_LINE_MIN_COUNT:
+        _line, count = Counter(lines).most_common(1)[0]
+        if count >= 18 and count / len(lines) >= _REPEAT_LINE_DOMINANCE:
+            return OutputValidation(False, "repeated_line_flood")
+
+    return OutputValidation(True)
+
+
+__all__ = ["MODEL_FAILURE_MESSAGE", "OutputValidation", "validate_model_output"]

--- a/tests/rex2/test_model_output_validation.py
+++ b/tests/rex2/test_model_output_validation.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rex.actions.dispatcher import ActionResult
+from rex.assistant import Assistant
+from rex.intent.router import IntentResult
+from rex.response.builder import FinalResponse
+from rex.runtime.events import EventKind
+
+SAFE_FAILURE = (
+    "I couldn't produce a reliable response from the selected model. " "Please try again."
+)
+
+
+def _assistant() -> Assistant:
+    assistant = Assistant.__new__(Assistant)
+    assistant._settings = SimpleNamespace(
+        max_memory_items=50,
+        persist_history=False,
+        followups_enabled=False,
+        model_routing=None,
+        transcripts_enabled=False,
+        llm_provider="test-provider",
+        llm_model="test-model",
+        llm=None,
+    )
+    assistant._user_id = "james"
+    assistant._histories = {}
+    assistant._history_limit = 50
+    assistant._plugins = []
+    assistant._history_store = None
+    assistant._followup_engine = None
+    assistant._followup_sessions = set()
+    assistant._followup_bootstrap_pending = False
+    assistant._pending_followups = {}
+    assistant._response_cache = None
+    assistant._ha_bridge = None
+    assistant._suggestion_engine = None
+    assistant._pattern_entries = {}
+    assistant._router = None
+    assistant._llm = MagicMock()
+    assistant._llm.model_name = "test-model"
+    assistant._context_builder = MagicMock()
+    assistant._context_builder.build.return_value = SimpleNamespace(
+        messages=[], prompt="prompt", system_prompt="system"
+    )
+    assistant._response_builder = MagicMock()
+    assistant._response_builder.check_cache.return_value = None
+    assistant._response_builder.build.side_effect = lambda result, _ctx, **_kwargs: FinalResponse(
+        text=result.response,
+        tts_text=result.response,
+    )
+    assistant._turn_events = []
+    assistant._turn_event_observer = assistant._turn_events.append
+    assistant._log_turn = MagicMock()
+    intent_router = MagicMock()
+    intent_router.route.return_value = IntentResult(handled=False, response=None, intent_type=None)
+    assistant._intent_router = intent_router
+    return assistant
+
+
+def _set_dispatch_response(assistant: Assistant, response: str) -> None:
+    async def dispatch(*_args, turn_events=None, **_kwargs):
+        if turn_events is not None:
+            turn_events.emit(
+                EventKind.MODEL_PROGRESS,
+                {"stage": "generation", "status": "returned"},
+            )
+        return ActionResult(
+            success=True,
+            response=response,
+            actions_taken=["llm"],
+            model_generated=True,
+        )
+
+    assistant._action_dispatcher = MagicMock()
+    assistant._action_dispatcher.dispatch = dispatch
+
+
+async def _collect(assistant: Assistant, text: str, *, voice_mode: bool = False) -> list[str]:
+    return [
+        chunk
+        async for chunk in assistant.stream_reply(
+            text,
+            voice_mode=voice_mode,
+        )
+    ]
+
+
+def _repetition_flood() -> str:
+    return " ".join(["broken-loop"] * 240)
+
+
+def test_generate_reply_replaces_obvious_repetition_with_model_failure() -> None:
+    assistant = _assistant()
+    bad_output = _repetition_flood()
+    _set_dispatch_response(assistant, bad_output)
+
+    reply = asyncio.run(assistant.generate_reply("explain this"))
+
+    assert reply == SAFE_FAILURE
+    assert bad_output not in reply
+    assistant._response_builder.build.assert_not_called()
+    assert assistant._turn_events[-1].kind is EventKind.FAILED
+    assert assistant._turn_events[-1].details.get("failure_kind") == "model_failure"
+
+
+def test_stream_and_voice_use_same_model_failure_guard() -> None:
+    assistant = _assistant()
+    _set_dispatch_response(assistant, _repetition_flood())
+
+    text_chunks = asyncio.run(_collect(assistant, "stream request"))
+    assistant._turn_events.clear()
+    voice_chunks = asyncio.run(_collect(assistant, "voice request", voice_mode=True))
+
+    assert " ".join(text_chunks) == SAFE_FAILURE
+    assert " ".join(voice_chunks) == SAFE_FAILURE
+    assert assistant._turn_events[-1].kind is EventKind.FAILED
+
+
+def test_model_failure_log_is_diagnostic_without_response_content(caplog) -> None:
+    assistant = _assistant()
+    bad_output = _repetition_flood()
+    _set_dispatch_response(assistant, bad_output)
+
+    with caplog.at_level(logging.WARNING, logger="rex.assistant"):
+        reply = asyncio.run(assistant.generate_reply("diagnose"))
+
+    assert reply == SAFE_FAILURE
+    assert "provider=test-provider" in caplog.text
+    assert "model=test-model" in caplog.text
+    assert "route=action_dispatch" in caplog.text
+    assert f"output_length={len(bad_output)}" in caplog.text
+    assert "reason=repeated_token_flood" in caplog.text
+    assert bad_output not in caplog.text
+
+
+def test_routed_model_output_is_validated_before_terminal_response(caplog) -> None:
+    assistant = _assistant()
+    assistant._llm.model_name = "fast-model"
+    router = MagicMock()
+    router.classify.return_value = "complex"
+    router.resolve_model.return_value = "deep-model"
+    assistant._router = router
+    _set_dispatch_response(assistant, _repetition_flood())
+
+    with caplog.at_level(logging.WARNING, logger="rex.assistant"):
+        reply = asyncio.run(assistant.generate_reply("complex request"))
+
+    assert reply == SAFE_FAILURE
+    assert "model=deep-model" in caplog.text
+    assert assistant._llm.model_name == "fast-model"
+    assert assistant._turn_events[-1].kind is EventKind.FAILED
+
+
+def test_normal_answer_and_refusal_are_not_reclassified() -> None:
+    assistant = _assistant()
+    normal = "I can't help with that request, but I can explain the underlying concept."
+    _set_dispatch_response(assistant, normal)
+
+    reply = asyncio.run(assistant.generate_reply("normal request"))
+
+    assert reply == normal
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+
+
+@pytest.mark.parametrize(
+    "bad_output",
+    [
+        'Error code: 429 - {"error": {"message": "rate limit exceeded"}}',
+        "[Ollama: connection failed — is Ollama running?]",
+        "[Ollama: model 'qwen' not found — run: ollama pull qwen]",
+        "[Ollama: unexpected error: provider exploded]",
+        "(silence)",
+        "!@#$%^&*()_+{}[]<>?/|\\" * 120,
+    ],
+)
+def test_other_obvious_provider_failure_shapes_are_replaced(bad_output: str) -> None:
+    assistant = _assistant()
+    _set_dispatch_response(assistant, bad_output)
+
+    reply = asyncio.run(assistant.generate_reply("provider request"))
+
+    assert reply == SAFE_FAILURE
+    assert bad_output not in reply
+    assert assistant._turn_events[-1].kind is EventKind.FAILED
+
+
+def test_legitimate_json_error_example_is_not_reclassified() -> None:
+    assistant = _assistant()
+    example = '{"error":"invalid input","code":400}'
+    _set_dispatch_response(assistant, example)
+
+    reply = asyncio.run(assistant.generate_reply("show me a JSON error example"))
+
+    assert reply == example
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+
+
+def test_bounded_repetition_and_symbolic_output_are_not_reclassified() -> None:
+    from rex.response.validation import validate_model_output
+
+    examples = [
+        "-" * 200,
+        " ".join(["test"] * 100),
+        "😀" * 400,
+        "separator\n" * 10,
+    ]
+
+    assert all(validate_model_output(example).valid for example in examples)
+
+
+def test_unicode_repetition_flood_is_rejected() -> None:
+    from rex.response.validation import validate_model_output
+
+    result = validate_model_output(" ".join(["сломано"] * 240))
+
+    assert result.valid is False
+    assert result.reason == "repeated_token_flood"
+
+
+def test_real_dispatcher_marks_deterministic_skill_response_as_non_model() -> None:
+    from rex.actions.dispatcher import ActionDispatcher
+
+    assistant = _assistant()
+    trainer = MagicMock()
+    trainer.handle_if_training_request.return_value = _repetition_flood()
+    dispatcher = ActionDispatcher(
+        context_builder=assistant._context_builder,
+        llm=assistant._llm,
+        result_handler=MagicMock(),
+        skill_trainer=trainer,
+        skill_registry=MagicMock(),
+    )
+    assistant._action_dispatcher = dispatcher
+
+    reply = asyncio.run(assistant.generate_reply("teach a deterministic skill"))
+
+    assert reply == _repetition_flood()
+    assert assistant._turn_events[-1].kind is EventKind.COMPLETED
+    assistant._llm.generate.assert_not_called()
+
+
+def test_real_dispatcher_validates_model_tool_reprompt_before_terminal_response() -> None:
+    from rex.actions.dispatcher import ActionDispatcher
+
+    assistant = _assistant()
+    assistant._context_builder.build_system_context.return_value = "system"
+    assistant._llm.generate.side_effect = ["tool-request", _repetition_flood()]
+
+    class RePromptingResultHandler:
+        async def process(
+            self,
+            _transcript,
+            _completion,
+            *,
+            tool_context,
+            model_call_fn,
+            plugin_enrichments,
+        ):
+            del tool_context, plugin_enrichments
+            return model_call_fn({"role": "tool", "content": "verified tool result"})
+
+    assistant._action_dispatcher = ActionDispatcher(
+        context_builder=assistant._context_builder,
+        llm=assistant._llm,
+        result_handler=RePromptingResultHandler(),
+        model_call_fn_builder=assistant._build_tool_model_call,
+    )
+
+    reply = asyncio.run(assistant.generate_reply("use a tool and summarize it"))
+
+    assert reply == SAFE_FAILURE
+    assert assistant._llm.generate.call_count == 2
+    assert assistant._response_builder.build.call_count == 0
+    assert assistant._turn_events[-1].kind is EventKind.FAILED
+    assert assistant._turn_events[-1].details.get("failure_kind") == "model_failure"


### PR DESCRIPTION
## Summary
- add conservative terminal validation for unmistakable incoherent/provider-error model output
- enforce validation on the canonical Assistant/TurnEngine completion path before ResponseBuilder/cache, history, streaming, or voice/TTS delivery
- preserve deterministic action responses via explicit ActionResult.model_generated provenance, including validation of tool-result model re-prompts
- surface a typed model_failure status through the Electron bridge/main/preload/ChatPage path and visibly distinguish it from a normal refusal
- close US-075's stale CI checkbox with verified PR #374 evidence and add the user-requested US-119 Windows service absolute-venv-path story before the final release gate

## Verification
- pytest primary CI-marker suite: 8,675 passed, 48 skipped, 0 failed
- focused Python regression matrix: 105 passed; final TurnEngine/model matrix: 36 passed
- full GUI Vitest suite: 118 passed
- targeted GUI model-failure/preload tests: 7 passed
- npm run typecheck: pass
- npm run build: pass
- Ruff, Black, mypy: pass on touched Python runtime/tests
- staged pre-commit Ruff/Black/detect-secrets: pass using isolated cache
- git diff --check: pass

## Independent review
Codex found no blocker/high-severity issue. Its two medium findings (bounded repetition false positives and ASCII-only repetition detection) were fixed with conservative thresholds and Unicode-aware tokenization. Its test-strength findings were addressed with real ActionDispatcher provenance/re-prompt coverage plus exact Electron status-listener cleanup verification.

## Tracking
US-076 remains intentionally unchecked only for All relevant GitHub checks pass until this exact PR head completes the repository CI matrix.
