### PR TITLE
feat(routing): add provider reliability evaluation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,7 +401,10 @@ ModelRouter 2.0 deterministic routing evidence:
 
 ```powershell
 python scripts/rexbench.py --profile model-routing --iterations 8 --output docs/performance/rexbench-model-routing.json
+python scripts/rexbench.py --profile routing-eval --iterations 8
 ```
+
+`routing-eval` is deterministic/local by default and reads the checked-in provider-fallback corpus. It must not contact live providers. A live provider probe is allowed only through the explicit `--live-provider-eval` opt-in and must remain labeled `live_provider`; CI must never require that flag or a paid provider. Provider reliability diagnostics may expose bounded provider IDs, health state, counters, latency, and cooldown only, never prompts, responses, user identity, exception text, or credentials. Provider candidates must be supplied explicitly in preference order; health tracking never discovers or silently enables a cloud/paid provider.
 
 `deterministic_mock` RexBench results never prove live provider, model, network, audio, or hardware latency is within budget. Use `docs/performance.md` and the final live RexBench release gate for production claims.
 

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -3646,12 +3646,12 @@ grep -n "askrex.app\|Cloudflare\|CORS\|rate limit\|revocation" docs/deployment.m
 **Files/areas likely involved:** provider health metrics, ModelRouter, RexBench eval fixtures/reports, diagnostics.
 
 **Acceptance Criteria:**
-- [ ] Provider reliability records bounded latency/failure/rate-limit/cooldown signals without prompt/response/private contents.
-- [ ] Routing respects outages/cooldowns and has deterministic fallback across configured providers.
-- [ ] A checked-in deterministic routing corpus measures selection correctness, fallback, and regression without live-provider dependence.
-- [ ] Live-provider evaluation is opt-in/labeled separately and cannot become a required paid CI dependency.
-- [ ] Diagnostics explain provider unavailability/fallback without exposing credentials.
-- [ ] All relevant GitHub checks pass.
+- [x] Provider reliability records bounded latency/failure/rate-limit/cooldown signals without prompt/response/private contents.
+- [x] Routing respects outages/cooldowns and has deterministic fallback across configured providers.
+- [x] A checked-in deterministic routing corpus measures selection correctness, fallback, and regression without live-provider dependence.
+- [x] Live-provider evaluation is opt-in/labeled separately and cannot become a required paid CI dependency.
+- [x] Diagnostics explain provider unavailability/fallback without exposing credentials.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:** `pytest tests/rex2/test_provider_reliability.py tests/rex2/test_routing_eval.py -q`; `python scripts/rexbench.py --profile routing-eval`.
 

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2009,3 +2009,25 @@ US-105 implementation evidence:
 - Local evidence: 103 cross-system tests passed; ModelRouter/RexBench focused set passed; Ruff and Black passed; mypy passed for the touched runtime modules.
 - `python scripts/rexbench.py --profile model-routing --iterations 8` passed with privacy-safe deterministic-local evidence.
 - Exact implementation head `51d927a70df7c05d82451f8c2a8cdd53817b8a7d` passed CI, Commitlint, Windows Electron Artifact, CodeFactor, pre-commit, hardcoded-secret scan, security audit, lint/format, mypy, GUI checks, and dependency scans on 2026-08-14; US-110 GitHub-check criterion is closed.
+
+
+2026-08-14 - US-111 provider reliability and routing evaluation closure
+
+Implementation and local evidence:
+- Added a bounded, content-free provider reliability ledger for latency, failures, rate limits, cooldowns, recovery state, and sanitized diagnostics. Prompts, responses, private user content, credentials, and exception messages are never retained by the ledger.
+- ModelRouter now respects provider-specific outage/cooldown evidence and deterministically falls back only across explicitly configured provider/model candidates; it never discovers or silently enables a cloud/paid provider.
+- Assistant generation and stream boundaries feed real success/failure timing into the ledger, including rate-limit and connection-failure classification, while preserving legacy TypeError signature compatibility as one provider attempt.
+- Added checked-in deterministic routing corpus `tests/fixtures/rexbench/routing-eval.json` and `rexbench --profile routing-eval`; four golden cases cover healthy primary, rate-limit fallback, provider-outage fallback, and all-providers-unavailable.
+- Live-provider evaluation remains explicit opt-in through `--live-provider-eval`, is labeled separately, and is not part of default/CI evaluation.
+- Focused US-111 suite: 14 passed. Broader routing/reliability/RexBench regression: 73 passed. Assistant/routing regression: 88 passed.
+- Full Windows primary marker suite: 8,778 passed / 49 skipped / 0 failed in 483.64s. Repository-integrity tests passed and the post-suite tree matched the pre-run US-111 diff.
+- Full Ruff and Black gates passed; changed runtime mypy passed with 0 errors; compileall, security release gate, `git diff --check`, and full pre-commit (Ruff/Black/detect-secrets) passed.
+- Deterministic RexBench routing-eval at 8 iterations passed 4/4 cases with selection_accuracy 1.0 and live_provider_eval=false.
+
+Remote exact-head evidence:
+- PR #397 implementation head `d98323952400796feb1767a99caa9866143913d7` passed all 18 registered checks before this documentation closure commit.
+- CI workflow run 31822925357 completed success, including Python 3.11 Tests & Coverage, skip-budget enforcement, integration tests, tracked-tree cleanliness, security audit, lint/format/type/GUI/dependency/pre-commit/wheel checks.
+- Commitlint workflow run 31822925363 completed success.
+- Windows Electron Artifact workflow run 31822925430 completed success, including managed runtime/installer build, signature truthfulness, packaged-resource rejection, and installed-artifact smoke without machine Python or Node.
+- CodeFactor reported no issues and GitGuardian reported no secrets detected. No failed/cancelled exact-head check conclusion and no PR review/review-thread blocker was present.
+- US-111 acceptance criteria are therefore closed. The docs-only closure head still must pass its own exact-head repository checks before PR #397 is merged.

--- a/docs/performance/provider-routing.md
+++ b/docs/performance/provider-routing.md
@@ -1,0 +1,46 @@
+# Provider reliability and routing evaluation
+
+US-111 adds a privacy-safe in-memory provider reliability ledger to ModelRouter 2.0.
+It records only bounded operational evidence: provider ID, latest bounded latency,
+success/failure counters, rate-limit count, consecutive failures, failure category,
+and remaining cooldown. It never accepts or stores prompts, responses, credentials,
+user identity, exception text, memory content, or tool results.
+
+Provider candidates are explicit and ordered. The router filters that supplied list
+by current health and selects the first available candidate. It does not discover,
+auto-configure, or silently enable a cloud or paid provider. Existing legacy
+`cloud_limit_hit()` behavior remains supported and feeds the same reliability ledger.
+
+## Deterministic evaluation
+
+Run the required offline evaluation with:
+
+```powershell
+python scripts/rexbench.py --profile routing-eval --iterations 8
+```
+
+The default corpus is checked in at `tests/fixtures/rexbench/routing-eval.json`.
+It covers a healthy primary provider, a rate-limit fallback, an outage fallback,
+and the fail-closed case where every candidate is unavailable. Results are labeled
+`deterministic_local` and report selection accuracy plus bounded routing timings.
+
+## Optional live probe
+
+A live provider probe is deliberately separate and opt-in:
+
+```powershell
+python scripts/rexbench.py --profile routing-eval --iterations 8 --live-provider-eval
+```
+
+That flag may use the currently configured provider and can therefore incur network
+or provider usage. It must never become a required CI dependency. Its output is
+labeled `live_provider` separately from deterministic evidence and does not retain
+the generated content or raw provider exception message.
+
+## Runtime diagnostics
+
+`ModelRouter.provider_diagnostics()` exposes content-free health metadata suitable
+for logs or future status surfaces. Routing evidence uses bounded reason labels such
+as `provider_openai_cooldown`, `provider_fallback_selected`, and
+`all_providers_unavailable`; these labels explain degradation without exposing a
+credential, request, response, or private user value.

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -27,6 +27,7 @@ from .llm_client import LanguageModel
 from .memory import trim_history
 from .model_router import ModelRouteDecision, ModelRouter
 from .plugins import PluginSpec
+from .provider_reliability import classify_provider_failure
 from .runtime.events import EventKind, EventObserver, TurnEvent, TurnEventStream
 from .runtime.invocation import current_turn_invocation
 from .runtime.turn import (
@@ -574,17 +575,61 @@ class Assistant:
             model = getattr(settings_obj, "llm_model", "unknown")
         return str(provider or "unknown"), str(model or "unknown")
 
+    def _provider_attempt_latency_ms(self, started_ns: int) -> float:
+        return max(0.0, (time.perf_counter_ns() - started_ns) / 1_000_000)
+
+    def _record_provider_success(self, started_ns: int) -> None:
+        router = getattr(self, "_router", None)
+        if not isinstance(router, ModelRouter):
+            return
+        provider, _model = self._latency_provider_model()
+        router.record_provider_success(
+            provider, latency_ms=self._provider_attempt_latency_ms(started_ns)
+        )
+
+    def _record_provider_failure(self, exc: BaseException, started_ns: int) -> None:
+        router = getattr(self, "_router", None)
+        if not isinstance(router, ModelRouter):
+            return
+        provider, _model = self._latency_provider_model()
+        router.record_provider_failure(
+            provider,
+            classify_provider_failure(exc),
+            latency_ms=self._provider_attempt_latency_ms(started_ns),
+        )
+
     def _generate_model_reply(self, prompt: str, messages: list[dict[str, str]]) -> str:
+        started_ns = time.perf_counter_ns()
         try:
-            return self._llm.generate(messages=messages)
-        except TypeError:
-            return self._llm.generate(prompt)
+            try:
+                reply = self._llm.generate(messages=messages)
+            except TypeError:
+                reply = self._llm.generate(prompt)
+        except Exception as exc:
+            self._record_provider_failure(exc, started_ns)
+            raise
+        self._record_provider_success(started_ns)
+        return reply
+
+    def _track_provider_stream(self, stream: Iterable[str], started_ns: int) -> Iterable[str]:
+        try:
+            yield from stream
+        except Exception as exc:
+            self._record_provider_failure(exc, started_ns)
+            raise
+        self._record_provider_success(started_ns)
 
     def _stream_model_reply(self, prompt: str, messages: list[dict[str, str]]) -> Iterable[str]:
+        started_ns = time.perf_counter_ns()
         try:
-            return self._llm.stream(messages=messages)
-        except TypeError:
-            return self._llm.stream(prompt)
+            try:
+                stream = self._llm.stream(messages=messages)
+            except TypeError:
+                stream = self._llm.stream(prompt)
+        except Exception as exc:
+            self._record_provider_failure(exc, started_ns)
+            raise
+        return self._track_provider_stream(stream, started_ns)
 
     async def _post_process_completion(
         self, transcript: str, completion: str, *, user_id: str | None = None

--- a/rex/model_router.py
+++ b/rex/model_router.py
@@ -21,6 +21,8 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import StrEnum, auto
 
+from rex.provider_reliability import ProviderFailureKind, ProviderReliability
+
 logger = logging.getLogger(__name__)
 
 
@@ -57,6 +59,24 @@ class ModelRouteDecision:
             "escalation_count": self.escalation_count,
             "fallback_reason": self.fallback_reason,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRouteCandidate:
+    """One configured provider/model candidate in deterministic preference order."""
+
+    provider: str
+    model: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRouteSelection:
+    """Privacy-safe result of provider health filtering and fallback."""
+
+    provider: str
+    model: str
+    fallback_reason: str | None = None
+    evidence: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +246,7 @@ class ModelRouter:
         refresh_interval: int = _DEFAULT_REFRESH_INTERVAL,
         cooldown_seconds: int = _DEFAULT_COOLDOWN_SECONDS,
         notify_callback: Callable[[str], None] | None = None,
+        provider_reliability: ProviderReliability | None = None,
     ) -> None:
         self._ollama_base_url = ollama_base_url.rstrip("/")
         self._refresh_interval = refresh_interval
@@ -235,8 +256,11 @@ class ModelRouter:
 
         # Cloud rate-limit cooldown state
         self._cooldown_seconds = cooldown_seconds
-        self._cloud_limited_until: float = 0.0  # epoch seconds
+        self._cloud_limited_until: float = 0.0  # monotonic seconds
         self._notify_callback = notify_callback
+        self._provider_reliability = provider_reliability or ProviderReliability(
+            cooldown_seconds=cooldown_seconds
+        )
 
         # Determine whether any routing target could be an Ollama model.
         self._needs_ollama = self._any_ollama_target(routing_config)
@@ -305,17 +329,27 @@ class ModelRouter:
     # Cloud rate-limit / quota fallback (US-045)
     # ------------------------------------------------------------------
 
-    def cloud_limit_hit(self, status_code: int) -> None:
-        """Record that the cloud API returned *status_code* 429 or 402.
+    def _reliability(self) -> ProviderReliability:
+        reliability = getattr(self, "_provider_reliability", None)
+        if reliability is None:
+            reliability = ProviderReliability(
+                cooldown_seconds=int(
+                    getattr(self, "_cooldown_seconds", self._DEFAULT_COOLDOWN_SECONDS)
+                )
+            )
+            self._provider_reliability = reliability
+        return reliability
 
-        Activates a cooldown period during which :py:meth:`route` will route
-        to the local model instead of cloud.  Calls *notify_callback* (if
-        supplied) with a human-readable message so callers can surface the
-        notification to the user.
-        """
+    def cloud_limit_hit(self, status_code: int, *, provider: str = "cloud") -> None:
+        """Record legacy cloud quota/rate-limit evidence and provider cooldown."""
         if status_code not in (429, 402):
             return
         self._cloud_limited_until = time.monotonic() + self._cooldown_seconds
+        self._reliability().record_failure(
+            provider,
+            ProviderFailureKind.RATE_LIMIT,
+            cooldown_seconds=self._cooldown_seconds,
+        )
         msg = (
             f"Cloud limit reached (HTTP {status_code}), switching to local model. "
             f"Cloud will be retried in {self._cooldown_seconds // 60} min."
@@ -325,8 +359,62 @@ class ModelRouter:
             self._notify_callback(msg)
 
     def _cloud_in_cooldown(self) -> bool:
-        """Return True if cloud is currently under a rate-limit cooldown."""
+        """Return True if cloud is currently under the legacy global cooldown."""
         return time.monotonic() < self._cloud_limited_until
+
+    @property
+    def provider_reliability(self) -> ProviderReliability:
+        return self._reliability()
+
+    def record_provider_success(
+        self, provider: str, *, latency_ms: float | int | None = None
+    ) -> None:
+        self._reliability().record_success(provider, latency_ms=latency_ms)
+
+    def record_provider_failure(
+        self,
+        provider: str,
+        kind: ProviderFailureKind | str,
+        *,
+        latency_ms: float | int | None = None,
+    ) -> None:
+        self._reliability().record_failure(provider, kind, latency_ms=latency_ms)
+
+    def provider_diagnostics(self) -> list[dict[str, object]]:
+        return self._reliability().diagnostics()
+
+    def select_provider(
+        self, candidates: Sequence[ProviderRouteCandidate]
+    ) -> ProviderRouteSelection:
+        """Choose the first healthy configured provider in stable preference order."""
+        evidence: list[str] = []
+        fallback_reason: str | None = None
+        for index, candidate in enumerate(candidates):
+            if not candidate.provider or not candidate.model:
+                continue
+            status = self._reliability().status(candidate.provider)
+            if status.available:
+                if index == 0 and not evidence:
+                    evidence.append("provider_primary_selected")
+                else:
+                    evidence.append("provider_fallback_selected")
+                return ProviderRouteSelection(
+                    provider=candidate.provider,
+                    model=candidate.model,
+                    fallback_reason=fallback_reason,
+                    evidence=tuple(evidence),
+                )
+            evidence.append(f"provider_{status.provider}_{status.state}")
+            fallback_reason = (
+                "provider_cooldown" if status.state == "cooldown" else "provider_unavailable"
+            )
+        evidence.append("all_providers_unavailable")
+        return ProviderRouteSelection(
+            provider="",
+            model="",
+            fallback_reason="all_providers_unavailable",
+            evidence=tuple(evidence),
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -568,7 +656,16 @@ class ModelRouter:
                 model=fast_model,
             )
 
-        fallback_reason = self._deep_fallback_reason(
+        provider_fallback_reason: str | None = None
+        normalized_provider = provider.strip().lower()
+        if deep_provider_available and normalized_provider:
+            provider_status = self._reliability().status(normalized_provider)
+            if not provider_status.available:
+                deep_provider_available = False
+                evidence.append(f"provider_{provider_status.provider}_{provider_status.state}")
+                provider_fallback_reason = f"deep_provider_{provider_status.state}"
+
+        fallback_reason = provider_fallback_reason or self._deep_fallback_reason(
             deep_provider_available=deep_provider_available,
             deep_model=deep_model,
             fast_model=fast_model,

--- a/rex/provider_reliability.py
+++ b/rex/provider_reliability.py
@@ -1,0 +1,237 @@
+"""Privacy-safe provider reliability signals for ModelRouter decisions.
+
+Only bounded operational metadata is retained. Prompt text, responses, user
+identity, credentials, and exception messages are never accepted or stored.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+_PROVIDER_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{0,47}$")
+_MAX_COUNT = 1_000_000
+
+
+class ProviderFailureKind(StrEnum):
+    AUTH = "auth"
+    RATE_LIMIT = "rate_limit"
+    TRANSIENT = "transient"
+    UNAVAILABLE = "unavailable"
+    MODEL_NOT_FOUND = "model_not_found"
+    UNKNOWN = "unknown"
+
+
+def _provider_id(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    return normalized if _PROVIDER_ID.fullmatch(normalized) else "unknown"
+
+
+def _bounded_latency(value: float | int | None, maximum: float) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return round(max(0.0, min(maximum, numeric)), 3)
+
+
+def _inc(value: int) -> int:
+    return min(_MAX_COUNT, value + 1)
+
+
+@dataclass(slots=True)
+class _ProviderRecord:
+    provider: str
+    attempts: int = 0
+    successes: int = 0
+    failures: int = 0
+    rate_limits: int = 0
+    consecutive_failures: int = 0
+    latency_ms: float | None = None
+    last_failure: ProviderFailureKind | None = None
+    cooldown_until: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderStatus:
+    provider: str
+    state: str
+    available: bool
+    reason: str | None
+    latency_ms: float | None
+    attempts: int
+    successes: int
+    failures: int
+    rate_limits: int
+    consecutive_failures: int
+    cooldown_remaining_s: int
+
+    def to_metadata(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "state": self.state,
+            "available": self.available,
+            "reason": self.reason,
+            "latency_ms": self.latency_ms,
+            "attempts": self.attempts,
+            "successes": self.successes,
+            "failures": self.failures,
+            "rate_limits": self.rate_limits,
+            "consecutive_failures": self.consecutive_failures,
+            "cooldown_remaining_s": self.cooldown_remaining_s,
+        }
+
+
+class ProviderReliability:
+    """Keep bounded provider health evidence without request/private content."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        cooldown_seconds: int = 3600,
+        max_latency_ms: float = 120_000.0,
+    ) -> None:
+        self._clock = clock
+        self._cooldown_seconds = max(0, int(cooldown_seconds))
+        self._max_latency_ms = max(1.0, float(max_latency_ms))
+        self._records: dict[str, _ProviderRecord] = {}
+
+    def _record(self, provider: str) -> _ProviderRecord:
+        key = _provider_id(provider)
+        record = self._records.get(key)
+        if record is None:
+            record = _ProviderRecord(provider=key)
+            self._records[key] = record
+        return record
+
+    def record_success(self, provider: str, *, latency_ms: float | int | None = None) -> None:
+        record = self._record(provider)
+        record.attempts = _inc(record.attempts)
+        record.successes = _inc(record.successes)
+        record.consecutive_failures = 0
+        record.last_failure = None
+        record.cooldown_until = 0.0
+        bounded = _bounded_latency(latency_ms, self._max_latency_ms)
+        if bounded is not None:
+            record.latency_ms = bounded
+
+    def record_failure(
+        self,
+        provider: str,
+        kind: ProviderFailureKind | str,
+        *,
+        latency_ms: float | int | None = None,
+        cooldown_seconds: int | None = None,
+    ) -> None:
+        record = self._record(provider)
+        try:
+            failure = ProviderFailureKind(str(kind))
+        except ValueError:
+            failure = ProviderFailureKind.UNKNOWN
+        record.attempts = _inc(record.attempts)
+        record.failures = _inc(record.failures)
+        record.consecutive_failures = _inc(record.consecutive_failures)
+        record.last_failure = failure
+        if failure is ProviderFailureKind.RATE_LIMIT:
+            record.rate_limits = _inc(record.rate_limits)
+        bounded = _bounded_latency(latency_ms, self._max_latency_ms)
+        if bounded is not None:
+            record.latency_ms = bounded
+
+        should_cooldown = failure in {
+            ProviderFailureKind.AUTH,
+            ProviderFailureKind.RATE_LIMIT,
+            ProviderFailureKind.UNAVAILABLE,
+            ProviderFailureKind.MODEL_NOT_FOUND,
+        }
+        if should_cooldown:
+            seconds = (
+                self._cooldown_seconds
+                if cooldown_seconds is None
+                else max(0, int(cooldown_seconds))
+            )
+            record.cooldown_until = max(record.cooldown_until, self._clock() + seconds)
+
+    def status(self, provider: str) -> ProviderStatus:
+        key = _provider_id(provider)
+        record = self._records.get(key)
+        if record is None:
+            return ProviderStatus(
+                provider=key,
+                state="unknown",
+                available=True,
+                reason=None,
+                latency_ms=None,
+                attempts=0,
+                successes=0,
+                failures=0,
+                rate_limits=0,
+                consecutive_failures=0,
+                cooldown_remaining_s=0,
+            )
+
+        remaining = max(0.0, record.cooldown_until - self._clock())
+        in_cooldown = remaining > 0
+        if in_cooldown:
+            state = "cooldown"
+        elif record.last_failure is not None or record.failures:
+            state = "degraded"
+        else:
+            state = "healthy"
+        return ProviderStatus(
+            provider=record.provider,
+            state=state,
+            available=not in_cooldown,
+            reason=record.last_failure.value if record.last_failure is not None else None,
+            latency_ms=record.latency_ms,
+            attempts=record.attempts,
+            successes=record.successes,
+            failures=record.failures,
+            rate_limits=record.rate_limits,
+            consecutive_failures=record.consecutive_failures,
+            cooldown_remaining_s=int(math.ceil(remaining)),
+        )
+
+    def diagnostics(self) -> list[dict[str, object]]:
+        return [self.status(provider).to_metadata() for provider in sorted(self._records)]
+
+
+def classify_provider_failure(exc: BaseException) -> ProviderFailureKind:
+    """Classify a provider exception without retaining its message or payload."""
+    status = getattr(exc, "status_code", None)
+    if not isinstance(status, int):
+        response = getattr(exc, "response", None)
+        candidate = getattr(response, "status_code", None)
+        status = candidate if isinstance(candidate, int) else None
+    if status in {401, 403}:
+        return ProviderFailureKind.AUTH
+    if status in {402, 429}:
+        return ProviderFailureKind.RATE_LIMIT
+    if status == 404:
+        return ProviderFailureKind.MODEL_NOT_FOUND
+    if status in {408, 409, 425} or (isinstance(status, int) and status >= 500):
+        return ProviderFailureKind.TRANSIENT
+
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return ProviderFailureKind.UNAVAILABLE
+    name = type(exc).__name__.lower()
+    if "timeout" in name or "connection" in name or "connect" in name:
+        return ProviderFailureKind.UNAVAILABLE
+    return ProviderFailureKind.UNKNOWN
+
+
+__all__ = [
+    "ProviderFailureKind",
+    "ProviderReliability",
+    "ProviderStatus",
+    "classify_provider_failure",
+]

--- a/scripts/rexbench.py
+++ b/scripts/rexbench.py
@@ -25,7 +25,8 @@ from rex.actions.graph_executor import ActionGraphExecutor  # noqa: E402
 from rex.actions.lifecycle import lifecycle_from_legacy_status  # noqa: E402
 from rex.capabilities.registry import Capability, CapabilityRegistry  # noqa: E402
 from rex.capabilities.retrieval import CapabilityRetriever  # noqa: E402
-from rex.model_router import ModelRouter  # noqa: E402
+from rex.model_router import ModelRouter, ProviderRouteCandidate  # noqa: E402
+from rex.provider_reliability import ProviderFailureKind, ProviderReliability  # noqa: E402
 from rex.rexbench import BenchmarkSample, build_report  # noqa: E402
 from rex.runtime.warm import WarmComponentSpec, WarmRuntimeManager  # noqa: E402
 from rex.tools.execution import ToolOperation  # noqa: E402
@@ -671,6 +672,153 @@ def run_model_routing(iterations: int) -> dict:
     return build_report(samples, profile="model-routing")
 
 
+ROUTING_EVAL_CORPUS = REPO_ROOT / "tests" / "fixtures" / "rexbench" / "routing-eval.json"
+
+
+def _timing_percentiles(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    if not ordered:
+        raise ValueError("routing eval requires timing samples")
+
+    def percentile(q: float) -> float:
+        if len(ordered) == 1:
+            return ordered[0]
+        position = (len(ordered) - 1) * q
+        lower = int(position)
+        upper = min(lower + 1, len(ordered) - 1)
+        fraction = position - lower
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+    return {"p50": round(percentile(0.50), 3), "p95": round(percentile(0.95), 3)}
+
+
+def _routing_eval_reliability(raw_case: dict[str, object]) -> ProviderReliability:
+    reliability = ProviderReliability(cooldown_seconds=60)
+    failures = raw_case.get("failures", [])
+    if not isinstance(failures, list):
+        raise ValueError("Routing evaluation failures must be a list")
+    for failure in failures:
+        if not isinstance(failure, dict):
+            raise ValueError("Routing evaluation failure must be an object")
+        reliability.record_failure(
+            str(failure.get("provider") or ""),
+            ProviderFailureKind(str(failure.get("kind") or "unknown")),
+        )
+    return reliability
+
+
+def _routing_eval_candidates(raw_case: dict[str, object]) -> tuple[ProviderRouteCandidate, ...]:
+    raw_candidates = raw_case.get("candidates", [])
+    if not isinstance(raw_candidates, list):
+        raise ValueError("Routing evaluation candidates must be a list")
+    return tuple(
+        ProviderRouteCandidate(str(item.get("provider") or ""), str(item.get("model") or ""))
+        for item in raw_candidates
+        if isinstance(item, dict)
+    )
+
+
+def _routing_eval_case(
+    raw_case: dict[str, object], iterations: int
+) -> tuple[bool, dict[str, object]]:
+    timings: list[float] = []
+    case_passed = True
+    for _ in range(iterations):
+        router = ModelRouter(provider_reliability=_routing_eval_reliability(raw_case))
+        started = time.perf_counter_ns()
+        selection = router.select_provider(_routing_eval_candidates(raw_case))
+        timings.append((time.perf_counter_ns() - started) / 1_000_000)
+        case_passed = case_passed and (
+            selection.provider == str(raw_case.get("expected_provider") or "")
+            and selection.model == str(raw_case.get("expected_model") or "")
+            and selection.fallback_reason == raw_case.get("expected_fallback_reason")
+        )
+    return case_passed, {
+        "passed": case_passed,
+        "evidence_class": "deterministic_local",
+        "iterations": iterations,
+        "routing_ms": _timing_percentiles(timings),
+    }
+
+
+def run_routing_eval(
+    iterations: int,
+    *,
+    corpus_path: Path = ROUTING_EVAL_CORPUS,
+    live_provider_eval: bool = False,
+) -> dict[str, object]:
+    """Evaluate deterministic provider selection/fallback against a checked-in corpus."""
+    if iterations < 1:
+        raise ValueError("iterations must be at least 1")
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    if corpus.get("schema_version") != 1 or corpus.get("evidence_class") != "deterministic_local":
+        raise ValueError("Unsupported routing evaluation corpus")
+    cases = corpus.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("Routing evaluation corpus contains no cases")
+
+    results: dict[str, dict[str, object]] = {}
+    passed_cases = 0
+    for raw_case in cases:
+        if not isinstance(raw_case, dict):
+            raise ValueError("Routing evaluation case must be an object")
+        case_id = str(raw_case.get("id") or "")
+        if not case_id or case_id in results:
+            raise ValueError("Routing evaluation case IDs must be unique and non-empty")
+        case_passed, result = _routing_eval_case(raw_case, iterations)
+        results[case_id] = result
+        passed_cases += int(case_passed)
+
+    report: dict[str, object] = {
+        "schema_version": 1,
+        "profile": "routing-eval",
+        "privacy": "bounded_provider_health_and_timing_metadata_only",
+        "evidence_class": "deterministic_local",
+        "live_provider_eval": bool(live_provider_eval),
+        "corpus_version": int(corpus["schema_version"]),
+        "total_cases": len(cases),
+        "passed_cases": passed_cases,
+        "selection_accuracy": round(passed_cases / len(cases), 3),
+        "results": results,
+    }
+    if live_provider_eval:
+        report["live_provider"] = _live_provider_eval()
+    return report
+
+
+def _live_provider_eval() -> dict[str, object]:
+    """Run one explicitly requested live provider probe without retaining content."""
+    from rex.config import load_config  # noqa: PLC0415
+    from rex.llm_client import LanguageModel  # noqa: PLC0415
+    from rex.provider_reliability import classify_provider_failure  # noqa: PLC0415
+
+    config = load_config()
+    provider = str(getattr(config, "llm_provider", "unknown") or "unknown")
+    model = LanguageModel(config)
+    started = time.perf_counter_ns()
+    try:
+        model.generate("Reply with OK.")
+    except Exception as exc:
+        elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+        return {
+            "evidence_class": "live_provider",
+            "provider": provider,
+            "model": model.active_model_name(),
+            "success": False,
+            "failure_kind": classify_provider_failure(exc).value,
+            "latency_ms": round(elapsed_ms, 3),
+        }
+    elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+    return {
+        "evidence_class": "live_provider",
+        "provider": provider,
+        "model": model.active_model_name(),
+        "success": True,
+        "failure_kind": None,
+        "latency_ms": round(elapsed_ms, 3),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -681,10 +829,16 @@ def main() -> int:
             "parallel-actions",
             "warm-runtime",
             "model-routing",
+            "routing-eval",
         ),
         default="baseline",
     )
     parser.add_argument("--iterations", type=int, default=8)
+    parser.add_argument(
+        "--live-provider-eval",
+        action="store_true",
+        help="Opt in to one labeled live provider probe; never enabled by default or CI.",
+    )
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
 
@@ -696,6 +850,8 @@ def main() -> int:
         report = run_warm_runtime(args.iterations)
     elif args.profile == "model-routing":
         report = run_model_routing(args.iterations)
+    elif args.profile == "routing-eval":
+        report = run_routing_eval(args.iterations, live_provider_eval=args.live_provider_eval)
     else:
         report = run_baseline(args.iterations)
     encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"

--- a/tests/fixtures/rexbench/routing-eval.json
+++ b/tests/fixtures/rexbench/routing-eval.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "evidence_class": "deterministic_local",
+  "cases": [
+    {
+      "id": "healthy_primary",
+      "candidates": [
+        {"provider": "ollama", "model": "fast-local"},
+        {"provider": "openai", "model": "gpt-5.5"}
+      ],
+      "failures": [],
+      "expected_provider": "ollama",
+      "expected_model": "fast-local",
+      "expected_fallback_reason": null
+    },
+    {
+      "id": "rate_limit_fallback",
+      "candidates": [
+        {"provider": "openai", "model": "gpt-5.5"},
+        {"provider": "ollama", "model": "qwen3:8b"}
+      ],
+      "failures": [{"provider": "openai", "kind": "rate_limit"}],
+      "expected_provider": "ollama",
+      "expected_model": "qwen3:8b",
+      "expected_fallback_reason": "provider_cooldown"
+    },
+    {
+      "id": "provider_outage_fallback",
+      "candidates": [
+        {"provider": "anthropic", "model": "claude-sonnet"},
+        {"provider": "openai", "model": "gpt-5.5"}
+      ],
+      "failures": [{"provider": "anthropic", "kind": "unavailable"}],
+      "expected_provider": "openai",
+      "expected_model": "gpt-5.5",
+      "expected_fallback_reason": "provider_cooldown"
+    },
+    {
+      "id": "all_providers_unavailable",
+      "candidates": [
+        {"provider": "openai", "model": "gpt-5.5"},
+        {"provider": "anthropic", "model": "claude-sonnet"}
+      ],
+      "failures": [
+        {"provider": "openai", "kind": "auth"},
+        {"provider": "anthropic", "kind": "rate_limit"}
+      ],
+      "expected_provider": "",
+      "expected_model": "",
+      "expected_fallback_reason": "all_providers_unavailable"
+    }
+  ]
+}

--- a/tests/rex2/test_provider_reliability.py
+++ b/tests/rex2/test_provider_reliability.py
@@ -1,0 +1,255 @@
+"""US-111 provider reliability and deterministic fallback tests."""
+
+from types import SimpleNamespace
+
+from rex.model_router import ModelRouter, ProviderRouteCandidate
+from rex.provider_reliability import ProviderFailureKind, ProviderReliability
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 100.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _routing():
+    return SimpleNamespace(
+        default="fast-local",
+        fast="fast-local",
+        coding="deep-local",
+        reasoning="deep-local",
+        search="deep-local",
+        vision="deep-local",
+    )
+
+
+def test_rate_limit_enters_bounded_cooldown_then_recovers():
+    clock = _Clock()
+    reliability = ProviderReliability(clock=clock, cooldown_seconds=60)
+
+    reliability.record_failure("openai", ProviderFailureKind.RATE_LIMIT, latency_ms=250)
+    status = reliability.status("openai")
+
+    assert not status.available
+    assert status.state == "cooldown"
+    assert status.reason == "rate_limit"
+    assert status.cooldown_remaining_s == 60
+    assert status.rate_limits == 1
+
+    clock.advance(61)
+    recovered = reliability.status("openai")
+    assert recovered.available
+    assert recovered.state == "degraded"
+    assert recovered.cooldown_remaining_s == 0
+
+
+def test_success_resets_failure_streak_and_clamps_latency():
+    reliability = ProviderReliability(max_latency_ms=120_000)
+    reliability.record_failure("ollama", ProviderFailureKind.TRANSIENT, latency_ms=-10)
+    reliability.record_success("ollama", latency_ms=999_999)
+
+    status = reliability.status("ollama")
+    assert status.available
+    assert status.consecutive_failures == 0
+    assert status.successes == 1
+    assert status.failures == 1
+    assert status.latency_ms == 120_000
+
+
+def test_diagnostics_are_bounded_and_content_free():
+    reliability = ProviderReliability()
+    reliability.record_failure("openai", ProviderFailureKind.AUTH, latency_ms=12.3456)
+
+    diagnostics = reliability.diagnostics()
+    assert diagnostics == [
+        {
+            "provider": "openai",
+            "state": "cooldown",
+            "available": False,
+            "reason": "auth",
+            "latency_ms": 12.346,
+            "attempts": 1,
+            "successes": 0,
+            "failures": 1,
+            "rate_limits": 0,
+            "consecutive_failures": 1,
+            "cooldown_remaining_s": 3600,
+        }
+    ]
+    rendered = repr(diagnostics)
+    assert "prompt" not in rendered.lower()
+    assert "response" not in rendered.lower()
+    assert "credential" not in rendered.lower()
+
+
+def test_router_falls_back_to_next_configured_healthy_provider():
+    clock = _Clock()
+    reliability = ProviderReliability(clock=clock, cooldown_seconds=90)
+    router = ModelRouter(provider_reliability=reliability)
+    reliability.record_failure("openai", ProviderFailureKind.RATE_LIMIT)
+
+    selection = router.select_provider(
+        (
+            ProviderRouteCandidate("openai", "gpt-5.5"),
+            ProviderRouteCandidate("ollama", "qwen3:8b"),
+        )
+    )
+
+    assert selection.provider == "ollama"
+    assert selection.model == "qwen3:8b"
+    assert selection.fallback_reason == "provider_cooldown"
+    assert selection.evidence == ("provider_openai_cooldown", "provider_fallback_selected")
+
+
+def test_router_provider_fallback_order_is_deterministic():
+    reliability = ProviderReliability()
+    router = ModelRouter(provider_reliability=reliability)
+
+    selection = router.select_provider(
+        (
+            ProviderRouteCandidate("ollama", "fast-local"),
+            ProviderRouteCandidate("openai", "gpt-5.5"),
+            ProviderRouteCandidate("anthropic", "claude-sonnet"),
+        )
+    )
+
+    assert selection.provider == "ollama"
+    assert selection.model == "fast-local"
+    assert selection.fallback_reason is None
+    assert selection.evidence == ("provider_primary_selected",)
+
+
+def test_decide_respects_current_provider_cooldown_for_deep_route():
+    reliability = ProviderReliability(cooldown_seconds=60)
+    router = ModelRouter(provider_reliability=reliability)
+    router._available_ollama_models = {"fast-local", "deep-local"}
+    reliability.record_failure("openai", ProviderFailureKind.RATE_LIMIT)
+
+    decision = router.decide(
+        "Analyze the tradeoffs in this architecture.",
+        routing_config=_routing(),
+        current_model="fast-local",
+        provider="openai",
+    )
+
+    assert decision.tier == "fast"
+    assert decision.model == "fast-local"
+    assert decision.fallback_reason == "deep_provider_cooldown"
+    assert "provider_openai_cooldown" in decision.evidence
+
+
+def test_legacy_cloud_limit_hook_updates_provider_reliability():
+    reliability = ProviderReliability(cooldown_seconds=30)
+    router = ModelRouter(provider_reliability=reliability, cooldown_seconds=30)
+
+    router.cloud_limit_hit(429, provider="openrouter")
+
+    status = reliability.status("openrouter")
+    assert not status.available
+    assert status.reason == "rate_limit"
+    assert status.rate_limits == 1
+
+
+def _assistant_with_llm(llm):
+    from rex.assistant import Assistant
+
+    assistant = Assistant.__new__(Assistant)
+    assistant._settings = SimpleNamespace(
+        llm_provider="openai",
+        llm=SimpleNamespace(llm_provider="openai", model_name="gpt-test"),
+        llm_model="gpt-test",
+    )
+    assistant._llm = llm
+    assistant._router = ModelRouter(provider_reliability=ProviderReliability(cooldown_seconds=45))
+    return assistant
+
+
+def test_assistant_records_provider_success_at_generation_boundary():
+    class _LLM:
+        model_name = "gpt-test"
+
+        def generate(self, *, messages):
+            return "ok"
+
+    assistant = _assistant_with_llm(_LLM())
+
+    assert assistant._generate_model_reply("prompt", [{"role": "user", "content": "hello"}]) == "ok"
+    status = assistant._router.provider_reliability.status("openai")
+    assert status.attempts == 1
+    assert status.successes == 1
+    assert status.failures == 0
+    assert status.latency_ms is not None
+
+
+def test_assistant_records_rate_limit_without_storing_exception_text():
+    class _RateLimitedError(RuntimeError):
+        status_code = 429
+
+    class _LLM:
+        model_name = "gpt-test"
+
+        def generate(self, *, messages):
+            raise _RateLimitedError("PRIVATE-PROVIDER-ERROR-TEXT")
+
+    assistant = _assistant_with_llm(_LLM())
+
+    import pytest
+
+    with pytest.raises(_RateLimitedError):
+        assistant._generate_model_reply("prompt", [{"role": "user", "content": "hello"}])
+    status = assistant._router.provider_reliability.status("openai")
+    assert not status.available
+    assert status.reason == "rate_limit"
+    assert status.rate_limits == 1
+    assert "PRIVATE-PROVIDER-ERROR-TEXT" not in repr(assistant._router.provider_diagnostics())
+
+
+def test_legacy_generate_signature_typeerror_is_not_counted_as_provider_failure():
+    class _LLM:
+        model_name = "gpt-test"
+
+        def generate(self, prompt=None, **kwargs):
+            if "messages" in kwargs:
+                raise TypeError("legacy signature")
+            return "legacy ok"
+
+    assistant = _assistant_with_llm(_LLM())
+    assert (
+        assistant._generate_model_reply("prompt", [{"role": "user", "content": "hello"}])
+        == "legacy ok"
+    )
+    status = assistant._router.provider_reliability.status("openai")
+    assert status.attempts == 1
+    assert status.successes == 1
+    assert status.failures == 0
+
+
+def test_assistant_records_stream_failure_when_iteration_raises():
+    class _StreamError(ConnectionError):
+        pass
+
+    class _LLM:
+        model_name = "gpt-test"
+
+        def stream(self, *, messages):
+            yield "first"
+            raise _StreamError("PRIVATE-STREAM-ERROR")
+
+    assistant = _assistant_with_llm(_LLM())
+    stream = assistant._stream_model_reply("prompt", [{"role": "user", "content": "hello"}])
+
+    import pytest
+
+    assert next(iter(stream)) == "first"
+    with pytest.raises(_StreamError):
+        next(stream)
+    status = assistant._router.provider_reliability.status("openai")
+    assert not status.available
+    assert status.reason == "unavailable"
+    assert status.failures == 1
+    assert "PRIVATE-STREAM-ERROR" not in repr(assistant._router.provider_diagnostics())

--- a/tests/rex2/test_routing_eval.py
+++ b/tests/rex2/test_routing_eval.py
@@ -1,0 +1,98 @@
+"""US-111 deterministic routing evaluation corpus tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CORPUS = Path("tests/fixtures/rexbench/routing-eval.json")
+
+
+def _load_rexbench_module():
+    path = Path("scripts/rexbench.py").resolve()
+    spec = importlib.util.spec_from_file_location("askrex_rexbench_script", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_checked_in_routing_corpus_is_deterministic_and_content_safe():
+    corpus = json.loads(CORPUS.read_text(encoding="utf-8"))
+
+    assert corpus["schema_version"] == 1
+    assert corpus["evidence_class"] == "deterministic_local"
+    ids = [case["id"] for case in corpus["cases"]]
+    assert len(ids) == len(set(ids)) >= 4
+
+    encoded = CORPUS.read_text(encoding="utf-8").lower()
+    for forbidden in (
+        "prompt",
+        "response",
+        "transcript",
+        "memory_content",
+        "credential",
+        "api_key",
+        "token",
+        "user_id",
+    ):
+        assert forbidden not in encoded
+
+
+def test_routing_eval_scores_selection_fallback_and_regression_without_network():
+    module = _load_rexbench_module()
+    report = module.run_routing_eval(2, corpus_path=CORPUS)
+
+    assert report["profile"] == "routing-eval"
+    assert report["evidence_class"] == "deterministic_local"
+    assert report["live_provider_eval"] is False
+    assert report["corpus_version"] == 1
+    assert report["total_cases"] == 4
+    assert report["passed_cases"] == 4
+    assert report["selection_accuracy"] == 1.0
+    assert set(report["results"]) == {
+        "healthy_primary",
+        "rate_limit_fallback",
+        "provider_outage_fallback",
+        "all_providers_unavailable",
+    }
+
+    for case_id, result in report["results"].items():
+        assert result["passed"] is True, case_id
+        assert result["evidence_class"] == "deterministic_local"
+        assert result["iterations"] == 2
+        assert result["routing_ms"]["p50"] >= 0
+        assert result["routing_ms"]["p95"] >= 0
+
+    rendered = json.dumps(report).lower()
+    for forbidden in ("prompt", "transcript", "credential", "api_key", "user_id"):
+        assert forbidden not in rendered
+
+
+def test_routing_eval_cli_defaults_to_no_live_provider_calls(tmp_path):
+    output = tmp_path / "routing-eval.json"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/rexbench.py",
+            "--profile",
+            "routing-eval",
+            "--iterations",
+            "1",
+            "--output",
+            str(output),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["live_provider_eval"] is False
+    assert report["selection_accuracy"] == 1.0


### PR DESCRIPTION
## Summary
- add privacy-safe provider reliability signals for latency, failures, rate limits, cooldowns, and recovery
- make ModelRouter respect provider-specific outage/cooldown evidence and deterministic configured-provider fallback
- record provider outcomes at Assistant generation/stream boundaries without retaining prompt, response, user, credential, or exception-message content
- add checked-in deterministic routing evaluation corpus and `rexbench --profile routing-eval`
- keep live-provider evaluation explicitly opt-in via `--live-provider-eval`; CI/default evaluation stays offline
- document provider-routing privacy/evaluation rules in CLAUDE.md and docs/performance/provider-routing.md

## Local verification
- `pytest tests/rex2/test_provider_reliability.py tests/rex2/test_routing_eval.py -q` -> 14 passed
- `python scripts/rexbench.py --profile routing-eval --iterations 8` -> 4/4 cases, selection_accuracy 1.0, live_provider_eval false
- broader routing/reliability/RexBench regression -> 73 passed
- Assistant/routing regression -> 88 passed
- full release suite `pytest -m "not slow and not audio and not gpu" -q` -> 8778 passed, 49 skipped, 0 failed
- full Ruff -> passed
- Black over rex/tests/bridge + changed RexBench -> 1006 files unchanged
- mypy changed runtime package modules -> 0 errors
- `scripts/security_audit.py --release-gate` -> passed, 0 actionable placeholders, 0 exposed secrets
- pre-commit all-files -> Ruff/Black/detect-secrets passed

## Tracker
Implements US-111. PRD acceptance remains intentionally unchecked until all relevant GitHub checks pass on the exact PR head.