### PR TITLE
docs(mobile): harden askrex.app external API boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ via `pywin32`); config files only ever hold the vault *key*, never a secret
 value.
 
 - Two scopes, mirroring the household/private data split above:
-  `scope="household"` (installation-wide secrets — OpenAI/HA/search keys;
+  `scope="household"` (installation-wide secrets â€” OpenAI/HA/search keys;
   default, matches pre-vault global behavior) and `scope="user"` + a
   validated `user_id` (bound to one Rex profile, e.g. a personal email
   account `credential_ref`). Each scope encrypts with different DPAPI
@@ -220,7 +220,7 @@ value.
   is the only path Electron uses to reach it (stdin/stdout JSON, like every
   other bridge); `gui/src/main/credentialVault.ts` wraps that bridge call.
 - Non-Windows dev/CI: `get_credential_vault()` raises `VaultUnavailableError`
-  (no implicit fallback). `InMemoryCredentialVault` exists only for tests —
+  (no implicit fallback). `InMemoryCredentialVault` exists only for tests â€”
   never selected by a production code path.
 - One-time migration of existing plaintext `.env` / `config/credentials.json`
   secrets: `scripts/migrate_credentials_to_vault.py` (dry-run by default; <!-- pragma: allowlist secret -->
@@ -245,37 +245,37 @@ External inputs include:
 
 Top-level directories:
 
-- rex/ — main package (CLI, services, workflows, integrations)
-- bridge/ — canonical Electron stdin/stdout JSON bridge processes (plus integration adapters)
-- archived/ — retired files kept for reference; not maintained (see `archived/ARCHIVED.md`)
+- rex/ â€” main package (CLI, services, workflows, integrations)
+- bridge/ â€” canonical Electron stdin/stdout JSON bridge processes (plus integration adapters)
+- archived/ â€” retired files kept for reference; not maintained (see `archived/ARCHIVED.md`)
   - `archived/flask_dashboard/tests/` preserves retired Flask-dashboard placeholder tests and is outside pytest's active `tests/` collection.
-- scripts/ — operational and install scripts (platform scripts in `scripts/install/`)
-- plugins/ — optional plugins
-- config/ — application configuration (not secrets)
-- Memory/ — per-user memory profiles
-- tests/ — pytest suite
-- docs/ — documentation
-- gui/ — React + Electron desktop GUI source
+- scripts/ â€” operational and install scripts (platform scripts in `scripts/install/`)
+- plugins/ â€” optional plugins
+- config/ â€” application configuration (not secrets)
+- Memory/ â€” per-user memory profiles
+- tests/ â€” pytest suite
+- docs/ â€” documentation
+- gui/ â€” React + Electron desktop GUI source
 
 ### Root-level `.py` files (27 total)
 
 Active entry points and developer utilities (6):
 
-- rex_loop.py — source voice-loop entry point; defaults to Hold-to-Talk/manual activation, with beta wake-word only via `--mode wake-word`
-- rex_speak_api.py — Flask TTS API with auth and rate limiting
-- wsgi.py — WSGI entry point for `rex-gui`
-- setup.py — legacy setuptools stub (packaging via `pyproject.toml`)
-- sitecustomize.py — Windows UTF-8 encoding fix applied at interpreter start
-- conftest.py — pytest root conftest (shared fixtures)
+- rex_loop.py â€” source voice-loop entry point; defaults to Hold-to-Talk/manual activation, with beta wake-word only via `--mode wake-word`
+- rex_speak_api.py â€” Flask TTS API with auth and rate limiting
+- wsgi.py â€” WSGI entry point for `rex-gui`
+- setup.py â€” legacy setuptools stub (packaging via `pyproject.toml`)
+- sitecustomize.py â€” Windows UTF-8 encoding fix applied at interpreter start
+- conftest.py â€” pytest root conftest (shared fixtures)
 
 Deprecated compatibility shims (4):
 
-- voice_loop.py — legacy voice loop helpers (DeprecationWarning; canonical: `rex/voice_loop.py`)
-- config.py — config shim (re-exports from `rex.config`)
-- llm_client.py — LLM client shim (re-exports from `rex.llm_client`)
-- flask_proxy.py — legacy Flask API and proxy; canonical replacement is `rex-gui`; archived copy at `archived/compat_shims/flask_proxy.py`
+- voice_loop.py â€” legacy voice loop helpers (DeprecationWarning; canonical: `rex/voice_loop.py`)
+- config.py â€” config shim (re-exports from `rex.config`)
+- llm_client.py â€” LLM client shim (re-exports from `rex.llm_client`)
+- flask_proxy.py â€” legacy Flask API and proxy; canonical replacement is `rex-gui`; archived copy at `archived/compat_shims/flask_proxy.py`
 
-Bridge compatibility wrappers (17) — exec canonical `bridge/<name>.py` in their namespace for test-import compatibility; Electron resolves bridges from `bridge/` directly and does not use these root wrappers:
+Bridge compatibility wrappers (17) â€” exec canonical `bridge/<name>.py` in their namespace for test-import compatibility; Electron resolves bridges from `bridge/` directly and does not use these root wrappers:
 
 - rex_chat_bridge.py
 - rex_chat_stream_bridge.py
@@ -297,15 +297,15 @@ Bridge compatibility wrappers (17) — exec canonical `bridge/<name>.py` in thei
 
 ### Important subpackages
 
-- rex/commands/ — CLI command modules, one per domain (US-REM-027); `rex/cli.py` keeps parser registration, `main()`, and re-exports, and `rex.cli.<name>` remains the import/monkeypatch surface for handlers and service getters
-- rex/voice/ — voice pipeline modules, one per concern (US-REM-028); `rex/voice_loop.py` is the facade and `rex.voice_loop.<name>` remains the import/monkeypatch surface (settings, lazy importers, sa/sd, pipeline classes)
-- rex/tools/execution.py — canonical typed tool lifecycle; all registered dispatch must pass availability, argument, identity, permission, risk, confirmation, execution, normalization, independent verification, truthful response, and redacted audit stages. Read-only success is `completed`; mutation success is `verified` only.
+- rex/commands/ â€” CLI command modules, one per domain (US-REM-027); `rex/cli.py` keeps parser registration, `main()`, and re-exports, and `rex.cli.<name>` remains the import/monkeypatch surface for handlers and service getters
+- rex/voice/ â€” voice pipeline modules, one per concern (US-REM-028); `rex/voice_loop.py` is the facade and `rex.voice_loop.<name>` remains the import/monkeypatch surface (settings, lazy importers, sa/sd, pipeline classes)
+- rex/tools/execution.py â€” canonical typed tool lifecycle; all registered dispatch must pass availability, argument, identity, permission, risk, confirmation, execution, normalization, independent verification, truthful response, and redacted audit stages. Read-only success is `completed`; mutation success is `verified` only.
 - `rex/latency.py` / `rex/rexbench.py` - privacy-safe request timing and p50/p95 aggregation. Timing telemetry must never include prompts, transcripts, user IDs, memory contents, credentials, or tool payloads; see `docs/performance.md`.
 - gui/src/main/ - Electron main-process modules, one per concern (US-REM-029); `index.ts` is a thin entrypoint (app lifecycle wiring only), `ipc.ts` aggregates handler registration, IPC handlers live in `gui/src/main/handlers/`, integration credential persistence/rollback lives in `integrationSettingsStorage.ts`, and settings/integration/HA logic lives in `configStore.ts`, `aiSettings.ts`, `voiceSettings.ts`, `settingsDefaults.ts`, `settingsMirror.ts`, `homeAssistant.ts`, `integrationStatus.ts`, `integrationInventory.ts`, `window.ts`
 - `gui/src/pages/settings/integrations/` owns the Settings > Integrations controller and focused UI components; keep OpenClaw token handling renderer-blind and route all secret persistence through the main-process vault helpers.
 - `gui/src/types/settingsRouting.ts` is the shared parser for Settings deep links such as `#/settings?section=integrations`; invalid or missing sections fail safely to General.
 - Installed Electron artifact smoke may override Electron `userData` only when `ASKREX_ARTIFACT_SMOKE=1` and `ASKREX_ARTIFACT_SMOKE_RUNTIME_ROOT` is set; the PowerShell harness must point Python `ASKREX_RUNTIME_DIR` and Electron userData at the same isolated temp runtime root.
-- rex/credential_vault.py — Windows DPAPI-backed credential vault (S4); see "Credential vault (S4)" above
+- rex/credential_vault.py â€” Windows DPAPI-backed credential vault (S4); see "Credential vault (S4)" above
 - rex/email_backends/
 - rex/calendar_backends/
 - rex/messaging_backends/
@@ -314,14 +314,14 @@ Bridge compatibility wrappers (17) — exec canonical `bridge/<name>.py` in thei
 - rex/identity.py
 - rex/voice_identity/
 - rex/computers/
-- rex/mobile_api/ — authenticated mobile API gateway (issue #323): injectable Flask app factory (`app.py`), typed config helpers, idempotent `users.db` migrations (`db.py`), per-device sessions + rotating hashed refresh tokens (`sessions.py`), short-lived access JWTs + request principal (`auth.py`), structured mobile errors (`errors.py`), truthful runtime-aware capabilities (`capabilities.py`), cross-transport `(user_id, message_id)` chat idempotency (`idempotency.py`, `mobile_message_requests` table), canonical Assistant adapter (`chat.py` — explicit `active_user_id`, never direct `LanguageModel` calls), canonical snake_case streaming events (`events.py`), first-frame-auth WebSocket protocol via Flask-Sock (`websocket.py`, close codes 4401/4403/4408/4429), STT/TTS adapters reusing the existing Whisper and XTTS/edge-tts/pyttsx3 stacks (`voice.py`), routes under `rex/mobile_api/routes/` (`chat.py`: POST /mobile/chat + SSE /mobile/chat/stream; `voice.py`: /mobile/voice/upload + /mobile/tts/playback). Home Assistant/notifications/approvals/tasks/workflows/audit/settings remain explicit 501 scaffolds with false capabilities; `live_voice` stays false. Cross-repo wire contract fixtures live in `tests/mobile_api/contract_vectors.json` (identical copy in the AskRex mobile repo).
+- rex/mobile_api/ â€” authenticated mobile API gateway (issue #323): injectable Flask app factory (`app.py`), typed config helpers, idempotent `users.db` migrations (`db.py`), per-device sessions + rotating hashed refresh tokens (`sessions.py`), short-lived access JWTs + request principal (`auth.py`), structured mobile errors (`errors.py`), truthful runtime-aware capabilities (`capabilities.py`), cross-transport `(user_id, message_id)` chat idempotency (`idempotency.py`, `mobile_message_requests` table), canonical Assistant adapter (`chat.py` â€” explicit `active_user_id`, never direct `LanguageModel` calls), canonical snake_case streaming events (`events.py`), first-frame-auth WebSocket protocol via Flask-Sock (`websocket.py`, close codes 4401/4403/4408/4429), STT/TTS adapters reusing the existing Whisper and XTTS/edge-tts/pyttsx3 stacks (`voice.py`), routes under `rex/mobile_api/routes/` (`chat.py`: POST /mobile/chat + SSE /mobile/chat/stream; `voice.py`: /mobile/voice/upload + /mobile/tts/playback). Home Assistant/notifications/approvals/tasks/workflows/audit/settings remain explicit 501 scaffolds with false capabilities; `live_voice` stays false. Cross-repo wire contract fixtures live in `tests/mobile_api/contract_vectors.json` (identical copy in the AskRex mobile repo).
 
 ### Assistant architecture
 
 `Assistant.generate_reply()` and `Assistant.stream_reply()` are canonical TurnEngine entry points over one shared reply pipeline. Identity is validated before the turn begins; all subsequent intent/cache/model routing, context building, action/tool dispatch, result verification, response building, and history recording run inside one correlated turn. Streaming changes only delivery: verified final text is split into ordered sentence chunks before the terminal event. The shared pipeline is:
 
 ```
-Assistant → TurnEngine → IntentRouter/Cache → ContextBuilder → ActionDispatcher → ResponseBuilder → History → [final text or verified sentence chunks]
+Assistant â†’ TurnEngine â†’ IntentRouter/Cache â†’ ContextBuilder â†’ ActionDispatcher â†’ ResponseBuilder â†’ History â†’ [final text or verified sentence chunks]
 ```
 
 | Component | Module | Responsibility |
@@ -334,7 +334,7 @@ Assistant → TurnEngine → IntentRouter/Cache → ContextBuilder → ActionDis
 
 Helper functions extracted from `Assistant`:
 
-- `rex.followup_engine.init_followup_engine(settings, user_id)` — initialises the followup engine and returns `(engine, pending_prompt)`.
+- `rex.followup_engine.init_followup_engine(settings, user_id)` â€” initialises the followup engine and returns `(engine, pending_prompt)`.
 
 ## Commands
 
@@ -543,8 +543,8 @@ Do not invent filenames or APIs that do not exist.
 
 ### Respect the config split
 
-Secrets → OS-backed credential vault (plaintext only in explicit unpackaged legacy mode)
-Runtime configuration → config/rex_config.json
+Secrets â†’ OS-backed credential vault (plaintext only in explicit unpackaged legacy mode)
+Runtime configuration â†’ config/rex_config.json
 
 ### AppConfig sub-config access pattern
 
@@ -628,7 +628,7 @@ Use Conventional Commits for every commit and PR title.
 - Never use placeholders like "..."
 - If a file changes, output the entire updated file.
 - Prefer correct, complete implementations over minimal ones.
-- Use appropriate data structures and algorithms — don't brute-force what has a known better solution.
+- Use appropriate data structures and algorithms â€” don't brute-force what has a known better solution.
 - When fixing a bug, fix the root cause, not the symptom.
 - If something I asked for requires error handling or validation to work reliably, include it without asking.
 
@@ -651,11 +651,11 @@ Add a short rule here that would have prevented the mistake.
 - Direct Ruff and Black installations in CI must use the same revisions as `.pre-commit-config.yaml`; never install unpinned formatters in a required check.
 - The repository dependency security gate must audit the local project explicitly with `pip-audit --strict .`; a bare `pip-audit` audits the runner environment and is not an acceptable project gate.
 - Python releases use `release-please-config.json` plus `.release-please-manifest.json` with the `python` release strategy. Keep the manifest and `pyproject.toml` package version synchronized.
-- Session/user state on long-lived components wired into `Assistant` (engines, caches, in-memory logs) must be keyed by `user_id` in a dict, never held as plain instance attributes — one `Assistant` serves multiple identified users, and each request's identity is resolved once (`_resolve_request_user_id`) and passed explicitly as a function argument to every component. Never propagate a request identity by mutating `self._user_id`: shared mutable identity races across overlapping requests. Mirror the `FollowupEngine`/`SuggestionEngine` pattern: every stateful public method takes an explicit `user_id`, validates it via `rex.identity.validate_user_id`, and fails closed (no-op, never a default-user fallback) on missing or invalid identity.
+- Session/user state on long-lived components wired into `Assistant` (engines, caches, in-memory logs) must be keyed by `user_id` in a dict, never held as plain instance attributes â€” one `Assistant` serves multiple identified users, and each request's identity is resolved once (`_resolve_request_user_id`) and passed explicitly as a function argument to every component. Never propagate a request identity by mutating `self._user_id`: shared mutable identity races across overlapping requests. Mirror the `FollowupEngine`/`SuggestionEngine` pattern: every stateful public method takes an explicit `user_id`, validates it via `rex.identity.validate_user_id`, and fails closed (no-op, never a default-user fallback) on missing or invalid identity.
 - User IDs are authorization keys, not display strings. Validate them with `rex.identity.validate_user_id` before any path, cache, credential, database, or event access; never sanitize an invalid user ID into a valid one.
-- `Assistant` never invents an identity. `Assistant()` is an explicitly unbound instance: it does not assign `"default"`, does not inherit `settings.user_id`, and performs no user-scoped reads or writes at construction (no history preload, no follow-up session, no per-user cache/credential access). Private operations (intent shortcuts, cache lookup, greetings and other early returns, history, context, tool/action dispatch, streaming, completion recording) require an explicit validated identity — the bound constructor `user_id` or a per-request `active_user_id` — and fail closed with `rex.assistant_errors.IdentityRequiredError` otherwise. `user_id="default"` is a valid explicit profile selection only, never an automatic fallback. First-party single-user entrypoints resolve their profile outside `Assistant` via `rex.identity.resolve_entrypoint_user_id(settings, explicit_user=...)` and pass it to `Assistant(user_id=...)`.
+- `Assistant` never invents an identity. `Assistant()` is an explicitly unbound instance: it does not assign `"default"`, does not inherit `settings.user_id`, and performs no user-scoped reads or writes at construction (no history preload, no follow-up session, no per-user cache/credential access). Private operations (intent shortcuts, cache lookup, greetings and other early returns, history, context, tool/action dispatch, streaming, completion recording) require an explicit validated identity â€” the bound constructor `user_id` or a per-request `active_user_id` â€” and fail closed with `rex.assistant_errors.IdentityRequiredError` otherwise. `user_id="default"` is a valid explicit profile selection only, never an automatic fallback. First-party single-user entrypoints resolve their profile outside `Assistant` via `rex.identity.resolve_entrypoint_user_id(settings, explicit_user=...)` and pass it to `Assistant(user_id=...)`.
 - Vault (`rex.credential_vault`) failures fail closed. Read paths return an absent credential only when the vault is unavailable; corrupt schema, metadata, scope, account, slot, owner, or reference data raises. Plaintext config/environment is consulted only when explicit legacy mode is enabled outside packaged Electron. Write paths propagate vault, readback, registry, and mirror failures so the GUI cannot report false success.
-- An Electron `ipcMain.handle` callback returning `{ ok: true, someList: buildX() }` where `buildX()` is `async` is a silent bug, not a type error: TypeScript happily infers the handler's return type around a nested `Promise`, but the renderer receives an unresolved promise instead of the array. `tsc --noEmit` will not catch this — grep every call site of a function you just made `async` and confirm each one added `await`, don't rely on the type checker alone.
+- An Electron `ipcMain.handle` callback returning `{ ok: true, someList: buildX() }` where `buildX()` is `async` is a silent bug, not a type error: TypeScript happily infers the handler's return type around a nested `Promise`, but the renderer receives an unresolved promise instead of the array. `tsc --noEmit` will not catch this â€” grep every call site of a function you just made `async` and confirm each one added `await`, don't rely on the type checker alone.
 
 ## OpenClaw Migration Status
 
@@ -726,4 +726,5 @@ The first two files are the product sources of truth. Other PRDs are supporting 
 - Pairing key possession is not strong authentication. Never stamp `strong_auth_at` during pairing/session activation.
 - S8 (`rex/mobile_api/strong_auth.py`, `routes/strong_auth.py`, `routes/home.py`): high/critical mobile actions require a short-lived P-256 device assertion bound to the exact canonical action hash, authenticated session/user, paired device, immutable grant/version, desktop ID, server-owned risk level, scope, nonce, and expiry. Verification issues a second short-lived approval ID that is consumed atomically once at the actual execution boundary. A recent biometric timestamp, client risk label, or reused approval never authorizes another action. Home Assistant mobile commands return `verified`, `attempted_unverified`, `denied`, or `failed` truthfully; approval consumption does not imply the action succeeded. Physical Face ID/passcode and iPhone integration remain mobile-repo/hardware gates.
 - S7 (`rex/mobile_api/tls.py`): any non-loopback mobile API bind always requires usable TLS; `mobile_api.require_tls` only opts a *loopback* bind into TLS for local testing and cannot weaken the non-loopback boundary. `MobileApiServices.build()` provisions or reuses one long-lived self-signed P-256 certificate under `<household_data_dir>/mobile_tls/` and fails closed with `MobileTlsConfigurationError` when material cannot be generated or loaded. The advertised HTTPS URL, SHA-256 certificate fingerprint, and SPKI pins are included in every pairing QR payload, signed by pairing proof transcript v2, returned by approved `/mobile/pairing/status`, and persisted immutably on device/grant records. `create_mobile_app()` independently refuses a TLS-required injected service container without material, and a TLS-owned app rejects plaintext requests with `TLS_REQUIRED`. `POST /mobile/auth/activate-device` fails closed (`PAIRING_INVALID`) when the current gateway-owned transport binding differs from the approved device/grant binding (rotated/reset certificate, changed endpoint, or a pre-S7 unbound legacy device). Loopback-only development remains unaffected unless explicitly opted into TLS. Actual client-side pin validation and physical LAN/phone hardware validation live in the separate mobile repo and are not implemented or exercised here.
+- US-088 public-ingress rule: `askrex.app` may front only the dedicated `rex.mobile_api` contract through an explicit path allowlist and loopback-only origin; never proxy `rex.gui_app`, `/api/*`, the computer agent, TTS service, OpenClaw tool server, secrets, or arbitrary localhost services. Current S7 self-signed LAN pinning must not be bypassed for a tunnel: public pairing stays disabled until a versioned `https://askrex.app` WebPKI transport-binding mode, trusted-proxy handling, deployment-appropriate rate limiting, and public-topology tests exist. OpenClaw remains optional and cannot widen mobile authority. See `docs/mobile/MOBILE_API_THREAT_MODEL.md`, `docs/mobile/EXTERNAL_SURFACE_CLASSIFICATION.md`, and `docs/mobile/ASKREX_APP_GATEWAY.md`.
 - See `docs/mobile/DEVICE_PAIRING.md`, `docs/mobile/STRONG_AUTH.md`, `docs/mobile/MOBILE_API_SETUP_WINDOWS.md`, `tests/mobile_api/test_pairing.py`, `tests/mobile_api/test_grant_enforcement.py`, `tests/mobile_api/test_strong_auth.py`, `tests/mobile_api/test_home_strong_auth.py`, `tests/mobile_api/test_tls.py`, and `tests/mobile_api/test_transport_binding.py`.

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -3154,19 +3154,19 @@ pytest -q tests/test_identity.py tests/test_us048_data_isolation.py tests/test_v
 > **Decomposition directive (skill-compliance):** This story is larger than one Ralph iteration. Before execution, split it into ordered one-iteration slices and run them in order: (a) commit the mobile/API threat model; (b) classify the existing Flask/API bridge as safe or unsafe for external/mobile use with evidence; (c) design the secure gateway (HTTPS, auth, rate limiting, CORS, token management/revocation) and define the iOS API scope; (d) document the Cloudflare-Tunnel-or-equivalent deployment path without committing credentials; (e) auth-rejection, rate-limit, and CORS-policy tests for mobile/API routes. Do not attempt the full bundle in one iteration.
 
 **Acceptance Criteria:**
-- [ ] A mobile/API threat model is committed.
-- [ ] Existing local Flask/API bridge is classified as safe or unsafe for external/mobile use with evidence.
-- [ ] Secure gateway design requires HTTPS, authentication, rate limiting, CORS policy, token management, and token revocation.
-- [ ] Cloudflare Tunnel or equivalent deployment path is documented without committing credentials.
-- [ ] API scope defines what the iOS app can and cannot do.
-- [ ] Local admin routes are not exposed blindly.
-- [ ] Tests or smoke checks cover auth rejection, rate-limit behavior, and CORS policy for mobile/API routes.
-- [ ] Docs use `askrex.app` as the target domain.
-- [ ] All relevant GitHub checks pass.
+- [x] A mobile/API threat model is committed.
+- [x] Existing local Flask/API bridge is classified as safe or unsafe for external/mobile use with evidence.
+- [x] Secure gateway design requires HTTPS, authentication, rate limiting, CORS policy, token management, and token revocation.
+- [x] Cloudflare Tunnel or equivalent deployment path is documented without committing credentials.
+- [x] API scope defines what the iOS app can and cannot do.
+- [x] Local admin routes are not exposed blindly.
+- [x] Tests or smoke checks cover auth rejection, rate-limit behavior, and CORS policy for mobile/API routes.
+- [x] Docs use `askrex.app` as the target domain.
+- [x] All relevant GitHub checks pass.
 
-- [ ] Mobile chat and voice consume the same canonical TurnEngine/event contract as desktop/CLI rather than a mobile-only intelligence path.
-- [ ] Existing desktop-owned pairing, live grants, revocation, TLS binding, strong authentication, rate limits, and least-privilege scopes remain enforced.
-- [ ] OpenClaw remains optional; its absence or unhealthy state grants no additional mobile authority and does not disable core Rex functionality.
+- [x] Mobile chat and voice consume the same canonical TurnEngine/event contract as desktop/CLI rather than a mobile-only intelligence path.
+- [x] Existing desktop-owned pairing, live grants, revocation, TLS binding, strong authentication, rate limits, and least-privilege scopes remain enforced.
+- [x] OpenClaw remains optional; its absence or unhealthy state grants no additional mobile authority and does not disable core Rex functionality.
 
 **Validation commands:**
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,6 +20,14 @@ atomically sanitizing plaintext sources; it creates no plaintext backup and
 emits no secret-derived preview, length, or hash. See
 [docs/credentials.md](docs/credentials.md).
 
+## Mobile and public API boundary
+
+The future `https://askrex.app` hostname is **not** permission to expose the existing local Flask/admin services. Public/mobile ingress may target only the dedicated `rex.mobile_api` `/mobile/*` contract through a path allowlist and loopback-only origin. `rex.gui_app`, the computer agent, TTS service, OpenClaw tool server, credentials, logs, and admin/configuration routes remain non-public trust zones.
+
+Current paired LAN access uses desktop-owned S7 certificate fingerprint/SPKI binding. A tunnel terminating WebPKI TLS at an external edge must not disable or fake that control; public pairing stays gated until the versioned public transport-binding design is implemented and tested. See `docs/mobile/MOBILE_API_THREAT_MODEL.md` and `docs/mobile/ASKREX_APP_GATEWAY.md`.
+
+Tunnel/API credentials must never be committed. The reference deployment in `docs/mobile/CLOUDFLARE_TUNNEL.md` uses placeholders only and keeps provider credential files outside the repository.
+
 ## Reporting a vulnerability
 
 If you discover a security issue in AskRex Assistant, please do **not** open a public GitHub issue with exploit details.

--- a/docs/api.md
+++ b/docs/api.md
@@ -228,6 +228,14 @@ Routes defined directly in the file:
 
 Auth is based on Cloudflare Access email, `Authorization: Bearer <REX_PROXY_TOKEN>`, `X-Rex-Proxy-Token`, or loopback when `REX_PROXY_ALLOW_LOCAL=1`.
 
+## External mobile API (`askrex.app`)
+
+`rex-gui` and the other local HTTP services above are **not** the public mobile API. The only eligible external/mobile origin is the dedicated `rex.mobile_api` application and its `/mobile/*` contract.
+
+The planned public hostname is `https://askrex.app`. Public ingress remains gated: current S7 LAN pairing pins Rex-owned certificate material, while an external tunnel presents a different WebPKI certificate. Do not bypass that binding or proxy local `/api/*`, `/rex/tools/*`, `/run`, `/speak`, or GUI/admin surfaces.
+
+See `docs/mobile/MOBILE_API_THREAT_MODEL.md`, `docs/mobile/EXTERNAL_SURFACE_CLASSIFICATION.md`, `docs/mobile/ASKREX_APP_GATEWAY.md`, and `docs/mobile/CLOUDFLARE_TUNNEL.md`.
+
 ## Error Envelope
 
 Shared error helpers return a structured envelope:

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2053,3 +2053,26 @@ Remote exact-head evidence:
 - Windows Electron Artifact workflow run 31838356744 completed success, including managed runtime/installer build, Authenticode truthfulness, packaged-resource rejection, and installed-artifact smoke without machine Python or Node.
 - CodeFactor reported No issues found; GitGuardian reported no secrets detected. No failed/cancelled/in-progress exact-head check remained.
 - US-112 acceptance criteria are therefore closed. The docs-only closure head must pass its own exact-head repository checks before PR #398 is merged.
+
+
+2026-08-14 - US-088 authenticated askrex.app mobile/API boundary closure
+
+Implementation and local evidence:
+- Added and committed a mobile/API threat model plus evidence-based external-surface classification; only the dedicated rex.mobile_api contract is eligible for public ingress. Local admin, rex.gui_app /api routes, computer-control, TTS, OpenClaw tool-server, secret-management, and arbitrary localhost routes remain excluded.
+- Secure gateway design requires public HTTPS/WebPKI transport binding, authentication, server-side live grants and revocation, strong authentication for elevated actions, rate limiting, deny-by-default CORS, trusted-proxy handling, body/media bounds, idempotency, and privacy-safe logging.
+- Documented askrex.app Cloudflare Tunnel path allowlisting without credentials. Local cloudflared 2025.4.0 ingress validation confirmed /mobile/* routes to 127.0.0.1:8765 while /api/* falls through to http_status:404.
+- Mobile chat/stream continue through the canonical Assistant/TurnEngine contract with TurnSource.MOBILE. Existing pairing, live grant/version checks, revocation, TLS binding, strong-auth approval, least-privilege scope mapping, and per-user authorization remain server-derived and fail closed.
+- Dynamic OpenClaw tools remain denied from gaining mobile scope by default; OpenClaw is optional and does not widen authority or disable core Rex when absent.
+- Added external-gateway policy tests covering route allowlisting, auth rejection, deny-by-default/wildcard-rejecting CORS, canonical rate limiting, mobile TurnSource contract, OpenClaw scope denial, and required deployment/security documentation.
+- Full tests/mobile_api suite passed. Related Windows-agent/OpenClaw-tool-server/chat API regression passed.
+- Full Windows primary marker suite: 8,811 passed / 49 skipped / 0 failed in 479.11s.
+- Ruff, Black, mypy, compileall/security release gate, docs truth checks, pre-commit, and git diff checks passed for the US-088 branch.
+
+Remote exact-head evidence:
+- PR #399 implementation head 04dcee661002064b9da544f04b19c04fab45331b passed all 17 registered checks.
+- CI workflow run 31861029255 completed success, including Python 3.11 Tests & Coverage, skipped-test budget, integration tests, tracked-tree cleanliness, security/lint/type/GUI/dependency/pre-commit/wheel/raw-API checks.
+- Commitlint workflow run 31861029276 completed success.
+- CodeFactor reported No issues found and GitGuardian reported No secrets detected.
+- No failed, cancelled, or in-progress exact-head check remained and PR #399 had no review or review-thread blocker.
+- Windows Electron Artifact was not path-triggered for this docs/mobile-policy-test-only story and was not a relevant required check.
+- US-088 acceptance criteria are therefore closed. This documentation closure head must still pass its own exact-head relevant checks before PR #399 is merged.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -266,6 +266,12 @@ docker run --rm --env-file .env -p 5005:5005 \
   -it askrex-assistant rex-speak-api
 ```
 
+## External mobile access (`askrex.app`)
+
+Do **not** expose `rex-gui`, `rex-agent`, `rex-speak-api`, or `rex-tool-server` as the mobile backend. The planned public hostname `https://askrex.app` may front only a loopback-bound `rex.mobile_api` origin through an explicit `/mobile/*` path allowlist.
+
+A Cloudflare Tunnel reference is documented in `docs/mobile/CLOUDFLARE_TUNNEL.md`. It uses placeholder tunnel identifiers/credential-file paths only; generated Cloudflare credentials stay outside this repository. The public deployment gate remains closed until the versioned WebPKI transport-binding, trusted-proxy/rate-limit, and public-topology tests in `docs/mobile/ASKREX_APP_GATEWAY.md` are implemented.
+
 ## Security Notes
 
 - Keep services bound to localhost unless you have a reverse proxy and auth.

--- a/docs/mobile/ASKREX_APP_GATEWAY.md
+++ b/docs/mobile/ASKREX_APP_GATEWAY.md
@@ -1,0 +1,106 @@
+# `askrex.app` Secure Mobile Gateway Design
+
+Status: US-088 slice C design; public ingress gate is **closed**
+Date: 2026-08-14
+Target origin: `https://askrex.app`
+
+## 1. Design decision
+
+`askrex.app` may expose only the dedicated AskRex mobile API contract. It must never proxy the Electron/developer Flask API, computer agent, TTS service, OpenClaw tool server, credential surfaces, or arbitrary localhost ports.
+
+The desktop origin remains loopback-only for the public topology. Public HTTPS is terminated by an authenticated reverse-proxy/tunnel layer; no inbound Internet firewall port is opened to Flask.
+
+This design does not make the current Flask development server production-ready. The public gate remains closed until the transport-binding, trusted-proxy/rate-limit, ingress-route, and deployment tests listed below are implemented.
+## 2. Required request path
+
+```text
+iOS app
+  -> HTTPS + normal platform certificate validation for askrex.app
+  -> public edge/tunnel
+  -> authenticated/private connector
+  -> 127.0.0.1:<mobile-port>
+  -> rex.mobile_api only
+  -> canonical Assistant / TurnEngine / policy / verification
+```
+
+The ingress rule must be path-allowlisted to the supported `/mobile/*` contract and return a hard deny for any `/api/*`, `/rex/tools/*`, `/run`, `/speak`, `/ui/*`, or other local-service path. A catch-all localhost reverse proxy is prohibited.
+
+WebSocket upgrades are permitted only for the authenticated mobile chat endpoint and retain first-frame `auth`, session/grant validation, message-rate limits, and cross-transport idempotency.
+## 3. Authentication and token requirements
+
+- Access JWTs remain short-lived (15-minute default), fixed-algorithm, issuer/audience validated, and bound to a live server-side mobile session.
+- Refresh tokens remain opaque, high-entropy, hash-only at rest, rotate on every use, and revoke their family/session on reuse.
+- Every authenticated request re-resolves the active user, paired device, current immutable grant/version, scopes, and live Rex permissions; token/client display claims cannot authorize.
+- Device revocation, grant expiry/supersession, logout, disabled users, or refresh reuse must invalidate otherwise-unexpired access.
+- Password login remains bootstrap-only. Capability-bearing sessions require the desktop-approved P-256 device/grant activation flow.
+- High/critical actions keep S8 exact-action strong authentication and single-use approval consumption at the execution boundary.
+
+`askrex.app` does not introduce a separate cloud user database, permission model, API key, or assistant identity. Canonical desktop Rex state remains authoritative.
+## 4. HTTPS and transport binding
+
+Current S7 LAN pairing binds a desktop-owned HTTPS URL, leaf-certificate fingerprint, and SPKI pin. `PairingAuthority` fails closed when that binding is absent or incomplete, and device-session activation rechecks the stored binding.
+
+A public tunnel presents the edge provider's certificate to iOS rather than Rex's local S7 certificate. Therefore **the existing S7 pin record must not be reused or bypassed for `askrex.app`**.
+
+Before public pairing is enabled, Rex needs a versioned public transport-binding contract that:
+
+1. binds the exact canonical server URL `https://askrex.app` into pairing/device/grant/session activation;
+2. uses normal iOS WebPKI hostname/certificate validation at the public edge;
+3. identifies the binding mode separately from the current self-signed LAN fingerprint/SPKI mode;
+4. fails closed if the configured public hostname/mode changes and requires explicit re-pair/migration;
+5. never accepts an arbitrary client-supplied public URL as authority.
+
+Until that contract is implemented and tested, a loopback/tunnel deployment is documentation-only and must not be advertised as a usable production pairing path.
+## 5. Rate limiting, proxy trust, and body limits
+
+All current mobile route limits and JSON/audio bounds remain mandatory. Public/multi-process operation additionally requires shared limiter storage; the current `memory://` limiter is not sufficient for horizontally scaled or multi-worker Internet service.
+
+Client-address derivation must be explicit. Only a configured trusted local connector/reverse proxy may supply forwarded client-address metadata. Direct callers cannot choose their own rate-limit identity by sending `X-Forwarded-For` or equivalent headers.
+
+Authentication endpoints require stricter buckets than ordinary reads/chat. Voice/TTS must be limited before expensive decode/model/synthesis work. WebSocket connection attempts and messages remain bounded independently.
+
+## 6. CORS
+
+Native iOS traffic does not require permissive CORS. The default remains no browser origins. If a future first-party web client is introduced, its exact HTTPS origin must be allowlisted; wildcard `*`, credentials-based broad CORS, reflected arbitrary origins, and HTTP production origins are prohibited.
+## 7. iOS API scope
+
+The public iOS contract is allowlist-based. Implemented/currently eligible functions are:
+
+| Capability | Public mobile operation | Authority |
+|---|---|---|
+| Health/capability discovery | `/mobile/status`, `/mobile/capabilities` | Minimal non-sensitive public response only. |
+| Bootstrap/session | login, pairing submission/status, device challenge/activation, refresh, current session, logout/logout-all | Server credentials plus desktop-owned pairing/grant state; no client identity authority. |
+| Text chat | authenticated `/mobile/chat`, SSE and WebSocket chat | `chat.send` grant scope, live session/grant, canonical Assistant/TurnEngine. |
+| Voice/TTS | authenticated `/mobile/voice/upload`, `/mobile/tts/playback` | `voice.use` scope; voice transcript re-enters canonical Assistant/TurnEngine. |
+| Home state | authenticated `/mobile/home/entities` | `home.read` scope plus current `ha_control` or admin permission. |
+| Home mutation | `/mobile/home/command` | `home.control` + live permission + exact-action S8 strong authentication + canonical verification. |
+| Strong authentication | challenge/verify endpoints | Existing paired session/grant; proof never equals action success. |
+Explicitly **not public-authorized by default**:
+
+- Electron/developer `/api/*` routes, setup/admin permission management, logs, history administration, and integration credential configuration;
+- arbitrary filesystem/shell/computer commands or desktop agent routes;
+- direct TTS-service or OpenClaw tool-server access;
+- email, calendar, SMS, secrets/credential management, diagnostics, or arbitrary plugin/OpenClaw capabilities;
+- any scaffold merely because a route name exists.
+
+Adding a public mobile capability requires a server-owned scope mapping, current Rex permission mapping where applicable, risk/strong-auth decision, verification semantics, privacy review, and explicit tests. Remote metadata or a mobile app update cannot widen the server allowlist.
+
+## 8. OpenClaw boundary
+
+OpenClaw is an optional capability provider behind Rex. `askrex.app` never proxies the OpenClaw gateway/tool server directly. When OpenClaw is absent or unhealthy, core mobile chat/voice/local Rex functions continue according to their own provider availability, and no mobile authority is broadened to compensate.
+## 9. Public-ingress release gate
+
+`askrex.app` remains disabled until all of the following are true:
+
+- a versioned public/WebPKI transport-binding mode is implemented and paired-device migration/re-pair behavior is tested;
+- only the dedicated loopback mobile origin is reachable from the tunnel and ingress routing rejects non-mobile/admin paths;
+- public HTTPS and WebSocket upgrade behavior are verified end to end;
+- trusted-proxy handling is explicit and cannot be spoofed by direct requests;
+- rate limiting uses deployment-appropriate shared state or the deployment is provably one process with an equivalent enforced limit;
+- CORS remains deny-by-default with any browser origin explicitly enumerated;
+- access/refresh/session/device-grant revocation tests pass through the public topology;
+- strong-auth and truthful action verification remain intact for remotely reachable mutations;
+- logs/diagnostics expose no credentials or private request/response content;
+- iOS client contract tests and the required physical-device smoke are recorded truthfully.
+
+Slice D documents a concrete tunnel/reverse-proxy procedure without credentials. Slice E formalizes the authentication-rejection, rate-limit, CORS, and external-route safety tests.

--- a/docs/mobile/CLOUDFLARE_TUNNEL.md
+++ b/docs/mobile/CLOUDFLARE_TUNNEL.md
@@ -1,0 +1,80 @@
+# `askrex.app` Cloudflare Tunnel Reference
+
+Status: US-088 slice D deployment reference; **do not activate production public pairing yet**
+Verified against current Cloudflare Tunnel documentation: 2026-08-14
+
+This document shows the intended outbound-tunnel shape without storing a tunnel token, account certificate, API token, UUID credential JSON, or any other secret in the repository.
+
+The US-088 public-ingress gate in `ASKREX_APP_GATEWAY.md` remains authoritative. In particular, current S7 LAN certificate/SPKI pinning cannot simply be replaced by an externally terminated tunnel certificate.
+
+## 1. Preconditions
+
+- `askrex.app` is managed in the chosen DNS/tunnel provider.
+- `cloudflared` is installed on the AskRex desktop.
+- The dedicated mobile gateway is configured to bind **loopback only** for this topology, for example `127.0.0.1:8765`.
+- No Electron/developer API, tool server, TTS API, computer agent, or other localhost service is bound to the tunnel hostname.
+## 2. Create a locally managed tunnel
+
+Run these interactively on the desktop; do not paste generated credentials into the repo:
+
+```powershell
+cloudflared tunnel login
+cloudflared tunnel create askrex-mobile
+cloudflared tunnel list
+```
+
+Cloudflare writes the locally managed tunnel credential JSON outside this repository (normally under the user's `.cloudflared` directory). Treat that file like a secret. Do not copy it into `config/`, `.env`, documentation, logs, screenshots, or commits.
+
+Create the DNS route only when the public-ingress release gate is intentionally being exercised:
+
+```powershell
+cloudflared tunnel route dns askrex-mobile askrex.app
+```
+## 3. Path-allowlisted configuration
+
+Create a local `cloudflared` configuration **outside the AskRex repository**. Replace placeholders only on the machine that owns the tunnel:
+
+```yaml
+tunnel: <TUNNEL_UUID>
+credentials-file: "C:/Users/<WINDOWS_USER>/.cloudflared/<TUNNEL_UUID>.json"
+
+ingress:
+  - hostname: askrex.app
+    path: ^/mobile/.*
+    service: http://127.0.0.1:8765
+  - service: http_status:404
+```
+
+The final catch-all is mandatory. Do not add a second `askrex.app` rule without a path, because that would turn the hostname into a general localhost reverse proxy. Do not map `/api/*`, `/rex/tools/*`, `/run`, `/speak`, `/ui/*`, or another service port.
+## 4. Validate routing before run
+
+Cloudflare provides local ingress validation and rule-matching commands. Use both before starting a connector:
+
+```powershell
+cloudflared tunnel ingress validate
+cloudflared tunnel ingress rule https://askrex.app/mobile/status
+cloudflared tunnel ingress rule https://askrex.app/mobile/chat
+cloudflared tunnel ingress rule https://askrex.app/api/status
+cloudflared tunnel ingress rule https://askrex.app/rex/tools/time_now
+```
+
+The two `/mobile/*` examples must match the mobile-origin rule. The `/api/*` and `/rex/tools/*` examples must match the final 404 rule.
+
+Only after the US-088 public transport-binding and other release gates are implemented may the connector be started for a public validation run:
+
+```powershell
+cloudflared tunnel run askrex-mobile
+```
+
+A remotely managed tunnel is an acceptable equivalent, but its token is a credential and must remain in Cloudflare/service configuration rather than the AskRex repo or command examples.
+## 5. Security requirements after the tunnel
+
+The tunnel provides transport/routing, not Rex authorization. The origin must still enforce mobile JWT/session/grant revocation, current Rex permissions, S8 strong authentication, idempotency, payload bounds, CORS, rate limits, and truthful action verification.
+
+For Internet deployment, forwarded client-address handling must trust only the local connector/reverse-proxy hop. Do not accept arbitrary client-supplied forwarding headers. Public/multi-worker service also requires deployment-appropriate shared rate-limit state rather than treating the current in-memory limiter as horizontally safe.
+
+Cloudflare's edge certificate is not the desktop-owned S7 LAN certificate. Do not disable or fake the pairing transport-binding check to make the tunnel work. Public pairing stays off until the versioned WebPKI transport-binding contract in `ASKREX_APP_GATEWAY.md` is implemented and tested.
+
+## 6. Rollback
+
+Stopping `cloudflared` removes the outbound connector without requiring an inbound firewall change. Remove or disable the published DNS/tunnel route when testing ends. Revoking a tunnel credential does not replace Rex-side session/device-grant revocation; use both controls when compromise is suspected.

--- a/docs/mobile/EXTERNAL_SURFACE_CLASSIFICATION.md
+++ b/docs/mobile/EXTERNAL_SURFACE_CLASSIFICATION.md
@@ -1,0 +1,43 @@
+# AskRex External Surface Classification
+
+Status: US-088 slice B evidence classification
+Date: 2026-08-14
+
+## Decision
+
+The existing developer Flask/API bridge (`rex.gui_app`) is **unsafe and not approved for external/mobile exposure**. It remains a loopback developer/local surface.
+
+The dedicated `rex.mobile_api.create_mobile_app()` gateway is the **only eligible mobile/public API origin**, because it owns the mobile authentication, pairing/grant, revocation, scope, strong-auth, CORS, rate-limit, idempotency, TLS, and canonical Assistant boundaries. Its current approved remote topology is paired TLS LAN; direct Internet exposure is still prohibited until later US-088 slices complete the public `askrex.app` gateway design and deployment gate.
+
+## Evidence: `rex.gui_app`
+
+`rex.gui_app.main()` binds to `127.0.0.1` and explicitly describes the Flask/API surface as an incomplete standalone experience. Its registered `/api/*` blueprints include auth/setup, logs, users/admin permissions, Home Assistant configuration/control, quick actions, history, integrations, status, and chat.
+Its `/api/auth/login` issues the legacy `rex.auth.authenticate()` token: a signed JWT valid for 24 hours with `sub`, username, `iat`, and `exp`. The legacy `/api/auth/logout` is explicitly stateless and does not revoke the token/session server-side. `_require_auth()` validates only that JWT and does not resolve mobile paired-device grants, grant versions, scope intersection, refresh-family revocation, or S8 action-bound strong authentication.
+
+`rex.gui_app` also does not install the mobile gateway's deny-by-default CORS policy, route-specific Flask-Limiter controls, mobile request/body limits, mobile TLS ownership check, or mobile error/session middleware.
+
+Examples of sensitive/local routes on this surface include:
+
+- `/api/admin/permissions/grant` and `/api/admin/permissions/revoke`;
+- `/api/ha/save`, which persists the Home Assistant URL/token;
+- `/api/devices/<entity_id>/command` and quick-action mutation routes;
+- `/api/logs/stream` and `/api/logs/download`;
+- `/api/history` and user preference/avatar surfaces;
+- setup/registration routes and integration configuration/status routes.
+
+Some local information routes, including `/api/devices` and `/api/ha/states`, do not use the mobile authentication boundary at all. This is acceptable only within the documented local/developer trust model and is further evidence that the app must not be placed behind `askrex.app`.
+## Other active HTTP service surfaces
+
+| Surface | Classification for `askrex.app` | Evidence / reason |
+|---|---|---|
+| `rex.mobile_api` | **Eligible origin, public deployment still gated** | Dedicated `/mobile/*` app; server-derived identity; paired grants; live permissions; refresh/session revocation; strong auth; CORS/rate limits/idempotency/TLS; canonical Assistant/TurnEngine. |
+| `rex.gui_app` | **Do not expose** | Developer/local `/api/*` surface with legacy stateless auth and admin/config/log/device routes; not the mobile trust model. |
+| `rex_speak_api` | **Do not expose** | Local TTS service bound to `127.0.0.1`; service-level API key rather than per-user mobile grants; also registers HA and shopping surfaces. Mobile TTS already has a narrower authenticated `/mobile/tts/playback` adapter. |
+| `rex.computers.agent_server` | **Do not expose** | Executes server-allowlisted OS commands. It defaults to loopback and a static service token; it is desktop/device infrastructure, not an iOS grant/strong-auth surface. |
+| `rex.openclaw.tool_server` | **Do not expose** | Invokes Rex/OpenClaw tools using a service API key and local policy adapter. It defaults to loopback and is not scoped through mobile device grants. Dynamic OpenClaw tools are mobile-denied by default. |
+
+Authentication on an internal service is not sufficient to make it a mobile/public API. Each surface has a different principal model, authority scope, and failure impact; reverse-proxying them together would collapse those trust boundaries.
+
+## Required ingress rule
+
+A future `askrex.app` deployment may forward only the dedicated mobile gateway routes required by the published iOS API scope. It must never use a catch-all origin that also reaches `/api/*`, `/rex/tools/*`, `/run`, `/speak`, local GUI content, credential-management endpoints, or other desktop services.

--- a/docs/mobile/MOBILE_API_TEST_MATRIX.md
+++ b/docs/mobile/MOBILE_API_TEST_MATRIX.md
@@ -342,3 +342,17 @@ npx expo-doctor
 ```
 
 Add real unit/contract/export scripts before claiming those gates pass. After every validation run, confirm the Git working tree contains only intentional changes.
+
+## US-088 External Gateway Policy
+
+`tests/mobile_api/test_external_gateway_policy.py` is the regression gate for the future `askrex.app` boundary. It proves that:
+
+- the dedicated mobile Flask app registers only `/mobile/*` routes and does not expose local `/api/*`, tool, TTS, agent, or GUI paths;
+- protected mobile routes reject missing bearer authentication;
+- wildcard CORS remains invalid and an exact `https://askrex.app` origin can be allowlisted without reflecting other origins;
+- the public-facing limiter returns the canonical 429 envelope and `Retry-After`;
+- loopback origin without a secure transport binding cannot create a pairing challenge;
+- dynamic/OpenClaw capability metadata cannot manufacture a mobile grant scope;
+- the committed public-gateway documentation keeps `askrex.app`, Cloudflare Tunnel, CORS, rate limiting, revocation, and the closed public-ingress gate explicit.
+
+These tests do not declare the public tunnel production-ready. They enforce the fail-closed boundary while `ASKREX_APP_GATEWAY.md` lists the remaining public transport-binding/deployment gates.

--- a/docs/mobile/MOBILE_API_THREAT_MODEL.md
+++ b/docs/mobile/MOBILE_API_THREAT_MODEL.md
@@ -1,0 +1,101 @@
+# AskRex Mobile/API Threat Model
+
+Status: current-state security baseline for US-088 slice A
+Date: 2026-08-14
+Target public hostname: `askrex.app` (design target only; not an implicit live deployment)
+
+## 1. Security objective
+
+The mobile gateway lets an authenticated iOS/mobile client use the canonical Rex runtime without exposing desktop-admin authority or creating a weaker parallel assistant. External access must preserve Rex identity, permissions, action verification, user isolation, and truthful result semantics.
+
+The current supported remote topology is the S5-S8 desktop-paired mobile gateway on a TLS-protected LAN endpoint. A future `askrex.app` path is a separate public deployment profile and must remain gated until its reverse-proxy/tunnel and transport-binding requirements are implemented and verified.
+
+## 2. System and trust boundaries
+
+The public/mobile security boundary is `rex.mobile_api.create_mobile_app()`, a dedicated Flask application that registers only `/mobile/*` routes. It is separate from the Electron GUI, `rex.gui_app`, the computer agent, TTS service, OpenClaw tool server, and other local/developer/admin surfaces.
+
+Mobile chat and voice are transport adapters, not a second intelligence path. They pass validated identity and device provenance into `MobileChatService`, which enters the canonical `Assistant.generate_reply()` / `Assistant.stream_reply()` TurnEngine path under `TurnSource.MOBILE`.
+## 3. Protected assets
+
+- Canonical Rex user identities, profiles, permissions, and private per-user state.
+- Conversation history, memory, context caches, transcripts, and voice content.
+- Mobile access JWTs, opaque refresh tokens, sessions, device grants, and revocation state.
+- P-256 device public-key bindings, challenge/nonce state, strong-auth approvals, and audit records.
+- Household credential-vault entries, especially `REX_JWT_SECRET` and integration credentials.
+- Home Assistant and other action authority, including confirmation and independent verification state.
+- Desktop-owned TLS private key, certificate fingerprint, SPKI pins, and paired transport binding.
+- Cross-transport idempotency records that prevent duplicate tool/action execution.
+
+## 4. Threat actors and failure assumptions
+
+This model assumes hostile Internet traffic once `askrex.app` exists, not merely trusted LAN clients. Relevant actors include an unauthenticated remote attacker, a malicious browser origin, a stolen bearer/refresh token holder, a compromised or modified mobile client, a local-network attacker, and a malicious or compromised optional external capability provider.
+
+The reverse proxy/tunnel and DNS/edge account are also trusted infrastructure whose compromise can affect availability or transport routing. They are not allowed to become Rex authorization authorities.
+## 5. Trust and authorization invariants
+
+1. Server-validated credentials establish the principal. Client `user_id`, role, permission, risk, approval, biometric, capability tags, or decoded JWT display claims never grant authority.
+2. Password login is bootstrap-only. Mobile capability access requires an active desktop-approved device/grant binding.
+3. Device scopes only restrict authority. Current Rex user permissions are resolved server-side and must also allow the action.
+4. Revoked, expired, superseded, cross-user, cross-desktop, malformed, or partially bound grants fail closed; revocation/supersession also invalidates bound sessions and refresh families.
+5. High/critical actions require a fresh server-owned strong-auth challenge bound to the exact canonical action and a separate short-lived single-use approval at execution time.
+6. A successful authentication/approval check is not action-success evidence. Mutations retain canonical attempted/completed/verified/failed semantics and require independent verification to reach `verified`.
+7. New or dynamic tools are unavailable to mobile until an explicit mobile scope mapping and enforcement test exists. Descriptive capability metadata cannot widen authority.
+8. OpenClaw remains optional. Its health, absence, or remote metadata can never grant additional mobile authority or bypass Rex policy/verification.
+## 6. Threats and required controls
+
+| Threat | Required control / current evidence |
+|---|---|
+| Public exposure of desktop/admin surfaces | Public routing may target only the dedicated mobile gateway. Electron/admin, `rex.gui_app`, computer-control, secret-management, TTS-service, and OpenClaw tool-server routes are separate trust zones and must not be forwarded by the public mobile hostname. |
+| Plaintext/MITM | Current S7 requires in-process TLS for every non-loopback bind and pairs against the advertised HTTPS URL, certificate fingerprint, and SPKI pins. A future `askrex.app` edge must require public HTTPS; no direct plaintext Internet listener is permitted. |
+| Credential theft/replay | Access JWTs are short-lived and session-bound; refresh tokens are high-entropy, hash-only at rest, rotating, and family-revocable. Every authenticated request validates current session/user/grant state. |
+| Authorization escalation | Authorization is the intersection of the immutable current device grant and live Rex permissions. Client claims and capability tags are non-authoritative. Unknown tools fail closed. |
+| Pairing takeover | Initial enrollment is desktop-owned, P-256 signed, nonce/challenge bound, short-lived, single-use, and locally approved; the mobile HTTP API cannot create or approve its own grant. |
+| Risky-action replay/substitution | S8 challenges bind exact action hash, server risk, scope, session/user/device/grant/version/desktop identity, nonce, and expiry; resulting approval IDs are distinct, short-lived, and single-use. |
+| Duplicate tool execution | HTTP/SSE/WebSocket share server-side `(user_id, message_id)` idempotency before acknowledgement/execution. |
+| Cross-user leakage | Canonical user IDs are validated before private access and passed explicitly to the shared Assistant; no mutable process-global user authority is used. |
+| Brute force / resource exhaustion | Authentication, refresh, chat, voice, WebSocket, and default routes require rate limits and body/media bounds. The current in-memory limiter is single-process only; public/multi-process deployment requires shared limiter state before being called Internet-ready. |
+| Browser drive-by / hostile origin | Mobile CORS is deny-by-default; wildcard `*` is rejected by `MobileApiConfig`. Native mobile clients do not require permissive browser CORS. |
+| Proxy/client-IP spoofing | A public reverse proxy may supply forwarded addresses only through an explicit trusted-proxy configuration. The origin must not trust arbitrary `X-Forwarded-For` headers from direct clients. |
+| Token/content leakage | Access/refresh tokens never belong in URLs; request logging omits bodies. Passwords, chat text, transcripts, TTS text/audio, signatures, and private action bodies must not enter normal logs or diagnostics. |
+| Tunnel/DNS route drift | Public ingress must use an explicit route allowlist to the mobile origin only. A configuration change that would expose another local service is a security change requiring review, not an automatic capability expansion. |
+| Optional provider compromise | External/OpenClaw capabilities remain behind Rex's canonical registry, policy, mobile scope mapping, and verification. Current mobile code denies dynamic OpenClaw tools by default. |
+
+## 7. Network deployment states
+
+**Loopback development:** `127.0.0.1` may use HTTP unless local TLS is explicitly requested. It is not remote access.
+
+**Paired LAN:** any non-loopback bind is HTTPS-only with desktop-owned S7 certificate material. Pairing binds the endpoint and pins. This is the current supported remote topology.
+
+**Public `askrex.app`:** not yet a supported direct-server mode. The intended future topology is an authenticated reverse proxy/tunnel terminating public HTTPS and forwarding only `/mobile/*` to a loopback-only mobile gateway origin. The desktop must not open the Flask development server or any admin service directly to the Internet.
+Public deployment introduces a different transport identity from S7 LAN pinning. Existing pairing records bind an advertised endpoint/fingerprint/SPKI set owned by the gateway. A tunnel terminating TLS at an external edge must therefore not be described as deployable until the public-origin binding and re-pair/migration behavior is explicitly designed and tested. Slice C/D of US-088 owns that gateway design and deployment gate.
+
+## 8. Current iOS/mobile authority surface
+
+Currently authorized mobile capability scopes are deliberately narrow:
+
+- `chat.send`: HTTP, SSE, and WebSocket chat through canonical Assistant/TurnEngine.
+- `voice.use`: authenticated audio upload/STT/canonical Assistant response and protected TTS.
+- `home.control`: structured Home Assistant mutations only, requiring live user permission and S8 action-bound strong authentication.
+- Reserved future scopes include `home.read`, `tasks.read`, `tasks.write`, and `approvals.respond`; a route is not enabled merely because a scope name exists.
+
+Email, calendar, SMS, shell, filesystem, diagnostics, arbitrary computer control, credential/secret management, dynamic OpenClaw tools, and future unknown tools are not mobile-authorized by default.
+
+## 9. Residual and unverified risk
+
+- Physical iPhone validation of certificate/pin enforcement, SecureStore/device-key behavior, Face ID/passcode orchestration, and real network transitions remains a mobile-repository/hardware gate.
+- The Flask development server and in-memory limiter are not a production public serving stack.
+- `askrex.app` public ingress, trusted-proxy handling, external transport binding, and shared rate-limit storage are not yet implemented/verified by Slice A.
+- Availability of cloud/local LLM, STT, TTS, Home Assistant, or OpenClaw does not weaken authorization; unavailable dependencies must fail truthfully.
+## 10. Evidence and verification references
+
+Current security behavior is grounded in:
+
+- `rex/mobile_api/app.py`: dedicated `/mobile/*` application, deny-by-default CORS, limits, TLS ownership, privacy-safe middleware.
+- `rex/mobile_api/auth.py`, `authorization.py`, `sessions.py`, and `grants.py`: server-derived identity, live session/grant/permission authority, refresh rotation/revocation.
+- `rex/mobile_api/pairing.py`, `device_proof.py`, and `strong_auth.py`: desktop-owned P-256 pairing and exact-action strong authentication.
+- `rex/mobile_api/chat.py` and `routes/voice.py`: explicit identity and `TurnSource.MOBILE` into canonical Assistant/TurnEngine for text and voice.
+- `rex/mobile_api/action_context.py`: explicit mobile tool allowlisting; dynamic/unknown/OpenClaw tools fail closed.
+- `rex/mobile_api/tls.py`: mandatory TLS for non-loopback binds and persistent pairing transport identity.
+- `tests/mobile_api/`: authentication, revocation, grants, CORS, rate limits, transport binding, strong-auth, idempotency, chat, voice, and user-isolation coverage.
+
+This threat model is a security baseline, not evidence that `askrex.app` is already deployed. Subsequent US-088 slices must classify legacy/local Flask surfaces, define the public gateway and iOS scope, document the tunnel path, and formalize external-boundary tests before the story can close.

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -7,9 +7,10 @@ Read in this order:
 1. [MOBILE_API_MASTER_SPEC.md](MOBILE_API_MASTER_SPEC.md) — canonical wire and security contract.
 2. [MOBILE_API_THREAT_MODEL.md](MOBILE_API_THREAT_MODEL.md) — current external/mobile trust boundaries and the gated `askrex.app` threat model.
 3. [EXTERNAL_SURFACE_CLASSIFICATION.md](EXTERNAL_SURFACE_CLASSIFICATION.md) — evidence-based classification of which local services may or may not sit behind public mobile ingress.
-4. [MOBILE_CLIENT_CONTRACT_AUDIT.md](MOBILE_CLIENT_CONTRACT_AUDIT.md) — cross-repository findings and resolved conflicts.
-5. [MOBILE_API_ARCHITECTURE.md](MOBILE_API_ARCHITECTURE.md) — component, data, identity, idempotency, voice, and deployment architecture.
-6. [MOBILE_API_IMPLEMENTATION_PLAN.md](MOBILE_API_IMPLEMENTATION_PLAN.md) — implementation history and workstream plan.
-7. [MOBILE_API_TEST_MATRIX.md](MOBILE_API_TEST_MATRIX.md) — required automated and real-device validation.
+4. [ASKREX_APP_GATEWAY.md](ASKREX_APP_GATEWAY.md) — secure public-gateway design, transport-binding gate, and explicit iOS API scope.
+5. [MOBILE_CLIENT_CONTRACT_AUDIT.md](MOBILE_CLIENT_CONTRACT_AUDIT.md) — cross-repository findings and resolved conflicts.
+6. [MOBILE_API_ARCHITECTURE.md](MOBILE_API_ARCHITECTURE.md) — component, data, identity, idempotency, voice, and deployment architecture.
+7. [MOBILE_API_IMPLEMENTATION_PLAN.md](MOBILE_API_IMPLEMENTATION_PLAN.md) — implementation history and workstream plan.
+8. [MOBILE_API_TEST_MATRIX.md](MOBILE_API_TEST_MATRIX.md) — required automated and real-device validation.
 
 The threat model reflects the current S5-S8 desktop/server security boundary. It does **not** claim that the future `askrex.app` public ingress is deployed or production-ready; US-088 gates that separately.

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -8,9 +8,10 @@ Read in this order:
 2. [MOBILE_API_THREAT_MODEL.md](MOBILE_API_THREAT_MODEL.md) — current external/mobile trust boundaries and the gated `askrex.app` threat model.
 3. [EXTERNAL_SURFACE_CLASSIFICATION.md](EXTERNAL_SURFACE_CLASSIFICATION.md) — evidence-based classification of which local services may or may not sit behind public mobile ingress.
 4. [ASKREX_APP_GATEWAY.md](ASKREX_APP_GATEWAY.md) — secure public-gateway design, transport-binding gate, and explicit iOS API scope.
-5. [MOBILE_CLIENT_CONTRACT_AUDIT.md](MOBILE_CLIENT_CONTRACT_AUDIT.md) — cross-repository findings and resolved conflicts.
-6. [MOBILE_API_ARCHITECTURE.md](MOBILE_API_ARCHITECTURE.md) — component, data, identity, idempotency, voice, and deployment architecture.
-7. [MOBILE_API_IMPLEMENTATION_PLAN.md](MOBILE_API_IMPLEMENTATION_PLAN.md) — implementation history and workstream plan.
-8. [MOBILE_API_TEST_MATRIX.md](MOBILE_API_TEST_MATRIX.md) — required automated and real-device validation.
+5. [CLOUDFLARE_TUNNEL.md](CLOUDFLARE_TUNNEL.md) — credential-free `askrex.app` outbound-tunnel reference and path-allowlist checks.
+6. [MOBILE_CLIENT_CONTRACT_AUDIT.md](MOBILE_CLIENT_CONTRACT_AUDIT.md) — cross-repository findings and resolved conflicts.
+7. [MOBILE_API_ARCHITECTURE.md](MOBILE_API_ARCHITECTURE.md) — component, data, identity, idempotency, voice, and deployment architecture.
+8. [MOBILE_API_IMPLEMENTATION_PLAN.md](MOBILE_API_IMPLEMENTATION_PLAN.md) — implementation history and workstream plan.
+9. [MOBILE_API_TEST_MATRIX.md](MOBILE_API_TEST_MATRIX.md) — required automated and real-device validation.
 
 The threat model reflects the current S5-S8 desktop/server security boundary. It does **not** claim that the future `askrex.app` public ingress is deployed or production-ready; US-088 gates that separately.

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -1,13 +1,14 @@
 # Mobile API Gateway Planning Package
 
-This directory is the implementation handoff for issue #323.
+This directory is the implementation and security handoff for the AskRex mobile gateway.
 
 Read in this order:
 
 1. [MOBILE_API_MASTER_SPEC.md](MOBILE_API_MASTER_SPEC.md) — canonical wire and security contract.
-2. [MOBILE_CLIENT_CONTRACT_AUDIT.md](MOBILE_CLIENT_CONTRACT_AUDIT.md) — cross-repository findings and resolved conflicts.
-3. [MOBILE_API_ARCHITECTURE.md](MOBILE_API_ARCHITECTURE.md) — component, data, identity, idempotency, voice, and deployment architecture.
-4. [MOBILE_API_IMPLEMENTATION_PLAN.md](MOBILE_API_IMPLEMENTATION_PLAN.md) — minimum two-session Fable backlog.
-5. [MOBILE_API_TEST_MATRIX.md](MOBILE_API_TEST_MATRIX.md) — required automated and real-device validation.
+2. [MOBILE_API_THREAT_MODEL.md](MOBILE_API_THREAT_MODEL.md) — current external/mobile trust boundaries and the gated `askrex.app` threat model.
+3. [MOBILE_CLIENT_CONTRACT_AUDIT.md](MOBILE_CLIENT_CONTRACT_AUDIT.md) — cross-repository findings and resolved conflicts.
+4. [MOBILE_API_ARCHITECTURE.md](MOBILE_API_ARCHITECTURE.md) — component, data, identity, idempotency, voice, and deployment architecture.
+5. [MOBILE_API_IMPLEMENTATION_PLAN.md](MOBILE_API_IMPLEMENTATION_PLAN.md) — implementation history and workstream plan.
+6. [MOBILE_API_TEST_MATRIX.md](MOBILE_API_TEST_MATRIX.md) — required automated and real-device validation.
 
-The planning package does not claim that the mobile gateway is implemented. Capability and integration status remain unchanged until the corresponding backend and mobile code, tests, and smoke validation are complete.
+The threat model reflects the current S5-S8 desktop/server security boundary. It does **not** claim that the future `askrex.app` public ingress is deployed or production-ready; US-088 gates that separately.

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -6,9 +6,10 @@ Read in this order:
 
 1. [MOBILE_API_MASTER_SPEC.md](MOBILE_API_MASTER_SPEC.md) — canonical wire and security contract.
 2. [MOBILE_API_THREAT_MODEL.md](MOBILE_API_THREAT_MODEL.md) — current external/mobile trust boundaries and the gated `askrex.app` threat model.
-3. [MOBILE_CLIENT_CONTRACT_AUDIT.md](MOBILE_CLIENT_CONTRACT_AUDIT.md) — cross-repository findings and resolved conflicts.
-4. [MOBILE_API_ARCHITECTURE.md](MOBILE_API_ARCHITECTURE.md) — component, data, identity, idempotency, voice, and deployment architecture.
-5. [MOBILE_API_IMPLEMENTATION_PLAN.md](MOBILE_API_IMPLEMENTATION_PLAN.md) — implementation history and workstream plan.
-6. [MOBILE_API_TEST_MATRIX.md](MOBILE_API_TEST_MATRIX.md) — required automated and real-device validation.
+3. [EXTERNAL_SURFACE_CLASSIFICATION.md](EXTERNAL_SURFACE_CLASSIFICATION.md) — evidence-based classification of which local services may or may not sit behind public mobile ingress.
+4. [MOBILE_CLIENT_CONTRACT_AUDIT.md](MOBILE_CLIENT_CONTRACT_AUDIT.md) — cross-repository findings and resolved conflicts.
+5. [MOBILE_API_ARCHITECTURE.md](MOBILE_API_ARCHITECTURE.md) — component, data, identity, idempotency, voice, and deployment architecture.
+6. [MOBILE_API_IMPLEMENTATION_PLAN.md](MOBILE_API_IMPLEMENTATION_PLAN.md) — implementation history and workstream plan.
+7. [MOBILE_API_TEST_MATRIX.md](MOBILE_API_TEST_MATRIX.md) — required automated and real-device validation.
 
 The threat model reflects the current S5-S8 desktop/server security boundary. It does **not** claim that the future `askrex.app` public ingress is deployed or production-ready; US-088 gates that separately.

--- a/tests/mobile_api/test_external_gateway_policy.py
+++ b/tests/mobile_api/test_external_gateway_policy.py
@@ -1,0 +1,114 @@
+"""US-088 external/mobile gateway security contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _build_app(mobile_env: Path, clock, **config_overrides):
+    from rex.config import MobileApiConfig
+    from rex.mobile_api.app import create_mobile_app
+    from rex.mobile_api.db import migrate_users_db
+    from rex.mobile_api.services import MobileApiServices
+
+    db_path = mobile_env / "users.db"
+    migrate_users_db(db_path)
+    services = MobileApiServices.build(
+        MobileApiConfig(**config_overrides), db_path=db_path, clock=clock
+    )
+    app = create_mobile_app(services=services)
+    app.config["TESTING"] = True
+    return app, services
+
+
+def test_public_origin_registers_only_mobile_routes(app) -> None:
+    routes = {rule.rule for rule in app.url_map.iter_rules() if rule.endpoint != "static"}
+    assert routes
+    assert all(route.startswith("/mobile/") for route in routes)
+
+
+def test_local_admin_paths_are_not_present(client) -> None:
+    for path in (
+        "/api/status/current",
+        "/api/admin/permissions/grant",
+        "/rex/tools/time_now",
+        "/speak",
+        "/run",
+        "/ui/",
+    ):
+        response = client.get(path)
+        assert response.status_code == 404, path
+        assert response.get_json()["error"]["code"] == "NOT_FOUND"
+
+
+def test_protected_mobile_route_rejects_missing_bearer(client) -> None:
+    response = client.get("/mobile/auth/session")
+    assert response.status_code == 401
+    assert response.get_json()["error"]["code"] == "AUTH_TOKEN_INVALID"
+
+
+def test_wildcard_cors_is_rejected() -> None:
+    from rex.config import MobileApiConfig
+
+    with pytest.raises(ValueError, match="wildcard.*CORS is deny-by-default"):
+        MobileApiConfig(allowed_origins=["*"])
+
+
+def test_cors_allows_only_exact_askrex_origin(mobile_env: Path, clock) -> None:
+    app, _ = _build_app(mobile_env, clock, allowed_origins=["https://askrex.app"])
+    with app.test_client() as client:
+        allowed = client.get("/mobile/status", headers={"Origin": "https://askrex.app"})
+        denied = client.get("/mobile/status", headers={"Origin": "https://evil.example"})
+    assert allowed.headers.get("Access-Control-Allow-Origin") == "https://askrex.app"
+    assert "Access-Control-Allow-Origin" not in denied.headers
+
+
+def test_public_gateway_rate_limit_is_canonical(mobile_env: Path, clock) -> None:
+    app, _ = _build_app(mobile_env, clock, rate_limit_default="2 per minute")
+    with app.test_client() as client:
+        assert client.get("/mobile/status").status_code == 200
+        assert client.get("/mobile/status").status_code == 200
+        limited = client.get("/mobile/status")
+    assert limited.status_code == 429
+    assert limited.get_json()["error"]["code"] == "RATE_LIMITED"
+    assert int(limited.headers["Retry-After"]) >= 1
+
+
+def test_loopback_origin_without_transport_binding_cannot_pair(mobile_env: Path, clock) -> None:
+    from rex.mobile_api.pairing import PairingError
+
+    _, services = _build_app(mobile_env, clock)
+    assert services.transport_binding is None
+    with pytest.raises(PairingError, match="Secure mobile transport is unavailable"):
+        services.pairing_authority.create_challenge(user_id="alice", scopes=["chat.send"])
+
+
+def test_dynamic_openclaw_tool_cannot_gain_mobile_scope() -> None:
+    from rex.mobile_api.action_context import required_scope_for_tool
+
+    assert (
+        required_scope_for_tool(
+            "openclaw_dynamic_tool",
+            capability_tags=("chat", "safe", "mobile"),
+            operation="read",
+        )
+        is None
+    )
+
+
+def test_public_gateway_docs_keep_release_gate_explicit() -> None:
+    root = Path(__file__).resolve().parents[2]
+    files = [
+        root / "docs" / "mobile" / "MOBILE_API_THREAT_MODEL.md",
+        root / "docs" / "mobile" / "ASKREX_APP_GATEWAY.md",
+        root / "docs" / "mobile" / "CLOUDFLARE_TUNNEL.md",
+        root / "docs" / "deployment.md",
+        root / "docs" / "api.md",
+        root / "SECURITY.md",
+    ]
+    text = "\n".join(path.read_text(encoding="utf-8") for path in files)
+    for required in ("askrex.app", "Cloudflare Tunnel", "CORS", "rate limit", "revocation"):
+        assert required.lower() in text.lower()
+    assert "public ingress gate is **closed**" in text


### PR DESCRIPTION
## Summary
- document a committed mobile/API threat model and classify every existing external-facing Rex surface
- define a secure `askrex.app` gateway boundary that exposes only the dedicated `/mobile/*` contract
- document a credential-free Cloudflare Tunnel deployment path with an explicit allowlist and 404 fallback
- add regression tests for auth rejection, deny-by-default CORS, rate limiting, TurnEngine/TurnSource.MOBILE routing, and OpenClaw scope isolation

## Security boundary
- local admin, `rex.gui_app` `/api/*`, computer-control, TTS service, OpenClaw tool-server, secret-management, and arbitrary localhost services remain out of public scope
- pairing, live grants/revocation, TLS binding, strong auth, least-privilege scopes, and canonical verification remain server-derived
- OpenClaw remains optional and cannot widen mobile authority

## Validation
- full `tests/mobile_api` suite passed
- related Windows-agent/OpenClaw-tool-server/chat API regression passed
- full primary release suite: **8,811 passed, 49 skipped, 0 failed**
- Ruff, Black, mypy, security release gate, pre-commit, docs truth checks, and `git diff --check` passed
- local `cloudflared tunnel ingress validate` confirmed `askrex.app/mobile/* -> 127.0.0.1:8765` and non-mobile paths -> `http_status:404`

US-088 will be marked complete only after all relevant GitHub checks pass on the final PR head.