### PR TITLE
feat(gui): discover configured local models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,8 @@ config/rex_config.json
 
 Electron AI-provider selection uses `models.llm_provider` in this file as the canonical runtime source of truth. The GUI value `local` maps only to runtime `transformers`; do not add a second provider key such as `llm.provider`. Persist provider selection independently from provider-specific model editing so changing providers is not blocked while a model identifier is still blank.
 
+Electron local-model discovery is user-initiated main-process IPC over the provider endpoint already stored in canonical runtime config. The renderer may request only the supported discovery kind (`ollama` or `lmstudio`), not an arbitrary fetch URL. Ollama discovery uses configured `ollama.base_url`; LM Studio remains Rex's existing OpenAI-compatible runtime path and discovery uses configured `openai.base_url`. Keep loading, error, successful-empty, and discovered-model states distinct, and never present placeholder/example model names as discovered availability.
+
 Core config, `.env`, profiles, and persistent data paths must resolve
 through `rex.runtime_paths`, not the process working directory. Electron must
 launch every Python bridge with `bridgeSpawnOptions()` so development uses the

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2512,7 +2512,7 @@ cd gui && npm run typecheck && npm run build
 - [x] Stale or hardcoded fake model names are not shown as available.
 - [x] Tests mock provider endpoints for success, failure, and empty responses.
 - [x] `cd gui && npm run typecheck && npm run build` passes.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2505,13 +2505,13 @@ cd gui && npm run typecheck && npm run build
 **Implementation notes:** Ollama and LM Studio have different APIs. Use configured endpoints, show loading/error/empty states, and avoid network calls unless the user requests discovery or opens the relevant provider section.
 
 **Acceptance Criteria:**
-- [ ] Ollama model discovery reads the configured Ollama endpoint.
-- [ ] LM Studio model discovery reads the configured OpenAI-compatible endpoint.
-- [ ] UI shows loading, error, and empty states.
-- [ ] Selected model persists and reloads.
-- [ ] Stale or hardcoded fake model names are not shown as available.
-- [ ] Tests mock provider endpoints for success, failure, and empty responses.
-- [ ] `cd gui && npm run typecheck && npm run build` passes.
+- [x] Ollama model discovery reads the configured Ollama endpoint.
+- [x] LM Studio model discovery reads the configured OpenAI-compatible endpoint.
+- [x] UI shows loading, error, and empty states.
+- [x] Selected model persists and reloads.
+- [x] Stale or hardcoded fake model names are not shown as available.
+- [x] Tests mock provider endpoints for success, failure, and empty responses.
+- [x] `cd gui && npm run typecheck && npm run build` passes.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2118,3 +2118,33 @@ Remote exact-head evidence for implementation commit `b8d8ed3aa9be688ec2a02cfe6a
 - CodeFactor and GitGuardian exact-head checks completed successfully with no blocking findings.
 - PR #401 has no submitted reviews and no inline review threads.
 - US-071's final GitHub-check acceptance criterion is therefore closed. The subsequent documentation-only closure commit must still pass the repository's final merge checks before PR #401 is merged.
+
+2026-08-15 - US-072 local implementation complete; remote CI pending
+
+Implementation:
+- Added bounded, dependency-free local model discovery in `gui/src/main/modelDiscovery.ts`.
+- Ollama discovery reads the configured `ollama.base_url` and requests `/api/tags`; LM Studio remains Rex's existing OpenAI-compatible runtime path and discovery reads configured `openai.base_url` and requests `/models`.
+- Discovery validates HTTP/HTTPS endpoints, applies a five-second AbortController timeout, deduplicates nonblank model IDs, distinguishes successful empty lists from malformed responses, and returns content-free errors without provider bodies or exception payloads.
+- Added typed `rex:discoverAiModels` IPC. The renderer can request only `ollama` or `lmstudio`; the main process reads the endpoint from canonical runtime config and does not accept a renderer-supplied fetch URL.
+- Added `openaiBaseUrl` to Electron AI settings and mirrored it to `openai.base_url`. Blank explicitly clears the compatible endpoint back to official OpenAI behavior; no new LM Studio provider identity or duplicate provider authority was introduced.
+- Added explicit user-triggered discovery controls for Ollama and LM Studio. Current settings are persisted before discovery so the main process always reads canonical configured endpoints.
+- Added truthful UI states for idle, loading, safe error, successful empty list, and populated discovered models. The discovered-model selector renders only endpoint-returned model IDs while manual model-entry fields remain available.
+- Selecting a discovered Ollama or LM Studio model uses the existing settings persistence path and reloads correctly from canonical runtime config.
+- Documented the durable discovery/security boundary in `CLAUDE.md`, plus the design spec and implementation plan under `docs/superpowers/`.
+
+TDD / validation evidence:
+- Discovery contract began red because `modelDiscovery.ts` did not exist; after implementation `gui/tests/modelDiscovery.test.ts` passes 13/13 covering Ollama/LM Studio success, deduplication, empty, HTTP failure, network failure, malformed payloads, URL composition, query/fragment rejection, and invalid configuration without a fetch.
+- OpenAI-compatible endpoint persistence began with 4 intended red failures; after implementation `aiSettings.test.ts` + `settingsMirror.test.ts` pass 18/18.
+- IPC boundary began with 4 intended red failures because `rex:discoverAiModels` was unregistered; after implementation the targeted discovery/settings matrix passes.
+- Model discovery results component passes 6/6 for idle, loading, error, successful-empty, returned-model-only, and selected-model rendering.
+- Complete focused US-072 GUI matrix: 67 passed across discovery, UI wiring, persistence/reload, settings mapping, and settings handler tests.
+- Full GUI Vitest suite: 164 passed across 32 files.
+- `npm.cmd run typecheck`: passed.
+- `npm.cmd run build`: passed.
+- `npm.cmd run lint`: 0 errors, 3 pre-existing unrelated warnings.
+- `npm.cmd audit --audit-level=high`: passed; only 2 pre-existing moderate React Router advisories remain and require a breaking v7 upgrade.
+- `pytest -q tests/test_llm_client.py tests/test_model_router.py`: 49 passed, with 2 pre-existing root-shim deprecation warnings.
+- Independent Codex review found two pre-commit issues: stale out-of-order discovery completions and malformed query/fragment URL composition. Both were fixed with request invalidation and URL-API construction/rejection tests; the follow-up Codex review returned `NO ACTIONABLE FINDINGS`.
+- `python scripts/security_audit.py --release-gate`: passed with 0 actionable findings and no exposed secrets.
+- `git diff --check`: passed.
+- US-072 local acceptance criteria are complete. The final GitHub-check criterion remains intentionally unchecked until the exact PR implementation head passes the remote matrix.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2148,3 +2148,15 @@ TDD / validation evidence:
 - `python scripts/security_audit.py --release-gate`: passed with 0 actionable findings and no exposed secrets.
 - `git diff --check`: passed.
 - US-072 local acceptance criteria are complete. The final GitHub-check criterion remains intentionally unchecked until the exact PR implementation head passes the remote matrix.
+
+2026-08-15 - US-072 remote GitHub evidence complete
+
+Remote exact-head evidence for implementation commit `ebc1d6616949eef99bd6a223aa6f9d2846c4270c` on PR #404:
+- GitHub Actions CI run #1186 completed successfully.
+- Commitlint run #806 completed successfully.
+- Windows Electron Artifact run #159 completed successfully, including managed runtime/installer build, signature/resource validation, and installed-artifact smoke execution without machine Python or Node.
+- Exact-head check suite registered 18 checks; all completed with no failure or cancellation conclusions.
+- CodeFactor completed successfully.
+- GitGuardian completed successfully with no secrets detected.
+- PR #404 has no submitted reviews and no inline review threads.
+- US-072's final GitHub-check acceptance criterion is therefore closed. This documentation-only closure commit must still pass the repository's final merge checks before PR #404 is merged.

--- a/docs/superpowers/plans/2026-08-15-us072-model-discovery.md
+++ b/docs/superpowers/plans/2026-08-15-us072-model-discovery.md
@@ -1,0 +1,90 @@
+# US-072 Model Discovery Implementation Plan
+
+**Goal:** Discover real Ollama and LM Studio model IDs from configured endpoints, expose truthful UI states, and persist the selected model through existing AI settings.
+
+**Architecture:** Keep LM Studio on Rex's existing OpenAI-compatible runtime path. Add one bounded main-process discovery module and one typed IPC method. The renderer chooses only discovery kind; the main process owns endpoint lookup and HTTP access.
+
+## Task 1: Add red discovery contract tests
+
+**Files:**
+- Create: `gui/tests/modelDiscovery.test.ts`
+- Create: `gui/src/main/modelDiscovery.ts`
+
+Write tests first for:
+- Ollama configured endpoint -> `/api/tags` -> unique model names.
+- LM Studio configured OpenAI-compatible endpoint -> `/models` -> unique IDs.
+- successful empty responses.
+- non-2xx/network/malformed responses return safe provider-specific errors.
+- missing/invalid configured endpoints do not call fetch.
+
+Run `cd gui && npx vitest run tests/modelDiscovery.test.ts`; confirm red before implementation, then implement the smallest passing module.
+
+## Task 2: Persist the OpenAI-compatible base URL
+
+**Files:**
+- Modify: `gui/src/types/ipc.ts`
+- Modify: `gui/src/main/aiSettings.ts`
+- Modify: `gui/src/main/settingsMirror.ts`
+- Modify: `gui/tests/aiSettings.test.ts`
+- Modify: `gui/tests/settingsMirror.test.ts`
+
+Add `openaiBaseUrl` to `AiSettings`. Load it from `openai.base_url`, mirror trimmed nonblank values, and clear runtime `openai.base_url` when the GUI value is blank. Keep `models.llm_provider` unchanged as provider authority.
+
+Add round-trip tests before implementation changes.
+
+## Task 3: Add typed discovery IPC
+
+**Files:**
+- Modify: `gui/src/types/ipc.ts`
+- Modify: `gui/src/preload/index.ts`
+- Modify: `gui/src/main/handlers/settings.ts`
+- Modify: `gui/tests/settingsHandlers.test.ts`
+
+Add `discoverAiModels(provider: 'ollama' | 'lmstudio')`. The handler reads canonical `rex_config`, passes only the configured endpoint to the discovery module, rejects unsupported discovery kinds, and never accepts a renderer-provided URL.
+
+Test handler registration, configured endpoint selection, unsupported provider handling, and safe error return.
+
+## Task 4: Add truthful discovery UI
+
+**Files:**
+- Modify: `gui/src/pages/settings/AiSettingsSection.tsx`
+- Create or modify focused GUI/source tests under `gui/tests/`
+
+OpenAI section:
+- optional OpenAI-compatible Base URL field;
+- explicit `Discover LM Studio Models` button when configured;
+- discovered model selector bound to `form.model`.
+
+Ollama section:
+- explicit `Discover Models` button;
+- discovered model selector bound to `form.customModelId`.
+
+Both:
+- explicit loading, error, empty, and populated states;
+- no network call on mount;
+- selecting a model uses the existing `setSettings` path.
+
+## Task 5: Documentation and durable rule
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `PRD-production-readiness.md`
+- Modify: `docs/archive/progress/progress-production-readiness.txt`
+
+Record that model discovery is user-initiated main-process IPC over configured endpoints, LM Studio remains the OpenAI-compatible runtime path, and renderer URLs are never accepted for discovery.
+
+Check local acceptance criteria, leaving only GitHub checks unchecked until the exact PR implementation head is green.
+
+## Task 6: Verification
+
+Run fresh:
+- `cd gui && npx vitest run` / documented Windows `npm.cmd test`
+- `cd gui && npm.cmd run typecheck`
+- `cd gui && npm.cmd run build`
+- `cd gui && npm.cmd run lint`
+- `cd gui && npm.cmd audit --audit-level=high`
+- `python -m pytest -q tests/test_llm_client.py tests/test_model_router.py`
+- `python scripts/security_audit.py --release-gate`
+- `git diff --check`
+
+Commit, push only after PR #401 is merged, open the US-072 PR, wait for exact-head checks, record evidence, rerun final merge checks on the closure head, and merge when green.

--- a/docs/superpowers/specs/2026-08-15-us072-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-15-us072-model-discovery-design.md
@@ -1,0 +1,61 @@
+# US-072 Model Discovery Design
+
+## Goal
+
+Let Settings > AI discover the real models exposed by the user-configured Ollama or LM Studio endpoint, select one, persist it through the existing AI settings source of truth, and present truthful loading/error/empty states.
+
+## Architecture decision
+
+LM Studio remains Rex's existing OpenAI-compatible runtime path. Do not add a new Python provider name or a second provider authority. Runtime `models.llm_provider = "openai"` plus `openai.base_url` continues to drive LM Studio-compatible inference. Ollama continues to use runtime provider `ollama` plus `ollama.base_url`.
+
+Discovery is a user-initiated Electron main-process operation. The renderer sends only a discovery kind (`ollama` or `lmstudio`); it never supplies a URL to fetch. The main process reads the canonical configured endpoint from `rex_config`, validates it as HTTP/HTTPS, applies a bounded timeout, and performs the request. This preserves the existing raw-renderer-fetch security boundary and prevents a renderer caller from turning the IPC method into an arbitrary URL fetch primitive.
+
+## Components
+
+### `gui/src/main/modelDiscovery.ts`
+
+A small, dependency-free discovery module with an injectable fetch function for deterministic tests.
+
+- Ollama: GET `<configured ollama base>/api/tags`; extract unique nonblank `models[].name` strings.
+- LM Studio: GET `<configured openai base>/models`; for a normal `.../v1` base this becomes `.../v1/models`; extract unique nonblank `data[].id` strings.
+- Reject missing/invalid configured endpoints before network access.
+- Use `AbortController` with a 5-second timeout.
+- Return structured `{ok, models, error?}` data and never return response bodies or exception payloads to the renderer.
+
+### Settings IPC
+
+Add a typed `rex:discoverAiModels` handler and preload/API method. The handler accepts only `ollama | lmstudio`, reads `rex_config` itself, and delegates to the discovery module.
+
+### AI settings source of truth
+
+Add `openaiBaseUrl` to `AiSettings` and mirror it to `openai.base_url`. A blank value clears the compatible endpoint so official OpenAI behavior remains available. Existing `models.llm_provider` remains the sole provider source of truth.
+
+### Renderer UX
+
+- OpenAI section gains an optional `OpenAI-compatible Base URL (LM Studio)` field.
+- When that field is nonblank, show an explicit `Discover LM Studio Models` button.
+- Ollama shows an explicit `Discover Models` button.
+- Discovery is never automatic merely because the settings page opened.
+- State is explicit: loading, network/error, successful empty list, or successful model list.
+- A discovered model selection uses the existing save path (`model` for LM Studio/OpenAI-compatible; `customModelId` for Ollama), so restart/reload persistence stays within the current settings architecture.
+- Existing text inputs remain available for manual IDs. Placeholders/examples are not presented as discovered availability.
+
+## Error and security behavior
+
+- No discovery request occurs without a user action.
+- No external URL is accepted from the renderer.
+- Only configured HTTP/HTTPS endpoints are used.
+- Timeout/network/HTTP/schema failures produce concise provider-specific errors without raw body, stack, filesystem, credential, or exception details.
+- Empty successful responses are not errors; the UI says that no models were reported by the configured endpoint.
+
+## Testing
+
+1. Unit-test `modelDiscovery.ts` with mocked fetch for Ollama and LM Studio success, failure, malformed/empty responses, endpoint composition, and invalid configuration.
+2. Test settings build/mirror round-trip for `openaiBaseUrl` and discovered-model persistence.
+3. Test the IPC handler reads configured endpoints rather than accepting renderer URLs.
+4. Add renderer/source assertions for loading, error, empty, and model-selection states.
+5. Run the full GUI suite, typecheck, build, lint, high-severity npm audit, the PRD Python validation set, the repository security gate, and `git diff --check`.
+
+## Scope exclusions
+
+No live provider calls in tests, no LM Studio Python provider class, no automatic discovery on startup, no OpenRouter discovery, and no model download/install behavior.

--- a/gui/src/main/aiSettings.ts
+++ b/gui/src/main/aiSettings.ts
@@ -66,6 +66,11 @@ export function buildAiSettings(raw: Settings = {}): AiSettings {
   const customModelId =
     nonEmptyString(raw.customModelId)
     || (provider === 'ollama' || provider === 'local' ? runtimeModelId : '')
+  const openaiBaseUrl = Object.prototype.hasOwnProperty.call(raw, 'openaiBaseUrl')
+    ? typeof raw.openaiBaseUrl === 'string'
+      ? raw.openaiBaseUrl.trim()
+      : ''
+    : nonEmptyString(openai.base_url)
   const ollamaBaseUrl =
     nonEmptyString(raw.ollamaBaseUrl)
     || nonEmptyString(ollama.base_url)
@@ -91,6 +96,7 @@ export function buildAiSettings(raw: Settings = {}): AiSettings {
     model,
     provider,
     customModelId,
+    openaiBaseUrl,
     ollamaBaseUrl,
     openrouterModel,
     openrouterBaseUrl,

--- a/gui/src/main/handlers/settings.ts
+++ b/gui/src/main/handlers/settings.ts
@@ -2,7 +2,14 @@ import { ipcMain } from 'electron'
 import { join } from 'path'
 import { homedir } from 'os'
 import { existsSync, readFileSync } from 'fs'
-import type { AiSettings, PreferenceSuggestion, Settings, WakeWordStatus } from '../../types/ipc'
+import type {
+  AiSettings,
+  ModelDiscoveryProvider,
+  ModelDiscoveryResponse,
+  PreferenceSuggestion,
+  Settings,
+  WakeWordStatus
+} from '../../types/ipc'
 import { readGuiSettings, readRexConfigStrict, writeGuiSettings, writeRexConfig } from '../configStore'
 import { buildAiSettings } from '../aiSettings'
 import { buildVoiceSettings, buildWakeWordStatus } from '../voiceSettings'
@@ -13,6 +20,7 @@ import { getVaultReference, putVaultReference } from '../credentialReferences'
 import type { ElectronSessionIdentity } from '../sessionIdentity'
 import { safeIpcErrorMessage, SafeValidationError } from '../ipcErrors'
 import { loadIntegrationSettings, persistSettingsSection, removeEmailAccount } from '../integrationSettingsStorage'
+import { discoverAiModelsAtEndpoint } from '../modelDiscovery'
 
 const ALLOWED_API_KEYS = [
   'OPENAI_API_KEY',
@@ -41,6 +49,10 @@ function apiKeyContext(key: string): VaultContext {
   return { scope: 'household', integration: integrationNameForKey(key), account: null, slot: 'api_key' }
 }
 
+function objectSection(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
 export function registerSettingsHandlers(session: ElectronSessionIdentity): void {
   ipcMain.handle('rex:getSettings', async (_event, section: string): Promise<Settings> => {
     const stored = readGuiSettings()
@@ -55,6 +67,27 @@ export function registerSettingsHandlers(session: ElectronSessionIdentity): void
     }
     return stored[section] ?? defaultSettingsMap[section] ?? {}
   })
+
+  ipcMain.handle(
+    'rex:discoverAiModels',
+    async (_event, provider: ModelDiscoveryProvider | string): Promise<ModelDiscoveryResponse> => {
+      if (provider !== 'ollama' && provider !== 'lmstudio') {
+        return { ok: false, models: [], error: 'Unsupported model discovery provider' }
+      }
+      try {
+        const config = readRexConfigStrict()
+        const section = objectSection(provider === 'ollama' ? config.ollama : config.openai)
+        const endpoint = typeof section.base_url === 'string' ? section.base_url : ''
+        return discoverAiModelsAtEndpoint(provider, endpoint)
+      } catch {
+        return {
+          ok: false,
+          models: [],
+          error: 'Model discovery configuration could not be read'
+        }
+      }
+    }
+  )
 
   ipcMain.handle('rex:getWakeWordStatus', (_event, values?: Settings): WakeWordStatus => {
     const stored = readGuiSettings()

--- a/gui/src/main/modelDiscovery.ts
+++ b/gui/src/main/modelDiscovery.ts
@@ -1,0 +1,113 @@
+import type { ModelDiscoveryProvider, ModelDiscoveryResponse } from '../types/ipc'
+
+type FetchLike = typeof fetch
+
+function providerLabel(provider: ModelDiscoveryProvider): string {
+  return provider === 'ollama' ? 'Ollama' : 'LM Studio'
+}
+
+function validatedBaseUrl(
+  provider: ModelDiscoveryProvider,
+  endpoint: string
+): { ok: true; value: URL } | { ok: false; error: string } {
+  const label = providerLabel(provider)
+  if (!endpoint.trim()) {
+    return { ok: false, error: `${label} model discovery endpoint is not configured` }
+  }
+  try {
+    const url = new URL(endpoint.trim())
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return { ok: false, error: `${label} model discovery endpoint must use HTTP or HTTPS` }
+    }
+    if (url.search || url.hash) {
+      return { ok: false, error: `${label} model discovery endpoint must not include a query or fragment` }
+    }
+    return { ok: true, value: url }
+  } catch {
+    return { ok: false, error: `${label} model discovery endpoint must use HTTP or HTTPS` }
+  }
+}
+
+function discoveryUrl(provider: ModelDiscoveryProvider, base: URL): string {
+  const url = new URL(base.toString())
+  const suffix = provider === 'ollama' ? '/api/tags' : '/models'
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}${suffix}`
+  return url.toString()
+}
+
+function uniqueNonblank(values: unknown[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+  return result
+}
+
+function parseModels(
+  provider: ModelDiscoveryProvider,
+  payload: unknown
+): string[] | null {
+  if (!payload || typeof payload !== 'object') return null
+  const source = payload as Record<string, unknown>
+  const rows = provider === 'ollama' ? source.models : source.data
+  if (!Array.isArray(rows)) return null
+  const field = provider === 'ollama' ? 'name' : 'id'
+  return uniqueNonblank(
+    rows.map((row) =>
+      row && typeof row === 'object' ? (row as Record<string, unknown>)[field] : null
+    )
+  )
+}
+
+export async function discoverAiModelsAtEndpoint(
+  provider: ModelDiscoveryProvider,
+  endpoint: string,
+  fetchImpl: FetchLike = globalThis.fetch,
+  timeoutMs = 5000
+): Promise<ModelDiscoveryResponse> {
+  const validated = validatedBaseUrl(provider, endpoint)
+  if (!validated.ok) return { ok: false, models: [], error: validated.error }
+
+  const label = providerLabel(provider)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetchImpl(discoveryUrl(provider, validated.value), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal
+    })
+    if (!response.ok) {
+      return {
+        ok: false,
+        models: [],
+        error: `${label} model discovery failed (HTTP ${response.status})`
+      }
+    }
+
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch {
+      return { ok: false, models: [], error: `${label} returned an invalid model list` }
+    }
+    const models = parseModels(provider, payload)
+    if (models === null) {
+      return { ok: false, models: [], error: `${label} returned an invalid model list` }
+    }
+    return { ok: true, models }
+  } catch {
+    return {
+      ok: false,
+      models: [],
+      error: `Unable to reach configured ${label} endpoint`
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/gui/src/main/settingsDefaults.ts
+++ b/gui/src/main/settingsDefaults.ts
@@ -42,6 +42,7 @@ export const defaultSettingsMap: Record<string, Settings> = {
     model: 'gpt-4o',
     provider: 'openai',
     customModelId: '',
+    openaiBaseUrl: '',
     ollamaBaseUrl: 'http://localhost:11434',
     openrouterModel: 'openai/gpt-4o',
     openrouterBaseUrl: 'https://openrouter.ai/api/v1',

--- a/gui/src/main/settingsMirror.ts
+++ b/gui/src/main/settingsMirror.ts
@@ -48,6 +48,11 @@ export function mirrorToRexConfig(section: string, values: Settings): MirrorResu
         openai.model = values.model.trim()
         rexConfig.openai = openai
       }
+      if (typeof values.openaiBaseUrl === 'string') {
+        const openai = ((rexConfig.openai ?? {}) as Record<string, unknown>)
+        openai.base_url = values.openaiBaseUrl.trim() || null
+        rexConfig.openai = openai
+      }
       if (
         provider === 'openrouter'
         && (providerWasSupplied || typeof values.openrouterModel === 'string')

--- a/gui/src/pages/settings/AiSettingsSection.tsx
+++ b/gui/src/pages/settings/AiSettingsSection.tsx
@@ -1,8 +1,15 @@
 import React, { useEffect, useRef, useState } from 'react'
-import type { Settings, AiSettings, PreferenceSuggestion } from '../../types/ipc'
+import type {
+  Settings,
+  AiSettings,
+  ModelDiscoveryProvider,
+  PreferenceSuggestion
+} from '../../types/ipc'
 import { PageLoadingFallback } from '../../components/ui/PageLoadingFallback'
 import { useToast } from '../../components/ui/Toast'
 import { PasswordInput, SavedIndicator } from './shared'
+import { ModelDiscoveryRequestGate } from '../../types/modelDiscoveryRequestGate'
+import { ModelDiscoveryResults, type ModelDiscoveryStatus } from './ModelDiscoveryResults'
 
 const MODEL_ROUTING_FIELDS: Array<{
   key: keyof AiSettings['modelRouting']
@@ -43,6 +50,7 @@ export function AiSettingsSection(): React.ReactElement {
     model: 'gpt-4o',
     provider: 'openai',
     customModelId: '',
+    openaiBaseUrl: '',
     ollamaBaseUrl: 'http://localhost:11434',
     openrouterModel: 'openai/gpt-4o',
     openrouterBaseUrl: 'https://openrouter.ai/api/v1',
@@ -74,6 +82,11 @@ export function AiSettingsSection(): React.ReactElement {
   const [openaiKeyValue, setOpenaiKeyValue] = useState('')
   const [openrouterKeyValue, setOpenrouterKeyValue] = useState('')
   const [credentialSaving, setCredentialSaving] = useState<'openai' | 'openrouter' | null>(null)
+  const [discoveryProvider, setDiscoveryProvider] = useState<ModelDiscoveryProvider | null>(null)
+  const [discoveryStatus, setDiscoveryStatus] = useState<ModelDiscoveryStatus>('idle')
+  const [discoveredModels, setDiscoveredModels] = useState<string[]>([])
+  const [discoveryError, setDiscoveryError] = useState('')
+  const discoveryRequestGateRef = useRef(new ModelDiscoveryRequestGate())
 
   function loadSuggestions(): void {
     window.rex
@@ -101,6 +114,7 @@ export function AiSettingsSection(): React.ReactElement {
           model: typeof settings.model === 'string' && settings.model.trim() ? settings.model : 'gpt-4o',
           provider,
           customModelId: typeof settings.customModelId === 'string' ? settings.customModelId : '',
+          openaiBaseUrl: typeof settings.openaiBaseUrl === 'string' ? settings.openaiBaseUrl : '',
           ollamaBaseUrl: typeof settings.ollamaBaseUrl === 'string' ? settings.ollamaBaseUrl : 'http://localhost:11434',
           openrouterModel:
             typeof settings.openrouterModel === 'string' && settings.openrouterModel.trim()
@@ -158,8 +172,52 @@ export function AiSettingsSection(): React.ReactElement {
     savedTimerRef.current = setTimeout(() => setSavedField(null), 2000)
   }
 
+  function resetModelDiscovery(): void {
+    discoveryRequestGateRef.current.invalidate()
+    setDiscoveryProvider(null)
+    setDiscoveryStatus('idle')
+    setDiscoveredModels([])
+    setDiscoveryError('')
+  }
+
+  function handleDiscoverModels(provider: ModelDiscoveryProvider): void {
+    const requestId = discoveryRequestGateRef.current.begin()
+    setDiscoveryProvider(provider)
+    setDiscoveryStatus('loading')
+    setDiscoveredModels([])
+    setDiscoveryError('')
+
+    window.rex
+      .setSettings('ai', form as unknown as Settings)
+      .then((saved) => {
+        if (!saved.ok) {
+          throw new Error(saved.error ?? 'Failed to save AI settings before model discovery')
+        }
+        if (!discoveryRequestGateRef.current.isCurrent(requestId)) return null
+        return window.rex.discoverAiModels(provider)
+      })
+      .then((result) => {
+        if (!result || !discoveryRequestGateRef.current.isCurrent(requestId)) return
+        if (result.ok) {
+          setDiscoveredModels(result.models)
+          setDiscoveryStatus('success')
+          return
+        }
+        setDiscoveryError(result.error ?? 'Model discovery failed')
+        setDiscoveryStatus('error')
+      })
+      .catch(() => {
+        if (!discoveryRequestGateRef.current.isCurrent(requestId)) return
+        setDiscoveryError('Model discovery could not be completed')
+        setDiscoveryStatus('error')
+      })
+  }
+
   function handleFieldChange<K extends keyof AiSettings>(field: K, value: AiSettings[K]): void {
     const updated = { ...form, [field]: value }
+    if (field === 'provider' || field === 'openaiBaseUrl' || field === 'ollamaBaseUrl') {
+      resetModelDiscovery()
+    }
     setForm(updated)
     window.rex
       .setSettings('ai', updated as unknown as Settings)
@@ -345,6 +403,48 @@ export function AiSettingsSection(): React.ReactElement {
 
           <div className="mb-5">
             <div className="flex items-center justify-between mb-1.5">
+              <label htmlFor="openaiBaseUrl" className="text-sm font-medium text-text-primary">
+                OpenAI-compatible Base URL (LM Studio)
+              </label>
+              <SavedIndicator visible={savedField === 'openaiBaseUrl'} />
+            </div>
+            <input
+              id="openaiBaseUrl"
+              type="text"
+              value={form.openaiBaseUrl}
+              placeholder="Leave blank for official OpenAI"
+              onChange={(e) => {
+                resetModelDiscovery()
+                setForm((current) => ({ ...current, openaiBaseUrl: e.target.value }))
+              }}
+              onBlur={(e) => handleFieldChange('openaiBaseUrl', e.target.value)}
+              className="w-full bg-surface-raised border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
+            />
+            <p className="mt-1 text-xs text-text-secondary">
+              Leave blank for official OpenAI. For LM Studio, use its OpenAI-compatible endpoint such as http://127.0.0.1:1234/v1.
+            </p>
+            {form.openaiBaseUrl.trim() && (
+              <button
+                type="button"
+                onClick={() => handleDiscoverModels('lmstudio')}
+                disabled={discoveryProvider === 'lmstudio' && discoveryStatus === 'loading'}
+                className="mt-2 rounded-lg border border-border bg-surface-raised px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:border-accent/60 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Discover LM Studio Models
+              </button>
+            )}
+            <ModelDiscoveryResults
+              providerLabel="LM Studio"
+              status={discoveryProvider === 'lmstudio' ? discoveryStatus : 'idle'}
+              models={discoveryProvider === 'lmstudio' ? discoveredModels : []}
+              selectedModel={form.model}
+              error={discoveryProvider === 'lmstudio' ? discoveryError : ''}
+              onSelect={(model) => handleFieldChange('model', model)}
+            />
+          </div>
+
+          <div className="mb-5">
+            <div className="flex items-center justify-between mb-1.5">
               <label htmlFor="openaiApiKey" className="text-sm font-medium text-text-primary">
                 OpenAI API Key
               </label>
@@ -464,9 +564,28 @@ export function AiSettingsSection(): React.ReactElement {
               type="text"
               value={form.ollamaBaseUrl}
               placeholder="http://localhost:11434"
-              onChange={(e) => setForm((f) => ({ ...f, ollamaBaseUrl: e.target.value }))}
+              onChange={(e) => {
+                resetModelDiscovery()
+                setForm((f) => ({ ...f, ollamaBaseUrl: e.target.value }))
+              }}
               onBlur={(e) => handleFieldChange('ollamaBaseUrl', e.target.value)}
               className="w-full bg-surface-raised border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
+            />
+            <button
+              type="button"
+              onClick={() => handleDiscoverModels('ollama')}
+              disabled={discoveryProvider === 'ollama' && discoveryStatus === 'loading'}
+              className="mt-2 rounded-lg border border-border bg-surface-raised px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:border-accent/60 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Discover Models
+            </button>
+            <ModelDiscoveryResults
+              providerLabel="Ollama"
+              status={discoveryProvider === 'ollama' ? discoveryStatus : 'idle'}
+              models={discoveryProvider === 'ollama' ? discoveredModels : []}
+              selectedModel={form.customModelId}
+              error={discoveryProvider === 'ollama' ? discoveryError : ''}
+              onSelect={(model) => handleFieldChange('customModelId', model)}
             />
           </div>
           <div className="mb-5">

--- a/gui/src/pages/settings/ModelDiscoveryResults.test.tsx
+++ b/gui/src/pages/settings/ModelDiscoveryResults.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { ModelDiscoveryResults } from './ModelDiscoveryResults'
+
+function render(props: Partial<React.ComponentProps<typeof ModelDiscoveryResults>> = {}): string {
+  return renderToStaticMarkup(
+    <ModelDiscoveryResults
+      providerLabel="Ollama"
+      status="idle"
+      models={[]}
+      selectedModel=""
+      error=""
+      onSelect={vi.fn()}
+      {...props}
+    />
+  )
+}
+
+describe('ModelDiscoveryResults (US-072)', () => {
+  it('renders nothing before the user initiates discovery', () => {
+    expect(render()).toBe('')
+  })
+
+  it('shows an explicit loading state', () => {
+    expect(render({ status: 'loading' })).toContain('Discovering models…')
+  })
+
+  it('shows a provider error without inventing model availability', () => {
+    const html = render({
+      status: 'error',
+      error: 'Unable to reach configured Ollama endpoint'
+    })
+    expect(html).toContain('role="alert"')
+    expect(html).toContain('Unable to reach configured Ollama endpoint')
+    expect(html).not.toContain('<option')
+  })
+
+  it('distinguishes a successful empty list from an error', () => {
+    const html = render({ status: 'success', models: [] })
+    expect(html).toContain('No models reported by the configured Ollama endpoint.')
+    expect(html).not.toContain('role="alert"')
+  })
+
+  it('renders only models actually returned by discovery', () => {
+    const html = render({
+      status: 'success',
+      models: ['llama3.2:3b', 'qwen2.5:7b'],
+      selectedModel: 'hardcoded-example-that-was-not-discovered'
+    })
+    expect(html).toContain('llama3.2:3b')
+    expect(html).toContain('qwen2.5:7b')
+    expect(html).not.toContain('hardcoded-example-that-was-not-discovered')
+    expect(html).toContain('Select a discovered model')
+  })
+
+  it('marks a currently selected discovered model as selected', () => {
+    const html = render({
+      status: 'success',
+      models: ['llama3.2:3b', 'qwen2.5:7b'],
+      selectedModel: 'qwen2.5:7b'
+    })
+    expect(html).toContain('<option value="qwen2.5:7b" selected="">qwen2.5:7b</option>')
+  })
+})

--- a/gui/src/pages/settings/ModelDiscoveryResults.tsx
+++ b/gui/src/pages/settings/ModelDiscoveryResults.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+
+export type ModelDiscoveryStatus = 'idle' | 'loading' | 'success' | 'error'
+
+interface ModelDiscoveryResultsProps {
+  providerLabel: string
+  status: ModelDiscoveryStatus
+  models: string[]
+  selectedModel: string
+  error: string
+  onSelect: (model: string) => void
+}
+
+export function ModelDiscoveryResults({
+  providerLabel,
+  status,
+  models,
+  selectedModel,
+  error,
+  onSelect
+}: ModelDiscoveryResultsProps): React.ReactElement | null {
+  if (status === 'idle') return null
+
+  if (status === 'loading') {
+    return <p className="mt-2 text-xs text-text-secondary">Discovering models…</p>
+  }
+
+  if (status === 'error') {
+    return (
+      <p role="alert" className="mt-2 text-xs text-danger">
+        {error || `${providerLabel} model discovery failed.`}
+      </p>
+    )
+  }
+
+  if (models.length === 0) {
+    return (
+      <p className="mt-2 text-xs text-text-secondary">
+        No models reported by the configured {providerLabel} endpoint.
+      </p>
+    )
+  }
+
+  const value = models.includes(selectedModel) ? selectedModel : ''
+  return (
+    <div className="mt-3">
+      <label className="mb-1.5 block text-sm font-medium text-text-primary">
+        Discovered models
+      </label>
+      <select
+        value={value}
+        onChange={(event) => {
+          if (event.target.value) onSelect(event.target.value)
+        }}
+        className="w-full rounded-lg border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
+      >
+        <option value="">Select a discovered model</option>
+        {models.map((model) => (
+          <option key={model} value={model}>{model}</option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/gui/src/preload/index.ts
+++ b/gui/src/preload/index.ts
@@ -50,7 +50,9 @@ import type {
   TurnStatusValue,
   VoiceStartOptions,
   PairingResponse,
-  ProfileOperationResponse
+  ProfileOperationResponse,
+  ModelDiscoveryProvider,
+  ModelDiscoveryResponse
 } from '../types/ipc'
 
 function makeSendChatStream(
@@ -236,6 +238,8 @@ const rexAPI = {
   },
   getSettings: (section: string): Promise<Settings> =>
     ipcRenderer.invoke('rex:getSettings', section),
+  discoverAiModels: (provider: ModelDiscoveryProvider): Promise<ModelDiscoveryResponse> =>
+    ipcRenderer.invoke('rex:discoverAiModels', provider),
   setSettings: (section: string, values: Settings): Promise<SetSettingsResponse> =>
     ipcRenderer.invoke('rex:setSettings', section, values),
   removeEmailAccount: (id: string, confirmed: boolean): Promise<SetSettingsResponse> =>

--- a/gui/src/types/ipc.ts
+++ b/gui/src/types/ipc.ts
@@ -34,6 +34,14 @@ export interface SetSettingsResponse {
   error?: string
 }
 
+export type ModelDiscoveryProvider = 'ollama' | 'lmstudio'
+
+export interface ModelDiscoveryResponse {
+  ok: boolean
+  models: string[]
+  error?: string
+}
+
 export interface VoiceInfo {
   id: string
   name: string
@@ -258,6 +266,7 @@ export interface AiSettings {
   model: string
   provider: 'openai' | 'openrouter' | 'ollama' | 'local'
   customModelId: string
+  openaiBaseUrl: string
   ollamaBaseUrl: string
   openrouterModel: string
   openrouterBaseUrl: string
@@ -737,6 +746,7 @@ export interface RexAPI {
   onStatusChange: (cb: (status: string) => void) => (() => void)
   onTurnStatus: (cb: (update: TurnStatusUpdate) => void) => (() => void)
   getSettings: (section: string) => Promise<Settings>
+  discoverAiModels: (provider: ModelDiscoveryProvider) => Promise<ModelDiscoveryResponse>
   setSettings: (section: string, values: Settings) => Promise<SetSettingsResponse>
   removeEmailAccount: (id: string, confirmed: boolean) => Promise<SetSettingsResponse>
   startVoice: (

--- a/gui/src/types/modelDiscoveryRequestGate.ts
+++ b/gui/src/types/modelDiscoveryRequestGate.ts
@@ -1,0 +1,16 @@
+export class ModelDiscoveryRequestGate {
+  private latestRequestId = 0
+
+  begin(): number {
+    this.latestRequestId += 1
+    return this.latestRequestId
+  }
+
+  invalidate(): void {
+    this.latestRequestId += 1
+  }
+
+  isCurrent(requestId: number): boolean {
+    return requestId === this.latestRequestId
+  }
+}

--- a/gui/tests/aiModelDiscoveryUi.test.ts
+++ b/gui/tests/aiModelDiscoveryUi.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+import { ModelDiscoveryRequestGate } from '../src/types/modelDiscoveryRequestGate'
+
+const source = readFileSync(
+  join(process.cwd(), 'src/pages/settings/AiSettingsSection.tsx'),
+  'utf8'
+)
+
+describe('AI model discovery UI wiring (US-072)', () => {
+  it('exposes explicit user-triggered discovery for Ollama and LM Studio', () => {
+    expect(source).toContain("onClick={() => handleDiscoverModels('ollama')}")
+    expect(source).toContain("onClick={() => handleDiscoverModels('lmstudio')}")
+    expect(source).toContain('Discover LM Studio Models')
+    expect(source).toContain('Discover Models')
+  })
+
+  it('persists current AI settings before calling the configured-endpoint discovery IPC', () => {
+    const saveIndex = source.indexOf(".setSettings('ai', form as unknown as Settings)")
+    const discoverIndex = source.indexOf('.discoverAiModels(provider)')
+    expect(saveIndex).toBeGreaterThan(-1)
+    expect(discoverIndex).toBeGreaterThan(saveIndex)
+  })
+
+  it('does not trigger model discovery from the settings load effect', () => {
+    const effectStart = source.indexOf('useEffect(() => {')
+    const effectEnd = source.indexOf('}, [addToast])', effectStart)
+    const effectSource = source.slice(effectStart, effectEnd)
+    expect(effectSource).not.toContain('discoverAiModels')
+  })
+
+  it('keeps manual model entry while labeling discovered availability separately', () => {
+    expect(source).toContain('OpenAI Model ID')
+    expect(source).toContain('Model Name / Tag')
+    expect(source).toContain('OpenAI-compatible Base URL (LM Studio)')
+    expect(source).toContain('<ModelDiscoveryResults')
+  })
+
+  it('ignores an older discovery completion after a newer request starts', () => {
+    const gate = new ModelDiscoveryRequestGate()
+    const olderRequest = gate.begin()
+    const newerRequest = gate.begin()
+    const applied: string[] = []
+
+    if (gate.isCurrent(newerRequest)) applied.push('newer-model')
+    if (gate.isCurrent(olderRequest)) applied.push('older-model')
+
+    expect(applied).toEqual(['newer-model'])
+    gate.invalidate()
+    expect(gate.isCurrent(newerRequest)).toBe(false)
+  })
+})

--- a/gui/tests/aiProviderPersistence.test.ts
+++ b/gui/tests/aiProviderPersistence.test.ts
@@ -72,3 +72,56 @@ describe('AI provider persistence across settings reloads (US-071)', () => {
     expect(reloaded.provider).toBe('ollama')
   })
 })
+
+
+describe('discovered model persistence across settings reloads (US-072)', () => {
+  it('persists and reloads an Ollama model selected from discovery', async () => {
+    guiSettings = { ai: { provider: 'ollama', customModelId: '' } }
+    rexConfig = {
+      models: { llm_provider: 'ollama', llm_model: 'old-model:latest' },
+      ollama: { base_url: 'http://127.0.0.1:11434' }
+    }
+
+    const result = await persistSettingsSection(session, 'ai', {
+      provider: 'ollama',
+      customModelId: 'qwen2.5:7b',
+      ollamaBaseUrl: 'http://127.0.0.1:11434'
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(rexConfig).toMatchObject({
+      models: { llm_provider: 'ollama', llm_model: 'qwen2.5:7b' },
+      ollama: { base_url: 'http://127.0.0.1:11434' }
+    })
+    const reloaded = buildAiSettings(guiSettings.ai)
+    expect(reloaded.provider).toBe('ollama')
+    expect(reloaded.customModelId).toBe('qwen2.5:7b')
+  })
+
+  it('persists and reloads an LM Studio model through the OpenAI-compatible runtime path', async () => {
+    guiSettings = { ai: { provider: 'openai', model: 'gpt-4o', openaiBaseUrl: '' } }
+    rexConfig = {
+      models: { llm_provider: 'openai' },
+      openai: { model: 'gpt-4o', base_url: null }
+    }
+
+    const result = await persistSettingsSection(session, 'ai', {
+      provider: 'openai',
+      model: 'qwen/qwen3-8b',
+      openaiBaseUrl: 'http://127.0.0.1:1234/v1'
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(rexConfig).toMatchObject({
+      models: { llm_provider: 'openai' },
+      openai: {
+        model: 'qwen/qwen3-8b',
+        base_url: 'http://127.0.0.1:1234/v1'
+      }
+    })
+    const reloaded = buildAiSettings(guiSettings.ai)
+    expect(reloaded.provider).toBe('openai')
+    expect(reloaded.model).toBe('qwen/qwen3-8b')
+    expect(reloaded.openaiBaseUrl).toBe('http://127.0.0.1:1234/v1')
+  })
+})

--- a/gui/tests/aiSettings.test.ts
+++ b/gui/tests/aiSettings.test.ts
@@ -75,3 +75,24 @@ describe('AI provider reload behavior (US-071)', () => {
     expect(buildAiSettings({ provider: 'ollama' }).provider).toBe('openai')
   })
 })
+
+
+describe('OpenAI-compatible endpoint settings (US-072)', () => {
+  beforeEach(() => mockReadRexConfig.mockReset().mockReturnValue({}))
+
+  it('loads the configured OpenAI-compatible base URL for LM Studio discovery', () => {
+    mockReadRexConfig.mockReturnValue({
+      openai: { base_url: 'http://127.0.0.1:1234/v1' }
+    })
+
+    expect(buildAiSettings({}).openaiBaseUrl).toBe('http://127.0.0.1:1234/v1')
+  })
+
+  it('preserves an explicit blank GUI base URL so a configured compatible endpoint can be cleared', () => {
+    mockReadRexConfig.mockReturnValue({
+      openai: { base_url: 'http://127.0.0.1:1234/v1' }
+    })
+
+    expect(buildAiSettings({ openaiBaseUrl: '' }).openaiBaseUrl).toBe('')
+  })
+})

--- a/gui/tests/modelDiscovery.test.ts
+++ b/gui/tests/modelDiscovery.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest'
+import { discoverAiModelsAtEndpoint } from '../src/main/modelDiscovery'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  })
+}
+
+describe('model discovery (US-072)', () => {
+  it('discovers unique Ollama model names from the configured endpoint', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({
+      models: [
+        { name: 'llama3.2:3b' },
+        { name: 'qwen2.5:7b' },
+        { name: 'llama3.2:3b' },
+        { name: '   ' }
+      ]
+    }))
+
+    const result = await discoverAiModelsAtEndpoint(
+      'ollama',
+      'http://127.0.0.1:11434/',
+      fetchImpl
+    )
+
+    expect(result).toEqual({ ok: true, models: ['llama3.2:3b', 'qwen2.5:7b'] })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:11434/api/tags',
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
+
+  it('discovers unique LM Studio model ids from its configured OpenAI-compatible endpoint', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({
+      data: [
+        { id: 'qwen/qwen3-8b' },
+        { id: 'google/gemma-3-4b' },
+        { id: 'qwen/qwen3-8b' }
+      ]
+    }))
+
+    const result = await discoverAiModelsAtEndpoint(
+      'lmstudio',
+      'http://127.0.0.1:1234/v1/',
+      fetchImpl
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      models: ['qwen/qwen3-8b', 'google/gemma-3-4b']
+    })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:1234/v1/models',
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
+
+  it.each([
+    ['ollama', { models: [] }],
+    ['lmstudio', { data: [] }]
+  ] as const)('treats an empty %s model list as a successful empty result', async (provider, body) => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(body))
+
+    await expect(discoverAiModelsAtEndpoint(provider, 'http://127.0.0.1:9999', fetchImpl))
+      .resolves.toEqual({ ok: true, models: [] })
+  })
+
+  it('returns a safe error for provider HTTP failure without exposing the response body', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(
+      { error: 'secret internal provider detail' },
+      500
+    ))
+
+    const result = await discoverAiModelsAtEndpoint(
+      'ollama',
+      'http://127.0.0.1:11434',
+      fetchImpl
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      models: [],
+      error: 'Ollama model discovery failed (HTTP 500)'
+    })
+    expect(JSON.stringify(result)).not.toContain('secret internal provider detail')
+  })
+
+  it('returns a safe reachability error without forwarding exception payloads', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(
+      new Error('connect ECONNREFUSED credential-marker-should-not-leak')
+    )
+
+    const result = await discoverAiModelsAtEndpoint(
+      'lmstudio',
+      'http://127.0.0.1:1234/v1',
+      fetchImpl
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      models: [],
+      error: 'Unable to reach configured LM Studio endpoint'
+    })
+    expect(JSON.stringify(result)).not.toContain('credential-marker')
+  })
+
+  it.each([
+    ['ollama', { data: [] }],
+    ['lmstudio', { models: [] }]
+  ] as const)('rejects a malformed %s payload instead of pretending it is empty', async (provider, body) => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(body))
+
+    const result = await discoverAiModelsAtEndpoint(provider, 'http://127.0.0.1:9999', fetchImpl)
+
+    expect(result.ok).toBe(false)
+    expect(result.models).toEqual([])
+    expect(result.error).toContain('invalid model list')
+  })
+
+  it.each([
+    ['', 'Ollama model discovery endpoint is not configured'],
+    ['ftp://127.0.0.1/models', 'Ollama model discovery endpoint must use HTTP or HTTPS'],
+    ['not a url', 'Ollama model discovery endpoint must use HTTP or HTTPS'],
+    ['http://127.0.0.1:11434?token=secret', 'Ollama model discovery endpoint must not include a query or fragment'],
+    ['http://127.0.0.1:11434#models', 'Ollama model discovery endpoint must not include a query or fragment']
+  ])('rejects missing or invalid configured endpoints without calling fetch', async (endpoint, error) => {
+    const fetchImpl = vi.fn()
+
+    const result = await discoverAiModelsAtEndpoint('ollama', endpoint, fetchImpl)
+
+    expect(result).toEqual({ ok: false, models: [], error })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/gui/tests/settingsHandlers.test.ts
+++ b/gui/tests/settingsHandlers.test.ts
@@ -36,6 +36,11 @@ const { mockIntegrationStatus } = vi.hoisted(() => ({
 }))
 vi.mock('../src/main/integrationStatus', () => mockIntegrationStatus)
 
+const { mockModelDiscovery } = vi.hoisted(() => ({
+  mockModelDiscovery: { discoverAiModelsAtEndpoint: vi.fn() }
+}))
+vi.mock('../src/main/modelDiscovery', () => mockModelDiscovery)
+
 const { mockVault } = vi.hoisted(() => ({
   mockVault: {
     vaultSetSecret: vi.fn(),
@@ -76,6 +81,10 @@ describe('settings vault routing (S4)', () => {
     mockConfigStore.writeRexConfig.mockReset().mockImplementation((value) => { rexConfig = value })
     mockMirror.mirrorToRexConfig.mockReset().mockReturnValue({ ok: true })
     mockIntegrationStatus.reconcileIntegrationStatuses.mockReset().mockResolvedValue(undefined)
+    mockModelDiscovery.discoverAiModelsAtEndpoint.mockReset().mockResolvedValue({
+      ok: true,
+      models: []
+    })
     mockVault.vaultSetSecret.mockReset().mockResolvedValue(ref)
     mockVault.vaultHasSecret.mockReset().mockResolvedValue(false)
     mockVault.vaultDeleteSecret.mockReset().mockResolvedValue(true)
@@ -395,6 +404,67 @@ describe('settings vault routing (S4)', () => {
     expect(loaded.credentialStatus).toMatchObject({
       openclawToken: { ref, hasCredential: true }
     })
+  })
+
+  it('discovers Ollama models only from the configured runtime endpoint', async () => {
+    rexConfig = { ollama: { base_url: 'http://ollama.local:11434' } }
+    mockModelDiscovery.discoverAiModelsAtEndpoint.mockResolvedValue({
+      ok: true,
+      models: ['llama3.2:3b']
+    })
+
+    await expect(invoke('rex:discoverAiModels', 'ollama')).resolves.toEqual({
+      ok: true,
+      models: ['llama3.2:3b']
+    })
+    expect(mockModelDiscovery.discoverAiModelsAtEndpoint).toHaveBeenCalledWith(
+      'ollama',
+      'http://ollama.local:11434'
+    )
+  })
+
+  it('discovers LM Studio models only from the configured OpenAI-compatible endpoint', async () => {
+    rexConfig = { openai: { base_url: 'http://lmstudio.local:1234/v1' } }
+    mockModelDiscovery.discoverAiModelsAtEndpoint.mockResolvedValue({
+      ok: true,
+      models: ['qwen/qwen3-8b']
+    })
+
+    await expect(invoke('rex:discoverAiModels', 'lmstudio')).resolves.toEqual({
+      ok: true,
+      models: ['qwen/qwen3-8b']
+    })
+    expect(mockModelDiscovery.discoverAiModelsAtEndpoint).toHaveBeenCalledWith(
+      'lmstudio',
+      'http://lmstudio.local:1234/v1'
+    )
+  })
+
+  it('rejects unsupported model discovery kinds without accepting a renderer URL', async () => {
+    await expect(invoke(
+      'rex:discoverAiModels',
+      'https://attacker.example/models'
+    )).resolves.toEqual({
+      ok: false,
+      models: [],
+      error: 'Unsupported model discovery provider'
+    })
+    expect(mockModelDiscovery.discoverAiModelsAtEndpoint).not.toHaveBeenCalled()
+  })
+
+  it('returns a generic configuration error without leaking config read failures', async () => {
+    mockConfigStore.readRexConfigStrict.mockImplementationOnce(() => {
+      throw new Error('C:\\Users\\alice\\secret-config.json marker-should-not-leak')
+    })
+
+    const result = await invoke('rex:discoverAiModels', 'ollama') as Record<string, unknown>
+    expect(result).toEqual({
+      ok: false,
+      models: [],
+      error: 'Model discovery configuration could not be read'
+    })
+    expect(JSON.stringify(result)).not.toContain('marker-should-not-leak')
+    expect(mockModelDiscovery.discoverAiModelsAtEndpoint).not.toHaveBeenCalled()
   })
 
 })

--- a/gui/tests/settingsMirror.test.ts
+++ b/gui/tests/settingsMirror.test.ts
@@ -123,3 +123,46 @@ describe('AI provider persistence (US-071)', () => {
     }))
   })
 })
+
+
+describe('OpenAI-compatible endpoint persistence (US-072)', () => {
+  beforeEach(() => {
+    mockReadRexConfig.mockReset().mockReturnValue({
+      openai: { model: 'gpt-4o', base_url: null }
+    })
+    mockWriteRexConfig.mockReset()
+  })
+
+  it('mirrors a configured LM Studio-compatible base URL into openai.base_url', () => {
+    const result = mirrorToRexConfig('ai', {
+      provider: 'openai',
+      model: 'gpt-4o',
+      openaiBaseUrl: '  http://127.0.0.1:1234/v1  '
+    } as never)
+
+    expect(result).toEqual({ ok: true })
+    expect(mockWriteRexConfig).toHaveBeenCalledWith(expect.objectContaining({
+      openai: expect.objectContaining({
+        model: 'gpt-4o',
+        base_url: 'http://127.0.0.1:1234/v1'
+      })
+    }))
+  })
+
+  it('clears openai.base_url when the compatible endpoint field is blank', () => {
+    mockReadRexConfig.mockReturnValue({
+      openai: { model: 'gpt-4o', base_url: 'http://127.0.0.1:1234/v1' }
+    })
+
+    const result = mirrorToRexConfig('ai', {
+      provider: 'openai',
+      model: 'gpt-4o',
+      openaiBaseUrl: '   '
+    } as never)
+
+    expect(result).toEqual({ ok: true })
+    expect(mockWriteRexConfig).toHaveBeenCalledWith(expect.objectContaining({
+      openai: expect.objectContaining({ base_url: null })
+    }))
+  })
+})


### PR DESCRIPTION
## Summary
- add user-triggered Ollama and LM Studio model discovery from canonical configured endpoints
- keep LM Studio on the existing OpenAI-compatible runtime path and persist selected discovered models through existing AI settings
- add truthful loading/error/empty/result states and main-process-only endpoint authority
- guard against stale out-of-order discovery completions and reject query/fragment endpoint ambiguity
- document the durable discovery boundary and update US-072 evidence

## Validation
- focused US-072 GUI matrix: 67 passed
- full GUI Vitest: 164 passed
- GUI typecheck: passed
- GUI production build: passed
- GUI ESLint: 0 errors (3 pre-existing unrelated warnings)
- `pytest -q tests/test_llm_client.py tests/test_model_router.py`: 49 passed
- security release gate: 0 actionable findings, no exposed secrets
- pre-commit all-files: Ruff, Black, detect-secrets passed
- independent Codex rereview: NO ACTIONABLE FINDINGS
- `git diff --check`: passed

The final US-072 "All relevant GitHub checks pass" criterion remains intentionally unchecked until the exact PR head passes the remote matrix.