### PR TITLE
fix(gui): consolidate autonomy settings

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,7 +148,7 @@
         "filename": "config/rex_config.example.json",
         "hashed_secret": "1824173a4a5aacf3b0f3c42098a83de2fc3f1e32",
         "is_verified": false,
-        "line_number": 196
+        "line_number": 197
       }
     ],
     "docs/browser_os.md": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,8 @@ config/rex_config.json
 
 Electron AI-provider selection uses `models.llm_provider` in this file as the canonical runtime source of truth. The GUI value `local` maps only to runtime `transformers`; do not add a second provider key such as `llm.provider`. Persist provider selection independently from provider-specific model editing so changing providers is not blocked while a model identifier is still blank.
 
+Electron autonomy mode uses `models.autonomy_mode` as its only persisted authority. The single user-facing control belongs under Settings > AI; do not reintroduce `autonomyMode` in System settings or persist duplicate AI/System GUI copies. Legacy duplicate values migrate conservatively, with the more restrictive mode winning when no valid runtime value exists.
+
 Electron local-model discovery is user-initiated main-process IPC over the provider endpoint already stored in canonical runtime config. The renderer may request only the supported discovery kind (`ollama` or `lmstudio`), not an arbitrary fetch URL. Ollama discovery uses configured `ollama.base_url`; LM Studio remains Rex's existing OpenAI-compatible runtime path and discovery uses configured `openai.base_url`. Keep loading, error, successful-empty, and discovered-model states distinct, and never present placeholder/example model names as discovered availability.
 
 Core config, `.env`, profiles, and persistent data paths must resolve

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2551,7 +2551,7 @@ pytest -q tests/test_llm_client.py tests/test_model_router.py
 - [x] AI and runtime config read the same autonomy value.
 - [x] Tests cover migration from old duplicate values and System tab absence.
 - [x] `cd gui && npm run typecheck && npm run build` passes.
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass.
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2544,13 +2544,13 @@ pytest -q tests/test_llm_client.py tests/test_model_router.py
 **Implementation notes:** Keep autonomy under AI. Remove the duplicate System autonomy control and audit System for other AI-related settings that should move.
 
 **Acceptance Criteria:**
-- [ ] Only one autonomy UI control exists.
-- [ ] The remaining control lives under Settings > AI.
-- [ ] System no longer has a duplicate autonomy setting.
-- [ ] Saved autonomy value has one source of truth.
-- [ ] AI and runtime config read the same autonomy value.
-- [ ] Tests cover migration from old duplicate values and System tab absence.
-- [ ] `cd gui && npm run typecheck && npm run build` passes.
+- [x] Only one autonomy UI control exists.
+- [x] The remaining control lives under Settings > AI.
+- [x] System no longer has a duplicate autonomy setting.
+- [x] Saved autonomy value has one source of truth.
+- [x] AI and runtime config read the same autonomy value.
+- [x] Tests cover migration from old duplicate values and System tab absence.
+- [x] `cd gui && npm run typecheck && npm run build` passes.
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/config/rex_config.example.json
+++ b/config/rex_config.example.json
@@ -23,6 +23,7 @@
     "llm_model": "sshleifer/tiny-gpt2",
     "llm_max_tokens": 120,
     "llm_temperature": 0.7,
+    "autonomy_mode": "manual",
     "llm_top_p": 0.9,
     "llm_top_k": 50,
     "llm_seed": 42,

--- a/config/rex_config.schema.json
+++ b/config/rex_config.schema.json
@@ -129,6 +129,12 @@
           "minimum": 0,
           "maximum": 5
         },
+        "autonomy_mode": {
+          "type": "string",
+          "description": "Assistant autonomy level used by Settings > AI and runtime planning",
+          "enum": ["manual", "supervised", "full-auto"],
+          "default": "manual"
+        },
         "llm_top_p": {
           "type": "number",
           "description": "Top-p (nucleus) sampling parameter",

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2160,3 +2160,34 @@ Remote exact-head evidence for implementation commit `ebc1d6616949eef99bd6a223aa
 - GitGuardian completed successfully with no secrets detected.
 - PR #404 has no submitted reviews and no inline review threads.
 - US-072's final GitHub-check acceptance criterion is therefore closed. This documentation-only closure commit must still pass the repository's final merge checks before PR #404 is merged.
+
+
+2026-08-15 - US-073 local implementation complete; remote CI pending
+
+Implementation:
+- Consolidated the user-facing Autonomy Mode control under Settings > AI and removed the duplicate System control, type field, default, and System runtime mirror path.
+- Established `models.autonomy_mode` as the single persisted authority. Electron AI reads the canonical runtime value, writes valid submitted changes there, and no longer persists duplicate AI/System `autonomyMode` copies in `gui_settings.json`.
+- Added conservative legacy migration: a valid runtime value wins; otherwise conflicting legacy GUI values resolve to the more restrictive mode (`manual` < `supervised` < `full-auto`) so migration cannot increase autonomy unexpectedly.
+- Malformed runtime JSON is never silently overwritten by migration. AI Settings remains readable using a conservative in-memory legacy value and defers on-disk migration until the runtime config is repaired.
+- Added `AppConfig.autonomy_mode`, JSON loading from `models.autonomy_mode`, schema/example/default config coverage, and validation for the three supported string values. Non-string values fail with `ConfigurationError`, not `TypeError`.
+- Added a durable `CLAUDE.md` rule and config reference documentation so future work does not reintroduce duplicate autonomy authority.
+- Updated `.secrets.baseline` only for the one shifted line in `config/rex_config.example.json`; the final detect-secrets hook passed.
+
+Independent review / fixes:
+- First Codex review found a P1 save-path bug where canonical load precedence could overwrite a newly submitted autonomy change before persistence. Fixed by separating load normalization (`buildAiSettings`) from save intent (`buildAiSettingsForSave`) and added an IPC-level regression test.
+- Second Codex review found a P2 regression where strict migration reads could block AI Settings on malformed runtime JSON. Fixed with non-destructive deferred migration and regression coverage.
+- Third Codex review found a P2 malformed-input case where array/object autonomy values could raise `TypeError`. Fixed with explicit string validation and parametrized regression coverage.
+- Final Codex rereview found no discrete correctness issue in the reviewed changes.
+
+Validation evidence:
+- `pytest -q tests/test_us073_autonomy_config.py tests/test_config_loading.py tests/test_config_migration.py tests/test_config_string_coercion.py tests/test_us075_config_validation.py`: 74 passed on Python 3.11.9; 4 pre-existing `llm_provider` deprecation warnings.
+- Full GUI Vitest suite: 181 passed across 34 files.
+- Focused post-migration GUI matrix: 57 passed across autonomy/settings tests before final Python-only validation tightening; the full suite subsequently passed 181/181.
+- `npm.cmd run typecheck`: passed.
+- `npm.cmd run build`: passed.
+- `npm.cmd run lint`: 0 errors, 3 pre-existing unrelated warnings.
+- `python -m mypy rex/config.py --ignore-missing-imports`: passed.
+- `python scripts/security_audit.py --release-gate`: passed with 0 actionable findings and no exposed secrets.
+- `pre-commit run --all-files`: passed after Black reformatted `rex/config.py` and the baseline line-number refresh was staged.
+- `git diff --check`: passed.
+- US-073 local acceptance criteria are complete. The final GitHub-check criterion remains intentionally unchecked until the exact PR implementation head passes the remote matrix.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2191,3 +2191,15 @@ Validation evidence:
 - `pre-commit run --all-files`: passed after Black reformatted `rex/config.py` and the baseline line-number refresh was staged.
 - `git diff --check`: passed.
 - US-073 local acceptance criteria are complete. The final GitHub-check criterion remains intentionally unchecked until the exact PR implementation head passes the remote matrix.
+
+
+2026-08-16 - US-073 remote GitHub evidence complete
+
+Remote exact-head evidence for corrected implementation head `a85309d10fc721ba6f52a82284328f0ca5dd7562` on PR #405:
+- GitHub Actions CI run #1191 completed successfully.
+- Commitlint run #810 completed successfully.
+- Windows Electron Artifact run #162 completed successfully, including installed-artifact validation.
+- The exact-head check suite completed without failure; GitGuardian remained green and no secrets were reported.
+- CodeFactor initially failed the prior implementation head `93b6c1e2e75a636f16b8d31fd5f86466343f2f86` with one complexity finding in `gui/src/main/autonomySettings.ts`. That finding was addressed by refactoring migration planning/rollback into smaller helpers. CodeFactor then completed successfully on corrected head `a85309d10fc721ba6f52a82284328f0ca5dd7562` with no issues found.
+- PR #405 has no submitted reviews and no inline review threads.
+- US-073's final GitHub-check acceptance criterion is therefore closed. This documentation-only closure commit must still pass the repository's final merge checks before PR #405 is merged.

--- a/docs/claude/CONFIG_AND_SECURITY.md
+++ b/docs/claude/CONFIG_AND_SECURITY.md
@@ -530,6 +530,7 @@ Deprecated flat-field aliases that currently emit `DeprecationWarning`:
 | `active_profile` | `active_profile` (merged from profile) | json-only | runtime | `"default"` |
 | `capabilities` | `capabilities` (merged from profile) | json-only | runtime | `[]` |
 | `personality` | *(dataclass default only)* | default | runtime | `"Friendly"` |
+| `autonomy_mode` | `models.autonomy_mode` | json-only | runtime | `"manual"` |
 | `ui_enabled` | *(dataclass default only)* | default | feature-flag | `True` |
 | `shopping_pwa_pin` | *(dataclass default only)* | default | runtime | `None` |
 | `music_assistant_url` | *(dataclass default only)* | default | runtime | `None` |

--- a/gui/src/main/aiSettings.ts
+++ b/gui/src/main/aiSettings.ts
@@ -1,5 +1,6 @@
 import type { AiSettings, Settings } from '../types/ipc'
 import { readRexConfig } from './configStore'
+import { normalizeAutonomyMode, resolveAutonomyMode } from './autonomySettings'
 
 export const OPENROUTER_DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1'
 export const OPENAI_DEFAULT_MODEL = 'gpt-4o'
@@ -113,13 +114,17 @@ export function buildAiSettings(raw: Settings = {}): AiSettings {
           ? models.llm_max_tokens
           : 2048,
     systemPrompt: typeof raw.systemPrompt === 'string' ? raw.systemPrompt : '',
-    autonomyMode:
-      raw.autonomyMode === 'supervised' || raw.autonomyMode === 'full-auto'
-        ? raw.autonomyMode
-        : 'manual',
+    autonomyMode: resolveAutonomyMode(models.autonomy_mode, raw.autonomyMode),
     budgetPerPlan: typeof raw.budgetPerPlan === 'number' ? raw.budgetPerPlan : 0,
     budgetPerStep: typeof raw.budgetPerStep === 'number' ? raw.budgetPerStep : 0,
     modelRouting: normalizeAiModelRouting(routingSource),
     personality
   }
+}
+
+
+export function buildAiSettingsForSave(raw: Settings = {}): AiSettings {
+  const resolved = buildAiSettings(raw)
+  const submittedAutonomyMode = normalizeAutonomyMode(raw.autonomyMode)
+  return submittedAutonomyMode ? { ...resolved, autonomyMode: submittedAutonomyMode } : resolved
 }

--- a/gui/src/main/autonomySettings.ts
+++ b/gui/src/main/autonomySettings.ts
@@ -49,6 +49,109 @@ export function stripLegacyAutonomyMode(values: Settings): Settings {
   return withoutAutonomyMode(values) ?? {}
 }
 
+interface AutonomyMigrationPlan {
+  nextStored: Record<string, Settings>
+  nextConfig: Record<string, unknown>
+  configChanged: boolean
+  storedChanged: boolean
+}
+
+function cloneRecord<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function legacySettings(stored: Record<string, Settings>): [Settings, Settings] {
+  return [(stored.ai ?? {}) as Settings, (stored.system ?? {}) as Settings]
+}
+
+function malformedConfigFallback(
+  originalStored: Record<string, Settings>
+): Record<string, Settings> {
+  const fallback = cloneRecord(originalStored)
+  const [legacyAi, legacySystem] = legacySettings(originalStored)
+  const hasLegacyValue = normalizeAutonomyMode(legacyAi.autonomyMode) !== null
+    || normalizeAutonomyMode(legacySystem.autonomyMode) !== null
+  if (!hasLegacyValue) return fallback
+
+  fallback.ai = {
+    ...(fallback.ai ?? {}),
+    autonomyMode: resolveAutonomyMode(undefined, legacyAi.autonomyMode, legacySystem.autonomyMode)
+  }
+  return fallback
+}
+
+function buildMigrationPlan(
+  originalStored: Record<string, Settings>,
+  originalConfig: Record<string, unknown>
+): AutonomyMigrationPlan {
+  const nextStored = cloneRecord(originalStored)
+  const nextConfig = cloneRecord(originalConfig)
+  const models = nextConfig.models && typeof nextConfig.models === 'object'
+    ? { ...(nextConfig.models as Record<string, unknown>) }
+    : {}
+  const [legacyAi, legacySystem] = legacySettings(originalStored)
+  const hasRuntimeValue = Object.prototype.hasOwnProperty.call(models, 'autonomy_mode')
+  const hasLegacyValue = normalizeAutonomyMode(legacyAi.autonomyMode) !== null
+    || normalizeAutonomyMode(legacySystem.autonomyMode) !== null
+  const mode = resolveAutonomyMode(models.autonomy_mode, legacyAi.autonomyMode, legacySystem.autonomyMode)
+  const configChanged = (hasRuntimeValue || hasLegacyValue) && models.autonomy_mode !== mode
+  models.autonomy_mode = mode
+  nextConfig.models = models
+
+  const aiHadLegacy = Boolean(
+    nextStored.ai && Object.prototype.hasOwnProperty.call(nextStored.ai, 'autonomyMode')
+  )
+  const systemHadLegacy = Boolean(
+    nextStored.system && Object.prototype.hasOwnProperty.call(nextStored.system, 'autonomyMode')
+  )
+  if (aiHadLegacy) nextStored.ai = withoutAutonomyMode(nextStored.ai) ?? {}
+  if (systemHadLegacy) nextStored.system = withoutAutonomyMode(nextStored.system) ?? {}
+
+  return {
+    nextStored,
+    nextConfig,
+    configChanged,
+    storedChanged: aiHadLegacy || systemHadLegacy
+  }
+}
+
+function rollbackMigration(
+  originalStored: Record<string, Settings>,
+  originalConfig: Record<string, unknown>,
+  state: { storedWritten: boolean; configWritten: boolean }
+): void {
+  const { storedWritten, configWritten } = state
+  if (storedWritten) {
+    try { writeGuiSettings(originalStored) } catch { /* preserve migration error */ }
+  }
+  if (configWritten) {
+    try { writeRexConfig(originalConfig) } catch { /* preserve migration error */ }
+  }
+}
+
+function applyMigrationPlan(
+  plan: AutonomyMigrationPlan,
+  originalStored: Record<string, Settings>,
+  originalConfig: Record<string, unknown>
+): Record<string, Settings> {
+  let configWritten = false
+  let storedWritten = false
+  try {
+    if (plan.configChanged) {
+      writeRexConfig(plan.nextConfig)
+      configWritten = true
+    }
+    if (plan.storedChanged) {
+      writeGuiSettings(plan.nextStored)
+      storedWritten = true
+    }
+    return plan.nextStored
+  } catch (error) {
+    rollbackMigration(originalStored, originalConfig, { storedWritten, configWritten })
+    throw error
+  }
+}
+
 /**
  * Move legacy GUI autonomy values into models.autonomy_mode and remove both
  * duplicate GUI copies. The runtime config is the sole persisted authority.
@@ -62,66 +165,12 @@ export function migrateLegacyAutonomySettings(): Record<string, Settings> {
     // A malformed runtime config must remain untouched and repairable. Defer
     // on-disk migration, but surface a conservative legacy value in memory so
     // AI Settings can still load instead of becoming another recovery blocker.
-    const fallback = JSON.parse(JSON.stringify(originalStored)) as Record<string, Settings>
-    const legacyAi = (originalStored.ai ?? {}) as Settings
-    const legacySystem = (originalStored.system ?? {}) as Settings
-    const hasLegacyValue = normalizeAutonomyMode(legacyAi.autonomyMode) !== null
-      || normalizeAutonomyMode(legacySystem.autonomyMode) !== null
-    if (hasLegacyValue) {
-      fallback.ai = {
-        ...(fallback.ai ?? {}),
-        autonomyMode: resolveAutonomyMode(undefined, legacyAi.autonomyMode, legacySystem.autonomyMode)
-      }
-    }
-    return fallback
-  }
-  const nextStored = JSON.parse(JSON.stringify(originalStored)) as Record<string, Settings>
-  const nextConfig = JSON.parse(JSON.stringify(originalConfig)) as Record<string, unknown>
-  const models = nextConfig.models && typeof nextConfig.models === 'object'
-    ? { ...(nextConfig.models as Record<string, unknown>) }
-    : {}
-
-  const legacyAi = (originalStored.ai ?? {}) as Settings
-  const legacySystem = (originalStored.system ?? {}) as Settings
-  const hasRuntimeValue = Object.prototype.hasOwnProperty.call(models, 'autonomy_mode')
-  const hasLegacyValue = normalizeAutonomyMode(legacyAi.autonomyMode) !== null
-    || normalizeAutonomyMode(legacySystem.autonomyMode) !== null
-  const mode = resolveAutonomyMode(models.autonomy_mode, legacyAi.autonomyMode, legacySystem.autonomyMode)
-  const configChanged = (hasRuntimeValue || hasLegacyValue) && models.autonomy_mode !== mode
-  models.autonomy_mode = mode
-  nextConfig.models = models
-
-  const nextAi = withoutAutonomyMode(nextStored.ai)
-  const nextSystem = withoutAutonomyMode(nextStored.system)
-  let storedChanged = false
-  if (nextStored.ai && Object.prototype.hasOwnProperty.call(nextStored.ai, 'autonomyMode')) {
-    storedChanged = true
-    nextStored.ai = nextAi ?? {}
-  }
-  if (nextStored.system && Object.prototype.hasOwnProperty.call(nextStored.system, 'autonomyMode')) {
-    storedChanged = true
-    nextStored.system = nextSystem ?? {}
+    return malformedConfigFallback(originalStored)
   }
 
-  let configWritten = false
-  let storedWritten = false
-  try {
-    if (configChanged) {
-      writeRexConfig(nextConfig)
-      configWritten = true
-    }
-    if (storedChanged) {
-      writeGuiSettings(nextStored)
-      storedWritten = true
-    }
-    return nextStored
-  } catch (error) {
-    if (storedWritten) {
-      try { writeGuiSettings(originalStored) } catch { /* preserve migration error */ }
-    }
-    if (configWritten) {
-      try { writeRexConfig(originalConfig) } catch { /* preserve migration error */ }
-    }
-    throw error
-  }
+  return applyMigrationPlan(
+    buildMigrationPlan(originalStored, originalConfig),
+    originalStored,
+    originalConfig
+  )
 }

--- a/gui/src/main/autonomySettings.ts
+++ b/gui/src/main/autonomySettings.ts
@@ -1,0 +1,127 @@
+import type { AiSettings, Settings } from '../types/ipc'
+import { readGuiSettings, readRexConfigStrict, writeGuiSettings, writeRexConfig } from './configStore'
+
+export type AutonomyMode = AiSettings['autonomyMode']
+
+const AUTONOMY_RANK: Record<AutonomyMode, number> = {
+  manual: 0,
+  supervised: 1,
+  'full-auto': 2
+}
+
+export function normalizeAutonomyMode(value: unknown): AutonomyMode | null {
+  if (value === 'manual' || value === 'supervised' || value === 'full-auto') return value
+  return null
+}
+
+/**
+ * Resolve the single runtime autonomy mode.
+ *
+ * A valid canonical runtime value always wins. During migration from duplicate
+ * GUI values, conflicting legacy values resolve to the more restrictive mode so
+ * migration can never increase autonomy unexpectedly.
+ */
+export function resolveAutonomyMode(
+  runtimeValue: unknown,
+  legacyAiValue?: unknown,
+  legacySystemValue?: unknown
+): AutonomyMode {
+  const runtime = normalizeAutonomyMode(runtimeValue)
+  if (runtime) return runtime
+
+  const legacy = [legacyAiValue, legacySystemValue]
+    .map(normalizeAutonomyMode)
+    .filter((value): value is AutonomyMode => value !== null)
+  if (legacy.length === 0) return 'manual'
+  return legacy.reduce((safer, candidate) =>
+    AUTONOMY_RANK[candidate] < AUTONOMY_RANK[safer] ? candidate : safer
+  )
+}
+
+function withoutAutonomyMode(settings: Settings | undefined): Settings | undefined {
+  if (!settings || typeof settings !== 'object') return settings
+  const next = { ...settings }
+  delete next.autonomyMode
+  return next
+}
+
+export function stripLegacyAutonomyMode(values: Settings): Settings {
+  return withoutAutonomyMode(values) ?? {}
+}
+
+/**
+ * Move legacy GUI autonomy values into models.autonomy_mode and remove both
+ * duplicate GUI copies. The runtime config is the sole persisted authority.
+ */
+export function migrateLegacyAutonomySettings(): Record<string, Settings> {
+  const originalStored = readGuiSettings()
+  let originalConfig: Record<string, unknown>
+  try {
+    originalConfig = readRexConfigStrict()
+  } catch {
+    // A malformed runtime config must remain untouched and repairable. Defer
+    // on-disk migration, but surface a conservative legacy value in memory so
+    // AI Settings can still load instead of becoming another recovery blocker.
+    const fallback = JSON.parse(JSON.stringify(originalStored)) as Record<string, Settings>
+    const legacyAi = (originalStored.ai ?? {}) as Settings
+    const legacySystem = (originalStored.system ?? {}) as Settings
+    const hasLegacyValue = normalizeAutonomyMode(legacyAi.autonomyMode) !== null
+      || normalizeAutonomyMode(legacySystem.autonomyMode) !== null
+    if (hasLegacyValue) {
+      fallback.ai = {
+        ...(fallback.ai ?? {}),
+        autonomyMode: resolveAutonomyMode(undefined, legacyAi.autonomyMode, legacySystem.autonomyMode)
+      }
+    }
+    return fallback
+  }
+  const nextStored = JSON.parse(JSON.stringify(originalStored)) as Record<string, Settings>
+  const nextConfig = JSON.parse(JSON.stringify(originalConfig)) as Record<string, unknown>
+  const models = nextConfig.models && typeof nextConfig.models === 'object'
+    ? { ...(nextConfig.models as Record<string, unknown>) }
+    : {}
+
+  const legacyAi = (originalStored.ai ?? {}) as Settings
+  const legacySystem = (originalStored.system ?? {}) as Settings
+  const hasRuntimeValue = Object.prototype.hasOwnProperty.call(models, 'autonomy_mode')
+  const hasLegacyValue = normalizeAutonomyMode(legacyAi.autonomyMode) !== null
+    || normalizeAutonomyMode(legacySystem.autonomyMode) !== null
+  const mode = resolveAutonomyMode(models.autonomy_mode, legacyAi.autonomyMode, legacySystem.autonomyMode)
+  const configChanged = (hasRuntimeValue || hasLegacyValue) && models.autonomy_mode !== mode
+  models.autonomy_mode = mode
+  nextConfig.models = models
+
+  const nextAi = withoutAutonomyMode(nextStored.ai)
+  const nextSystem = withoutAutonomyMode(nextStored.system)
+  let storedChanged = false
+  if (nextStored.ai && Object.prototype.hasOwnProperty.call(nextStored.ai, 'autonomyMode')) {
+    storedChanged = true
+    nextStored.ai = nextAi ?? {}
+  }
+  if (nextStored.system && Object.prototype.hasOwnProperty.call(nextStored.system, 'autonomyMode')) {
+    storedChanged = true
+    nextStored.system = nextSystem ?? {}
+  }
+
+  let configWritten = false
+  let storedWritten = false
+  try {
+    if (configChanged) {
+      writeRexConfig(nextConfig)
+      configWritten = true
+    }
+    if (storedChanged) {
+      writeGuiSettings(nextStored)
+      storedWritten = true
+    }
+    return nextStored
+  } catch (error) {
+    if (storedWritten) {
+      try { writeGuiSettings(originalStored) } catch { /* preserve migration error */ }
+    }
+    if (configWritten) {
+      try { writeRexConfig(originalConfig) } catch { /* preserve migration error */ }
+    }
+    throw error
+  }
+}

--- a/gui/src/main/handlers/settings.ts
+++ b/gui/src/main/handlers/settings.ts
@@ -3,7 +3,6 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { existsSync, readFileSync } from 'fs'
 import type {
-  AiSettings,
   ModelDiscoveryProvider,
   ModelDiscoveryResponse,
   PreferenceSuggestion,
@@ -11,7 +10,8 @@ import type {
   WakeWordStatus
 } from '../../types/ipc'
 import { readGuiSettings, readRexConfigStrict, writeGuiSettings, writeRexConfig } from '../configStore'
-import { buildAiSettings } from '../aiSettings'
+import { buildAiSettings, buildAiSettingsForSave } from '../aiSettings'
+import { migrateLegacyAutonomySettings, stripLegacyAutonomyMode } from '../autonomySettings'
 import { buildVoiceSettings, buildWakeWordStatus } from '../voiceSettings'
 import { defaultSettingsMap } from '../settingsDefaults'
 import { mirrorToRexConfig } from '../settingsMirror'
@@ -55,7 +55,7 @@ function objectSection(value: unknown): Record<string, unknown> {
 
 export function registerSettingsHandlers(session: ElectronSessionIdentity): void {
   ipcMain.handle('rex:getSettings', async (_event, section: string): Promise<Settings> => {
-    const stored = readGuiSettings()
+    const stored = section === 'ai' ? migrateLegacyAutonomySettings() : readGuiSettings()
     if (section === 'ai') {
       return buildAiSettings((stored[section] ?? {}) as Settings) as unknown as Settings
     }
@@ -100,7 +100,7 @@ export function registerSettingsHandlers(session: ElectronSessionIdentity): void
     async (_event, section: string, values: Settings): Promise<{ ok: boolean; error?: string }> => {
       const normalizedValues =
         section === 'ai'
-          ? (buildAiSettings(values) as unknown as Settings)
+          ? (buildAiSettingsForSave(values) as unknown as Settings)
           : section === 'voice'
             ? (buildVoiceSettings(values) as unknown as Settings)
             : values
@@ -134,7 +134,7 @@ export function registerSettingsHandlers(session: ElectronSessionIdentity): void
     }
 
     const stored = readGuiSettings()
-    const aiSettings = (stored['ai'] ?? defaultSettingsMap['ai'] ?? {}) as unknown as AiSettings
+    const aiSettings = buildAiSettings((stored['ai'] ?? defaultSettingsMap['ai'] ?? {}) as Settings)
 
     const suggestions: PreferenceSuggestion[] = []
 
@@ -187,7 +187,7 @@ export function registerSettingsHandlers(session: ElectronSessionIdentity): void
       const originalStored = JSON.parse(JSON.stringify(stored)) as Record<string, Settings>
       const aiSection = buildAiSettings((stored['ai'] ?? defaultSettingsMap['ai'] ?? {}) as Settings) as unknown as Record<string, unknown>
       aiSection[field] = value
-      stored['ai'] = aiSection as Settings
+      stored['ai'] = stripLegacyAutonomyMode(aiSection as Settings)
       writeGuiSettings(stored)
       const result = mirrorToRexConfig('ai', aiSection as Settings)
       if (result.ok) return { ok: true }

--- a/gui/src/main/integrationSettingsStorage.ts
+++ b/gui/src/main/integrationSettingsStorage.ts
@@ -2,6 +2,7 @@ import type { Settings } from '../types/ipc'
 import { readGuiSettings, readRexConfigStrict, writeGuiSettings, writeRexConfig } from './configStore'
 import { defaultSettingsMap } from './settingsDefaults'
 import { mirrorToRexConfig } from './settingsMirror'
+import { stripLegacyAutonomyMode } from './autonomySettings'
 import { reconcileIntegrationStatuses } from './integrationStatus'
 import {
   vaultDeleteSecret,
@@ -328,7 +329,7 @@ export async function persistSettingsSection(
           session, values, originalStored, originalConfig, nextConfig, staged, replaced
         )
       : values
-    stored[section] = normalized
+    stored[section] = section === 'ai' ? stripLegacyAutonomyMode(normalized) : normalized
     writeGuiSettings(stored)
     guiWritten = true
     writeRexConfig(nextConfig)

--- a/gui/src/main/settingsDefaults.ts
+++ b/gui/src/main/settingsDefaults.ts
@@ -86,7 +86,6 @@ export const defaultSettingsMap: Record<string, Settings> = {
     credentialStatus: {}
   } satisfies IntegrationsSettings,
   system: {
-    autonomyMode: 'manual',
     toolTimeoutSeconds: 10,
     requireConfirmSystemChanges: true,
     allowedFileRoots: '',

--- a/gui/src/main/settingsMirror.ts
+++ b/gui/src/main/settingsMirror.ts
@@ -1,6 +1,7 @@
 import type { Settings } from '../types/ipc'
 import { readRexConfig, writeRexConfig } from './configStore'
 import { normalizeAiModelRouting, normalizeGuiAiProvider, toRuntimeAiProvider } from './aiSettings'
+import { normalizeAutonomyMode } from './autonomySettings'
 import { buildVoiceSettings, defaultCustomWakeWordAssetPath, wakeWordIdToPhrase } from './voiceSettings'
 
 export interface MirrorResult {
@@ -23,6 +24,11 @@ export function mirrorToRexConfig(section: string, values: Settings): MirrorResu
       const models = ((rexConfig.models ?? {}) as Record<string, unknown>)
       if (typeof values.temperature === 'number') models.llm_temperature = String(values.temperature)
       if (typeof values.maxTokens === 'number') models.llm_max_tokens = values.maxTokens
+      if (typeof values.autonomyMode === 'string') {
+        const autonomyMode = normalizeAutonomyMode(values.autonomyMode)
+        if (!autonomyMode) return { ok: false, error: 'Invalid autonomy mode' }
+        models.autonomy_mode = autonomyMode
+      }
       const providerWasSupplied = typeof values.provider === 'string'
       const provider = normalizeGuiAiProvider(
         providerWasSupplied ? values.provider : models.llm_provider
@@ -183,11 +189,6 @@ export function mirrorToRexConfig(section: string, values: Settings): MirrorResu
         const runtime = ((rexConfig.runtime ?? {}) as Record<string, unknown>)
         runtime.log_level = values.debugLogging ? 'DEBUG' : 'INFO'
         rexConfig.runtime = runtime
-      }
-      if (typeof values.autonomyMode === 'string') {
-        const models = ((rexConfig.models ?? {}) as Record<string, unknown>)
-        models.autonomy_mode = values.autonomyMode
-        rexConfig.models = models
       }
       writeRexConfig(rexConfig)
     }

--- a/gui/src/pages/settings/SystemSettingsSection.tsx
+++ b/gui/src/pages/settings/SystemSettingsSection.tsx
@@ -5,7 +5,6 @@ import { useToast } from '../../components/ui/Toast'
 export function SystemSettingsSection(): React.ReactElement {
   const addToast = useToast()
   const [settings, setSettings] = useState<SystemSettings>({
-    autonomyMode: 'manual',
     toolTimeoutSeconds: 10,
     requireConfirmSystemChanges: true,
     allowedFileRoots: '',
@@ -21,10 +20,6 @@ export function SystemSettingsSection(): React.ReactElement {
       .getSettings('system')
       .then((s: Settings) => {
         setSettings({
-          autonomyMode:
-            s.autonomyMode === 'supervised' || s.autonomyMode === 'full-auto'
-              ? (s.autonomyMode as 'supervised' | 'full-auto')
-              : 'manual',
           toolTimeoutSeconds: typeof s.toolTimeoutSeconds === 'number' ? s.toolTimeoutSeconds : 10,
           requireConfirmSystemChanges:
             typeof s.requireConfirmSystemChanges === 'boolean' ? s.requireConfirmSystemChanges : true,
@@ -81,28 +76,6 @@ export function SystemSettingsSection(): React.ReactElement {
   return (
     <div className="p-6 max-w-lg">
       <h2 className="text-lg font-semibold text-text-primary mb-6">System &amp; Advanced</h2>
-
-      {/* Autonomy mode */}
-      <div className="mb-6">
-        <label className="block text-sm font-medium text-text-primary mb-2">Autonomy Mode</label>
-        <select
-          value={settings.autonomyMode}
-          onChange={(e) =>
-            setSettings((s) => ({
-              ...s,
-              autonomyMode: e.target.value as SystemSettings['autonomyMode']
-            }))
-          }
-          className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
-        >
-          <option value="manual">Manual — Rex only acts when explicitly asked</option>
-          <option value="supervised">Supervised — Rex proposes actions, you confirm</option>
-          <option value="full-auto">Full-Auto — Rex acts autonomously within budget</option>
-        </select>
-        <p className="mt-1 text-xs text-text-secondary">
-          Controls how independently Rex takes actions on your behalf.
-        </p>
-      </div>
 
       {/* Tool timeout */}
       <div className="mb-6">

--- a/gui/src/types/ipc.ts
+++ b/gui/src/types/ipc.ts
@@ -202,7 +202,6 @@ export interface Procedure {
 }
 
 export interface SystemSettings {
-  autonomyMode: 'manual' | 'supervised' | 'full-auto'
   toolTimeoutSeconds: number
   requireConfirmSystemChanges: boolean
   allowedFileRoots: string

--- a/gui/tests/aiSettings.test.ts
+++ b/gui/tests/aiSettings.test.ts
@@ -8,6 +8,7 @@ import {
   OPENROUTER_DEFAULT_BASE_URL,
   OPENROUTER_DEFAULT_MODEL,
   buildAiSettings,
+  buildAiSettingsForSave,
   normalizeGuiAiProvider,
   toRuntimeAiProvider
 } from '../src/main/aiSettings'
@@ -94,5 +95,27 @@ describe('OpenAI-compatible endpoint settings (US-072)', () => {
     })
 
     expect(buildAiSettings({ openaiBaseUrl: '' }).openaiBaseUrl).toBe('')
+  })
+})
+
+
+describe('autonomy runtime authority (US-073)', () => {
+  beforeEach(() => mockReadRexConfig.mockReset().mockReturnValue({}))
+
+  it('loads the canonical runtime autonomy mode instead of stale GUI state', () => {
+    mockReadRexConfig.mockReturnValue({ models: { autonomy_mode: 'supervised' } })
+
+    expect(buildAiSettings({ autonomyMode: 'full-auto' }).autonomyMode).toBe('supervised')
+  })
+
+  it('falls back to a legacy AI value only when runtime authority is absent', () => {
+    expect(buildAiSettings({ autonomyMode: 'supervised' }).autonomyMode).toBe('supervised')
+  })
+
+  it('preserves an explicitly submitted autonomy change during save normalization', () => {
+    mockReadRexConfig.mockReturnValue({ models: { autonomy_mode: 'manual' } })
+
+    expect(buildAiSettingsForSave({ autonomyMode: 'full-auto' }).autonomyMode).toBe('full-auto')
+    expect(buildAiSettings({ autonomyMode: 'full-auto' }).autonomyMode).toBe('manual')
   })
 })

--- a/gui/tests/autonomySettings.test.ts
+++ b/gui/tests/autonomySettings.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockReadGuiSettings,
+  mockReadRexConfigStrict,
+  mockWriteGuiSettings,
+  mockWriteRexConfig
+} = vi.hoisted(() => ({
+  mockReadGuiSettings: vi.fn(),
+  mockReadRexConfigStrict: vi.fn(),
+  mockWriteGuiSettings: vi.fn(),
+  mockWriteRexConfig: vi.fn()
+}))
+
+vi.mock('../src/main/configStore', () => ({
+  readGuiSettings: mockReadGuiSettings,
+  readRexConfigStrict: mockReadRexConfigStrict,
+  writeGuiSettings: mockWriteGuiSettings,
+  writeRexConfig: mockWriteRexConfig
+}))
+
+import {
+  migrateLegacyAutonomySettings,
+  resolveAutonomyMode,
+  stripLegacyAutonomyMode
+} from '../src/main/autonomySettings'
+
+describe('autonomy settings consolidation (US-073)', () => {
+  beforeEach(() => {
+    mockReadGuiSettings.mockReset().mockReturnValue({})
+    mockReadRexConfigStrict.mockReset().mockReturnValue({})
+    mockWriteGuiSettings.mockReset()
+    mockWriteRexConfig.mockReset()
+  })
+
+  it('uses the canonical runtime autonomy mode when it is valid', () => {
+    expect(resolveAutonomyMode('supervised', 'manual', 'full-auto')).toBe('supervised')
+  })
+
+  it('chooses the more restrictive legacy mode when duplicate GUI values conflict', () => {
+    expect(resolveAutonomyMode(undefined, 'full-auto', 'manual')).toBe('manual')
+    expect(resolveAutonomyMode(undefined, 'full-auto', 'supervised')).toBe('supervised')
+  })
+
+  it('defaults to manual when no valid autonomy value exists', () => {
+    expect(resolveAutonomyMode('invalid', 'also-invalid', undefined)).toBe('manual')
+  })
+
+  it('keeps AI settings readable and defers writes when runtime config is malformed', () => {
+    mockReadGuiSettings.mockReturnValue({
+      ai: { autonomyMode: 'full-auto', model: 'gpt-4o' },
+      system: { autonomyMode: 'manual' }
+    })
+    mockReadRexConfigStrict.mockImplementation(() => { throw new Error('malformed json') })
+
+    const migrated = migrateLegacyAutonomySettings()
+
+    expect(migrated.ai).toEqual({ autonomyMode: 'manual', model: 'gpt-4o' })
+    expect(migrated.system).toEqual({ autonomyMode: 'manual' })
+    expect(mockWriteRexConfig).not.toHaveBeenCalled()
+    expect(mockWriteGuiSettings).not.toHaveBeenCalled()
+  })
+
+  it('does not create runtime config just to persist an unsaved default', () => {
+    const migrated = migrateLegacyAutonomySettings()
+
+    expect(migrated).toEqual({})
+    expect(mockWriteRexConfig).not.toHaveBeenCalled()
+    expect(mockWriteGuiSettings).not.toHaveBeenCalled()
+  })
+
+  it('migrates duplicate GUI values into the canonical runtime field and removes both copies', () => {
+    mockReadGuiSettings.mockReturnValue({
+      ai: { autonomyMode: 'full-auto', model: 'gpt-4o' },
+      system: { autonomyMode: 'manual', toolTimeoutSeconds: 10 }
+    })
+    mockReadRexConfigStrict.mockReturnValue({ models: { llm_provider: 'openai' } })
+
+    const migrated = migrateLegacyAutonomySettings()
+
+    expect(mockWriteRexConfig).toHaveBeenCalledWith({
+      models: { llm_provider: 'openai', autonomy_mode: 'manual' }
+    })
+    expect(mockWriteGuiSettings).toHaveBeenCalledTimes(1)
+    expect(migrated.ai).toEqual({ model: 'gpt-4o' })
+    expect(migrated.system).toEqual({ toolTimeoutSeconds: 10 })
+  })
+
+  it('preserves an existing canonical runtime value while removing stale GUI duplicates', () => {
+    mockReadGuiSettings.mockReturnValue({
+      ai: { autonomyMode: 'full-auto' },
+      system: { autonomyMode: 'manual' }
+    })
+    mockReadRexConfigStrict.mockReturnValue({ models: { autonomy_mode: 'supervised' } })
+
+    migrateLegacyAutonomySettings()
+
+    expect(mockWriteRexConfig).not.toHaveBeenCalled()
+    expect(mockWriteGuiSettings).toHaveBeenCalledWith({ ai: {}, system: {} })
+  })
+
+  it('does not retain autonomyMode in the GUI AI settings store', () => {
+    expect(stripLegacyAutonomyMode({ autonomyMode: 'full-auto', model: 'gpt-4o' })).toEqual({
+      model: 'gpt-4o'
+    })
+  })
+})

--- a/gui/tests/autonomySettingsUi.test.ts
+++ b/gui/tests/autonomySettingsUi.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+const root = join(__dirname, '..')
+const aiSection = readFileSync(join(root, 'src/pages/settings/AiSettingsSection.tsx'), 'utf8')
+const systemSection = readFileSync(join(root, 'src/pages/settings/SystemSettingsSection.tsx'), 'utf8')
+const defaults = readFileSync(join(root, 'src/main/settingsDefaults.ts'), 'utf8')
+const mirror = readFileSync(join(root, 'src/main/settingsMirror.ts'), 'utf8')
+
+describe('autonomy settings UI authority (US-073)', () => {
+  it('keeps the only Autonomy Mode control under AI settings', () => {
+    expect(aiSection).toContain('Autonomy Mode')
+    expect(aiSection).toContain('id="autonomyMode"')
+    expect(systemSection).not.toContain('Autonomy Mode')
+    expect(systemSection).not.toContain('autonomyMode')
+  })
+
+  it('does not define a duplicate System autonomy default or mirror path', () => {
+    const systemDefaults = defaults.slice(defaults.indexOf('system: {'))
+    expect(systemDefaults).not.toContain('autonomyMode')
+    const systemMirror = mirror.slice(mirror.indexOf("if (section === 'system')"))
+    expect(systemMirror).not.toContain('models.autonomy_mode')
+  })
+})

--- a/gui/tests/settingsHandlers.test.ts
+++ b/gui/tests/settingsHandlers.test.ts
@@ -21,6 +21,7 @@ vi.mock('electron', () => ({ app: mockApp, ipcMain: { handle: mockHandle } }))
 const { mockConfigStore } = vi.hoisted(() => ({
   mockConfigStore: {
     readGuiSettings: vi.fn(),
+    readRexConfig: vi.fn(),
     readRexConfigStrict: vi.fn(),
     writeGuiSettings: vi.fn(),
     writeRexConfig: vi.fn()
@@ -76,6 +77,7 @@ describe('settings vault routing (S4)', () => {
     guiSettings = {}
     rexConfig = {}
     mockConfigStore.readGuiSettings.mockReset().mockImplementation(() => guiSettings)
+    mockConfigStore.readRexConfig.mockReset().mockImplementation(() => rexConfig)
     mockConfigStore.readRexConfigStrict.mockReset().mockImplementation(() => rexConfig)
     mockConfigStore.writeGuiSettings.mockReset().mockImplementation((value) => { guiSettings = value })
     mockConfigStore.writeRexConfig.mockReset().mockImplementation((value) => { rexConfig = value })
@@ -89,6 +91,18 @@ describe('settings vault routing (S4)', () => {
     mockVault.vaultHasSecret.mockReset().mockResolvedValue(false)
     mockVault.vaultDeleteSecret.mockReset().mockResolvedValue(true)
     registerSettingsHandlers(session)
+  })
+
+  it('preserves an explicit AI autonomy change through save normalization', async () => {
+    rexConfig = { models: { autonomy_mode: 'manual' } }
+
+    const result = await invoke('rex:setSettings', 'ai', { autonomyMode: 'full-auto' })
+
+    expect(result).toEqual({ ok: true })
+    expect(mockMirror.mirrorToRexConfig).toHaveBeenCalledWith(
+      'ai', expect.objectContaining({ autonomyMode: 'full-auto' })
+    )
+    expect(guiSettings).toMatchObject({ ai: expect.not.objectContaining({ autonomyMode: expect.anything() }) })
   })
 
   it('writes an API key to the vault and persists only a contextual reference', async () => {

--- a/gui/tests/settingsMirror.test.ts
+++ b/gui/tests/settingsMirror.test.ts
@@ -166,3 +166,32 @@ describe('OpenAI-compatible endpoint persistence (US-072)', () => {
     }))
   })
 })
+
+
+describe('autonomy runtime persistence (US-073)', () => {
+  beforeEach(() => {
+    mockReadRexConfig.mockReset().mockReturnValue({ models: { autonomy_mode: 'manual' } })
+    mockWriteRexConfig.mockReset()
+  })
+
+  it('mirrors autonomy only from the AI settings section', () => {
+    expect(mirrorToRexConfig('ai', { autonomyMode: 'supervised' } as never)).toEqual({ ok: true })
+    expect(mockWriteRexConfig).toHaveBeenCalledWith(expect.objectContaining({
+      models: expect.objectContaining({ autonomy_mode: 'supervised' })
+    }))
+  })
+
+  it('rejects an invalid AI autonomy mode instead of corrupting runtime config', () => {
+    const result = mirrorToRexConfig('ai', { autonomyMode: 'unbounded' } as never)
+
+    expect(result).toEqual({ ok: false, error: 'Invalid autonomy mode' })
+    expect(mockWriteRexConfig).not.toHaveBeenCalled()
+  })
+
+  it('ignores a legacy System autonomy field instead of changing runtime authority', () => {
+    expect(mirrorToRexConfig('system', { autonomyMode: 'full-auto' } as never)).toEqual({ ok: true })
+    expect(mockWriteRexConfig).toHaveBeenCalledWith(expect.objectContaining({
+      models: expect.objectContaining({ autonomy_mode: 'manual' })
+    }))
+  })
+})

--- a/rex/config.py
+++ b/rex/config.py
@@ -392,6 +392,7 @@ class AppConfig:
     llm_max_tokens: int = 120
     voice_max_tokens: int = 150
     llm_temperature: float = 0.7
+    autonomy_mode: str = "manual"
     llm_top_p: float = 0.9
     llm_top_k: int = 50
     llm_seed: int = 42
@@ -1266,6 +1267,7 @@ def build_app_config(json_config: dict) -> AppConfig:
         llm_model=_get_nested(json_config, "models.llm_model", "sshleifer/tiny-gpt2"),
         llm_max_tokens=_coerce_int(json_config, "models.llm_max_tokens", 120),
         llm_temperature=_coerce_float(json_config, "models.llm_temperature", 0.7),
+        autonomy_mode=_get_nested(json_config, "models.autonomy_mode", "manual"),
         llm_top_p=_coerce_float(json_config, "models.llm_top_p", 0.9),
         llm_top_k=_coerce_int(json_config, "models.llm_top_k", 50),
         llm_seed=_coerce_int(json_config, "models.llm_seed", 42),
@@ -1493,6 +1495,12 @@ def validate_config(config: AppConfig) -> None:
         raise ConfigurationError("llm_max_tokens must be positive.")
     if not (0 <= config.llm_temperature <= 5.0):
         raise ConfigurationError("llm_temperature must be between 0 and 5.")
+    if not isinstance(config.autonomy_mode, str) or config.autonomy_mode not in {
+        "manual",
+        "supervised",
+        "full-auto",
+    }:
+        raise ConfigurationError("autonomy_mode must be manual, supervised, or full-auto.")
     if config.memory_max_turns <= 0:
         raise ConfigurationError("memory_max_turns must be positive.")
     if config.use_openclaw_tools or config.use_openclaw_voice_backend:

--- a/rex/config_manager.py
+++ b/rex/config_manager.py
@@ -51,6 +51,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "llm_model": "sshleifer/tiny-gpt2",
         "llm_max_tokens": 120,
         "llm_temperature": 0.7,
+        "autonomy_mode": "manual",
         "llm_top_p": 0.9,
         "llm_top_k": 50,
         "llm_seed": 42,

--- a/tests/test_us073_autonomy_config.py
+++ b/tests/test_us073_autonomy_config.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from rex.assistant_errors import ConfigurationError
+from rex.config import build_app_config, validate_config
+
+
+def test_runtime_config_reads_canonical_autonomy_mode() -> None:
+    config = build_app_config({"models": {"autonomy_mode": "supervised"}})
+
+    assert config.autonomy_mode == "supervised"
+    validate_config(config)
+
+
+def test_runtime_config_defaults_autonomy_mode_to_manual() -> None:
+    config = build_app_config({})
+
+    assert config.autonomy_mode == "manual"
+    validate_config(config)
+
+
+def test_runtime_config_rejects_unknown_autonomy_mode() -> None:
+    config = build_app_config({"models": {"autonomy_mode": "unbounded"}})
+
+    with pytest.raises(ConfigurationError, match="autonomy_mode"):
+        validate_config(config)
+
+
+@pytest.mark.parametrize("value", [["full-auto"], {"mode": "full-auto"}])
+def test_runtime_config_rejects_non_string_autonomy_mode(value: object) -> None:
+    config = build_app_config({"models": {"autonomy_mode": value}})
+
+    with pytest.raises(ConfigurationError, match="autonomy_mode"):
+        validate_config(config)


### PR DESCRIPTION
## Summary
- keep the only user-facing Autonomy Mode control under Settings > AI and remove the duplicate System setting
- make `models.autonomy_mode` the single persisted authority shared by Electron and Python runtime config
- migrate legacy duplicate AI/System values conservatively so migration cannot increase autonomy unexpectedly
- preserve explicit user save intent while canonical runtime values continue to win on load
- defer migration without overwriting malformed runtime JSON, keeping AI Settings usable for recovery
- validate runtime autonomy values, including non-string malformed values, with normal `ConfigurationError`

## Review fixes
- Codex P1: fixed submitted autonomy changes being overwritten by canonical load precedence during save
- Codex P2: fixed malformed runtime JSON blocking AI Settings load
- Codex P2: fixed array/object autonomy values raising `TypeError`
- final Codex rereview: no discrete correctness issue identified

## Validation
- Python 3.11 config matrix: 74 passed (4 pre-existing llm_provider deprecation warnings)
- full GUI Vitest: 181 passed across 34 files
- post-rebase focused GUI matrix: 57 passed
- GUI typecheck: passed
- GUI production build: passed
- GUI ESLint: 0 errors, 3 pre-existing unrelated warnings
- mypy `rex/config.py`: passed
- security release gate: 0 actionable findings, no exposed secrets
- pre-commit all-files: passed
- detect-secrets: passed with a one-line baseline line-number refresh
- `git diff --check`: passed

The final US-073 `All relevant GitHub checks pass` criterion remains intentionally unchecked until this exact PR head passes the remote matrix.