### PR TITLE
fix(search): route current info through verified search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,6 +594,8 @@ The following must degrade gracefully if not configured:
 - Home Assistant
 - web search
 
+Current-news/current-info requests must never fall through to an ungrounded LLM answer. Detect explicit live-news intent before generation, require an actually usable Web Search provider, execute search through the pre-LLM tool dispatcher, and fail closed if search is unavailable or returns no verified result. Do not claim a Settings UI path that does not exist; current Web Search setup authority is `search.providers` plus the credential/config guidance in `docs/configuration.md`.
+
 Integration readiness uses the shared state vocabulary in `rex/integration_state.py` and
 `gui/src/types/ipc.ts`: unavailable, unconfigured, configured, reachable, authenticated,
 degraded, read-only, write-capable, write-tested, and verified. Credentials alone mean

--- a/INTEGRATIONS_STATUS.md
+++ b/INTEGRATIONS_STATUS.md
@@ -14,7 +14,7 @@ For the production-facing mapping from backend/docs capabilities to Electron vis
 | Email | Partial | IMAP/SMTP backend paths exist. GUI email sending is unavailable; it creates a draft that can be copied to a mail client. Outlook Graph OAuth is unavailable. |
 | Calendar | Partial / read-only by backend | ICS reads exist. Credentials are configured-only until authenticated. Provider writes and Outlook Graph OAuth are unavailable. |
 | SMS / Phone | Experimental | Twilio paths require complete credentials. Status checks do not claim delivery or calling success; live delivery is externally verified. |
-| Web search | Partial | Provider selection exists. Configuration does not prove current network reachability. |
+| Web search | Partial | Provider selection exists. DuckDuckGo is a no-key fallback when enabled; keyed providers require usable credentials. Explicit current-news requests are routed through Web Search before the LLM and fail closed if no verified search result is returned. Configuration still does not prove current network reachability. |
 | OpenAI / OpenRouter / Ollama | Supported provider options | A key or URL is configuration evidence only. Provider availability depends on a live request. |
 | MQTT / Telegram / Push | Experimental | Visible and configurable, but live broker/provider authentication and delivery are externally verified. |
 | OpenClaw gateway | Experimental and optional | Disabled by default. URL/token are configuration evidence; the GUI health check can establish `reachable`, but authentication and tool capability remain unproven. The external gateway is not required by the packaged app. |

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2707,7 +2707,7 @@ pytest -q tests/test_llm_client.py tests/test_assistant.py
 - [x] Rex does not claim live news access when the capability is unavailable.
 - [x] Suggested setup paths are backed by actual code/config/docs.
 - [x] Tests cover configured and unconfigured paths for "what is in the news today".
-- [ ] All relevant GitHub checks pass.
+- [x] All relevant GitHub checks pass. *(PR #406 corrected exact head `c897fb8d745f1352d6b2fc53cb740468b61f5c4f` completed all 18 checks successfully, including CI #1197, Commitlint #815, Windows Electron Artifact #166, CodeFactor, GitGuardian, and pre-commit; no submitted reviews or review threads.)*
 
 **Validation commands:**
 ```bash

--- a/PRD-production-readiness.md
+++ b/PRD-production-readiness.md
@@ -2702,11 +2702,11 @@ pytest -q tests/test_llm_client.py tests/test_assistant.py
 **Implementation notes:** Detect current-info/news intent before a plain LLM answer. If search/news capability is configured, route to it. If not configured, explain the missing provider/key and point to the exact settings/docs path.
 
 **Acceptance Criteria:**
-- [ ] News/current-info questions route to a configured search/news capability when available.
-- [ ] If no capability is configured, Rex explains what is missing and how to enable it.
-- [ ] Rex does not claim live news access when the capability is unavailable.
-- [ ] Suggested setup paths are backed by actual code/config/docs.
-- [ ] Tests cover configured and unconfigured paths for "what is in the news today".
+- [x] News/current-info questions route to a configured search/news capability when available.
+- [x] If no capability is configured, Rex explains what is missing and how to enable it.
+- [x] Rex does not claim live news access when the capability is unavailable.
+- [x] Suggested setup paths are backed by actual code/config/docs.
+- [x] Tests cover configured and unconfigured paths for "what is in the news today".
 - [ ] All relevant GitHub checks pass.
 
 **Validation commands:**

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2203,3 +2203,37 @@ Remote exact-head evidence for corrected implementation head `a85309d10fc721ba6f
 - CodeFactor initially failed the prior implementation head `93b6c1e2e75a636f16b8d31fd5f86466343f2f86` with one complexity finding in `gui/src/main/autonomySettings.ts`. That finding was addressed by refactoring migration planning/rollback into smaller helpers. CodeFactor then completed successfully on corrected head `a85309d10fc721ba6f52a82284328f0ca5dd7562` with no issues found.
 - PR #405 has no submitted reviews and no inline review threads.
 - US-073's final GitHub-check acceptance criterion is therefore closed. This documentation-only closure commit must still pass the repository's final merge checks before PR #405 is merged.
+
+2026-08-16 - US-077 local implementation complete; remote CI pending
+
+Implementation:
+- Added narrow, explicit current-info/news intent detection before ordinary LLM generation. Covered current cues include "what is in the news today", latest/current/today news/headlines/developments/updates, "what happened today", and explicit "latest ... on/about" phrasing. Historical/topic-only prompts without a current cue continue through normal routing.
+- Configured current-info requests bypass the normal response cache so stale answers cannot satisfy live-news requests.
+- Current-info search runs through the existing pre-LLM `ToolDispatcher`, which already executes blocking providers off the asyncio event loop. No new synchronous network call was added to `IntentRouter`.
+- Current-info tool selection is biased locally with a `web search` selection hint only after the narrow current-info intent matches. Generic Web Search capability tags remain `search/web/lookup`, so unrelated requests such as current settings do not trigger browsing.
+- Search failure, missing dispatcher, or unavailable provider fails closed with a deterministic explanation; Rex does not call the LLM or guess at live events.
+- Successful current-info search adds a `CURRENT-INFO GROUNDING` instruction requiring current/live factual claims to come only from the verified `web_search` result and to admit insufficiency instead of supplementing with model memory.
+- Current-info bypasses unrelated Home Assistant transcript routing so a pending HA clarification cannot replace a verified news result or fail-closed response.
+- Added `configured_search_providers()` as the shared provider-truth helper. DuckDuckGo is usable without a key when its shipped dependencies are present; Brave, SerpAPI, Google CSE, and Browserless require usable credentials/dependencies. SerpAPI supports both `SERPAPI_KEY` and the legacy `SERPAPI_API_KEY` alias.
+- Canonical assistant execution uses explicit `AppConfig.search_providers` as non-secret provider authority. The legacy `REX_SEARCH_PROVIDERS` override remains only for direct plugin compatibility when no explicit runtime config is supplied, matching Rex's documented JSON runtime-config authority.
+- Search credential resolution uses runtime config where applicable, environment/vault secret lookup, and does not expose credentials in tool request/audit payloads.
+- `ToolExecutionLifecycle` can privately inject the exact runtime config into handlers that explicitly opt in via `_runtime_config`; `web_search` uses this so provider selection and execution share one authority without putting config or secrets into auditable tool arguments/context.
+- Integration status now uses the same provider-truth helper as execution.
+- Updated `docs/configuration.md`, `INTEGRATIONS_STATUS.md`, and `CLAUDE.md` with truthful Web Search setup/recovery rules. Documentation explicitly says there is not yet a dedicated Electron Web Search credential form, so recovery points only to existing `search.providers` plus credential/docs paths.
+
+TDD / review evidence:
+- Initial US-077 tests were red because no current-info provider-truth helper or current-info route existed.
+- Existing Web Search plugin regression tests exposed old one-argument provider/fake-plugin compatibility; compatibility was preserved while passing runtime config to the real implementation.
+- Codex found and we fixed: current cues containing a year being misclassified as historical; "latest updates on ..." bypassing current-info; legacy provider-list env/config availability mismatch; pending Home Assistant clarification intercepting current-info.
+- Additional self-review fixes: moved network search out of synchronous `IntentRouter`; unified provider selection/execution config; removed overly broad `current/latest` capability tags; bypassed stale response cache for current-info; added explicit LLM grounding rule.
+- Final Codex rereview: no discrete correctness issue identified in the modified or newly added code.
+
+Validation evidence:
+- Full US-077/tool/assistant matrix: 236 passed; 18 pre-existing `AppConfig.llm_provider` deprecation warnings.
+- Required PRD validation (`tests/test_assistant.py`, `tests/test_capabilities.py`, `tests/test_tools_registry.py`) is included in that passing matrix.
+- `tests/test_web_search_plugin.py`: 4 passed after compatibility preservation.
+- `python -m mypy rex/assistant.py rex/intent/router.py rex/actions/dispatcher.py rex/integration_state.py rex/tools/registry.py rex/tools/dispatcher.py rex/tools/execution.py plugins/web_search.py --ignore-missing-imports`: passed with no issues.
+- `python scripts/security_audit.py --release-gate`: passed with 0 actionable findings and no exposed secrets.
+- `pre-commit run --all-files`: Ruff, Black, and detect-secrets passed.
+- `git diff --check`: passed.
+- US-077 local acceptance criteria are complete. The final GitHub-check criterion remains intentionally unchecked until the exact PR implementation head passes the remote matrix.

--- a/docs/archive/progress/progress-production-readiness.txt
+++ b/docs/archive/progress/progress-production-readiness.txt
@@ -2237,3 +2237,17 @@ Validation evidence:
 - `pre-commit run --all-files`: Ruff, Black, and detect-secrets passed.
 - `git diff --check`: passed.
 - US-077 local acceptance criteria are complete. The final GitHub-check criterion remains intentionally unchecked until the exact PR implementation head passes the remote matrix.
+
+
+2026-08-16 - US-077 remote GitHub evidence complete
+
+Remote exact-head evidence for corrected implementation head `c897fb8d745f1352d6b2fc53cb740468b61f5c4f` on PR #406:
+- GitHub Actions CI run #1197 completed successfully, including Python 3.11 tests/coverage, integration tests, mypy, Ruff/Black, GUI tests/typecheck/build/lint, security audit, wheel smoke, dependency audits, raw-API guard, and pre-commit validation.
+- Commitlint run #815 completed successfully.
+- Windows Electron Artifact run #166 completed successfully, including managed runtime/installer build, signature/resource validation, and installed-artifact execution without machine Python or Node.
+- The exact-head check suite registered 18 checks; every check completed and none concluded failure or remained in progress.
+- CodeFactor completed successfully with no issues found.
+- GitGuardian/hardcoded-secret checks completed successfully with no exposed secrets.
+- Earlier PR heads exposed synthetic provider-key fixtures to detect-secrets; the fixtures were corrected with scanner-compatible inline allowlist annotations. The corrected exact head passed GitHub's Pre-commit Hook Validation.
+- PR #406 has no submitted reviews and no inline review threads.
+- US-077's final GitHub-check acceptance criterion is therefore closed. This documentation-only closure commit must still pass the repository's final merge checks before PR #406 is merged.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,14 @@ provider. AskRex does not purchase credits or enable paid usage automatically.
 
 ### Web Search
 
+Provider order is configured by `search.providers` in Rex config (for example,
+`"duckduckgo,brave"`). DuckDuckGo is a no-key provider; Brave, SerpAPI, and
+Google CSE require the credentials below. Current-news requests use Web Search
+only when at least one enabled provider is actually usable. If no provider is
+usable, Rex reports the missing capability instead of guessing at live events.
+There is not yet a dedicated Web Search credential form in Electron Settings;
+use the documented Rex config/credential path below until that UI exists.
+
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
 | `BRAVE_API_KEY` | (none) | Yes (Brave) | Brave Search API key |

--- a/plugins/web_search.py
+++ b/plugins/web_search.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 import re
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 from urllib.parse import quote_plus
 
@@ -59,6 +61,75 @@ def _extract_explicit_search_query(text: str) -> str | None:
     return query or None
 
 
+def _credential_value(
+    names: tuple[str, ...],
+    *,
+    config: object | None = None,
+    config_attr: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    """Resolve a search credential from runtime config, env, or the household vault."""
+    if config_attr and config is not None:
+        value = getattr(config, config_attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    env = os.environ if environ is None else environ
+    for name in names:
+        value = env.get(name)
+        if value:
+            return value
+
+    try:
+        from rex.credentials import get_persisted_credential
+
+        for name in names:
+            value = get_persisted_credential(name)
+            if value:
+                return value
+    except Exception as exc:
+        logger.debug("Search credential lookup failed: %s", exc)
+    return None
+
+
+def configured_search_providers(
+    config: object | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return providers that are both enabled and actually usable right now."""
+    env = os.environ if environ is None else environ
+    source = config if config is not None else settings
+    configured = str(getattr(source, "search_providers", "") or "")
+    if config is None:
+        # Legacy direct-plugin compatibility only. Canonical assistant execution
+        # passes AppConfig explicitly, where non-secret provider authority lives.
+        configured = env.get("REX_SEARCH_PROVIDERS") or configured
+    providers = [item.strip().lower() for item in configured.split(",") if item.strip()]
+    usable: list[str] = []
+    for provider in providers:
+        if provider == "duckduckgo":
+            if requests is not None and BeautifulSoupType is not None:
+                usable.append(provider)
+        elif provider == "brave":
+            if _credential_value(
+                ("BRAVE_API_KEY",), config=source, config_attr="brave_api_key", environ=env
+            ):
+                usable.append(provider)
+        elif provider == "serpapi":
+            if _credential_value(("SERPAPI_KEY", "SERPAPI_API_KEY"), config=source, environ=env):
+                usable.append(provider)
+        elif provider == "google":
+            if _credential_value(("GOOGLE_API_KEY",), config=source, environ=env) and env.get(
+                "GOOGLE_CSE_ID"
+            ):
+                usable.append(provider)
+        elif provider == "browserless":
+            if env.get("BROWSERLESS_API_KEY") and BeautifulSoupType is not None:
+                usable.append(provider)
+    return usable
+
+
 # API Endpoints
 SERPAPI_URL = "https://serpapi.com/search"
 BRAVE_URL = "https://api.search.brave.com/res/v1/web/search"
@@ -106,15 +177,21 @@ class WebSearchPlugin:
             return None
         return self.search(explicit_query)
 
-    def search(self, query: str) -> str | None:
+    def search(self, query: str, *, config: object | None = None) -> str | None:
         query = _sanitize_query(query)
         if not query:
             return None
-        for provider in self._provider_order():
+        source = config if config is not None else settings
+        for provider in configured_search_providers(source):
             method = getattr(self, f"_search_{provider}", None)
             if callable(method):
                 try:
-                    result = method(query)
+                    parameters = inspect.signature(method).parameters
+                    accepts_config = "config" in parameters or any(
+                        parameter.kind == inspect.Parameter.VAR_KEYWORD
+                        for parameter in parameters.values()
+                    )
+                    result = method(query, config=source) if accepts_config else method(query)
                     if isinstance(result, str):
                         return result
                     if result is not None:
@@ -124,16 +201,11 @@ class WebSearchPlugin:
         logger.warning("All search providers failed")
         return None
 
-    def _provider_order(self) -> list[str]:
-        env_value = os.getenv("REX_SEARCH_PROVIDERS")
-        providers_value = env_value if env_value else settings.search_providers
-        return [p.strip() for p in providers_value.split(",") if p.strip()]
-
     def _format_result(self, title: str, url: str, snippet: str) -> str:
         return f"{title} - {url}\n{snippet}"
 
-    def _search_serpapi(self, query: str) -> str | None:
-        api_key = os.getenv("SERPAPI_KEY")
+    def _search_serpapi(self, query: str, *, config: object | None = None) -> str | None:
+        api_key = _credential_value(("SERPAPI_KEY", "SERPAPI_API_KEY"), config=config)
         if not api_key:
             return None
         params: dict[str, str] = {
@@ -160,8 +232,8 @@ class WebSearchPlugin:
             logger.warning("SerpAPI search failed: %s", e)
             return None
 
-    def _search_brave(self, query: str) -> str | None:
-        api_key = os.getenv("BRAVE_API_KEY")
+    def _search_brave(self, query: str, *, config: object | None = None) -> str | None:
+        api_key = _credential_value(("BRAVE_API_KEY",), config=config, config_attr="brave_api_key")
         if not api_key:
             return None
         headers = {"X-Subscription-Token": api_key}
@@ -183,7 +255,7 @@ class WebSearchPlugin:
             logger.warning("Brave search failed: %s", e)
             return None
 
-    def _search_duckduckgo(self, query: str) -> str | None:
+    def _search_duckduckgo(self, query: str, *, config: object | None = None) -> str | None:
         if BeautifulSoupType is None:
             logger.warning("BeautifulSoup is required for DuckDuckGo scraping")
             return None
@@ -209,8 +281,8 @@ class WebSearchPlugin:
             logger.warning("DuckDuckGo search failed: %s", e)
             return None
 
-    def _search_google(self, query: str) -> str | None:
-        api_key = os.getenv("GOOGLE_API_KEY")
+    def _search_google(self, query: str, *, config: object | None = None) -> str | None:
+        api_key = _credential_value(("GOOGLE_API_KEY",), config=config)
         engine_id = os.getenv("GOOGLE_CSE_ID")
         if not api_key or not engine_id:
             return None
@@ -232,7 +304,7 @@ class WebSearchPlugin:
             logger.warning("Google CSE search failed: %s", e)
             return None
 
-    def _search_browserless(self, query: str) -> str | None:
+    def _search_browserless(self, query: str, *, config: object | None = None) -> str | None:
         token = os.getenv("BROWSERLESS_API_KEY")
         if not token or BeautifulSoupType is None:
             return None
@@ -284,9 +356,12 @@ def _get_plugin() -> WebSearchPlugin:
 # --- Public API ---
 
 
-def search_web(query: str) -> str | None:
-    """Search the web using the configured fallback order."""
-    return _get_plugin().search(query)
+def search_web(query: str, *, config: object | None = None) -> str | None:
+    """Search the web using only providers that are configured and usable."""
+    plugin = _get_plugin()
+    if config is None:
+        return plugin.search(query)
+    return plugin.search(query, config=config)
 
 
 def search_serpapi(query: str) -> str | None:

--- a/rex/actions/dispatcher.py
+++ b/rex/actions/dispatcher.py
@@ -294,18 +294,21 @@ class ActionDispatcher:
 
         # 6. Auto tool dispatch: build pre-LLM tool context string
         _tool_context: str | None = None
+        _tool_results: dict[str, Any] = {}
+        current_info_requested = getattr(intent, "intent_type", None) == "current_info"
+        selection_text = f"web search {transcript}" if current_info_requested else transcript
         if self._tool_dispatcher is not None:
             defined_select_for_user = inspect.getattr_static(
                 self._tool_dispatcher, "select_tools_for_user", None
             )
             if defined_select_for_user is not None:
                 select_for_user = self._tool_dispatcher.select_tools_for_user
-                _selected_tools = select_for_user(transcript, user_id=effective_user)
+                _selected_tools = select_for_user(selection_text, user_id=effective_user)
             else:
                 # Compatibility adapters predating US-106 implement only
                 # select_tools(message). The canonical dispatcher exposes the
                 # user-aware extension above, while older adapters remain valid.
-                _selected_tools = self._tool_dispatcher.select_tools(transcript)
+                _selected_tools = self._tool_dispatcher.select_tools(selection_text)
             if mobile_action_context_active():
                 # Pre-LLM dispatch has only free-form transcript text. Mobile
                 # mutations must wait for a canonical structured tool call so
@@ -343,12 +346,35 @@ class ActionDispatcher:
                 )
 
         completion: str | None = None
+        if current_info_requested:
+            search_result = _tool_results.get("web_search")
+            search_failed = (
+                not isinstance(search_result, str)
+                or not search_result.strip()
+                or search_result.startswith("[tool error:")
+                or search_result.startswith("I couldn't reach web_search")
+            )
+            if search_failed:
+                completion = (
+                    "I couldn't verify current news through Web Search, so I won't guess at live "
+                    "events. Check the configured search provider/network and "
+                    "`docs/configuration.md` under Integrations > Web Search."
+                )
+            else:
+                grounding_rule = (
+                    "CURRENT-INFO GROUNDING: Make current/live factual claims only from the "
+                    "web_search result below. If that result is insufficient, say so instead of "
+                    "supplementing with model memory."
+                )
+                _tool_context = f"{grounding_rule}\n{_tool_context or ''}".strip()
+
         model_generated = False
 
         # 7. HA command routing (including undo and proactive suggestion injection)
         if (
             self._ha_bridge is not None
             and self._ha_bridge.enabled
+            and not current_info_requested
             and not mobile_action_context_active()
             and mobile_scope_granted("home.control")
         ):

--- a/rex/assistant.py
+++ b/rex/assistant.py
@@ -1040,9 +1040,11 @@ class Assistant:
             return completion
 
         check_cancelled()
-        cached = self._get_or_create_response_builder().check_cache(
-            transcript, user_id=effective_user_id
-        )
+        cached = None
+        if self._should_check_response_cache(intent):
+            cached = self._get_or_create_response_builder().check_cache(
+                transcript, user_id=effective_user_id
+            )
         check_cancelled()
         turn_events.emit(
             EventKind.ROUTE_PROGRESS,
@@ -1154,6 +1156,11 @@ class Assistant:
         latency_trace.finish()
         latency_trace.log_summary(logger, event=latency_event)
         return completion
+
+    @staticmethod
+    def _should_check_response_cache(intent: Any) -> bool:
+        """Current-info replies must be freshly verified instead of served from cache."""
+        return getattr(intent, "intent_type", None) != "current_info"
 
     async def generate_reply(
         self,

--- a/rex/integration_state.py
+++ b/rex/integration_state.py
@@ -115,12 +115,12 @@ def build_integration_inventory(
             "TWILIO_PHONE_NUMBER",
         )
     )
-    search_configured = bool(
-        has_credential("SERPAPI_API_KEY")
-        or has_credential("BRAVE_API_KEY")
-        or has_credential("GOOGLE_API_KEY")
-        or "duckduckgo" in str(getattr(config, "search_providers", ""))
-    )
+    try:
+        from plugins.web_search import configured_search_providers
+    except ImportError:
+        search_configured = False
+    else:
+        search_configured = bool(configured_search_providers(config, environ=env))
     specs = [
         (
             "home_assistant",

--- a/rex/intent/router.py
+++ b/rex/intent/router.py
@@ -65,6 +65,40 @@ _RECIPE_REQUEST_PATTERN = re.compile(
 _CHOCOLATE_CAKE_PATTERN = re.compile(r"\bchocolate\s+cake\b", re.IGNORECASE)
 _SHOPPING_LIST_REFERENCE_PATTERN = re.compile(r"\b(?:shopping\s+)?list\b", re.IGNORECASE)
 
+_CURRENT_INFO_PATTERNS = (
+    re.compile(
+        r"\bwhat(?:'s| is)\s+(?:in\s+)?(?:the\s+)?news\s+today\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:latest|current|today'?s)\s+(?:news|headlines?|events?|developments?|updates?)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:news|headlines?|updates?|developments?)\s+(?:today|right\s+now|currently)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bwhat(?:'s| is)\s+happening\s+(?:today|right\s+now|currently)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bwhat\s+happened\s+today\b", re.IGNORECASE),
+    re.compile(
+        r"\bwhat(?:'s| is| are)\s+(?:the\s+)?latest\s+(?:updates?\s+)?(?:on|about)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:give|show|tell)\s+me\s+(?:the\s+)?latest\s+(?:updates?\s+)?(?:on|about)\b",
+        re.IGNORECASE,
+    ),
+)
+_CURRENT_INFO_SETUP = (
+    "Web Search is not configured for verified current information. Enable at least one "
+    "provider in `search.providers` in Rex config. DuckDuckGo works without an API key; "
+    "Brave and SerpAPI require `BRAVE_API_KEY` or `SERPAPI_KEY`. See "
+    "`docs/configuration.md` under Integrations > Web Search."
+)
+
 _CHOCOLATE_CAKE_RECIPE = (
     "Here is a simple chocolate cake recipe: mix 1 and 3/4 cups flour, "
     "2 cups sugar, 3/4 cup cocoa, 1 and 1/2 teaspoons baking powder, "
@@ -198,6 +232,10 @@ class IntentRouter:
         if resp is not None:
             return IntentResult(handled=True, response=resp, intent_type="time_query")
 
+        current_info = self._try_current_info(text, settings=settings)
+        if current_info is not None:
+            return current_info
+
         resp = self._try_greeting(text)
         if resp is not None:
             return IntentResult(handled=True, response=resp, intent_type="greeting")
@@ -211,6 +249,41 @@ class IntentRouter:
     # ------------------------------------------------------------------
     # Private helpers — time / date
     # ------------------------------------------------------------------
+
+    def _try_current_info(self, text: str, *, settings: Any = None) -> IntentResult | None:
+        """Mark explicit current-news requests for pre-LLM web-search dispatch."""
+        if not any(pattern.search(text) for pattern in _CURRENT_INFO_PATTERNS):
+            return None
+
+        if settings is None:
+            return IntentResult(
+                handled=True,
+                response=_CURRENT_INFO_SETUP,
+                intent_type="current_info_unavailable",
+            )
+
+        try:
+            from plugins.web_search import configured_search_providers
+
+            providers = configured_search_providers(settings)
+        except Exception as exc:
+            logger.debug("current-info provider check failed: %s", exc)
+            providers = []
+
+        if not providers:
+            return IntentResult(
+                handled=True,
+                response=_CURRENT_INFO_SETUP,
+                intent_type="current_info_unavailable",
+            )
+
+        # The actual network call belongs to ActionDispatcher, which already
+        # executes selected tools off the asyncio event loop before the LLM.
+        return IntentResult(
+            handled=False,
+            response=None,
+            intent_type="current_info",
+        )
 
     def _try_time(self, text: str) -> str | None:
         """Answer simple clock/date queries without an LLM round trip."""

--- a/rex/tools/dispatcher.py
+++ b/rex/tools/dispatcher.py
@@ -219,6 +219,7 @@ class ToolDispatcher:
                 context,
                 timeout_seconds=self._timeout_seconds,
                 available=available,
+                runtime_config=self._config,
             )
 
     @staticmethod

--- a/rex/tools/execution.py
+++ b/rex/tools/execution.py
@@ -125,6 +125,7 @@ class ToolExecutionLifecycle:
         *,
         timeout_seconds: float = 10.0,
         available: bool = True,
+        runtime_config: Any = None,
     ) -> ToolResult:
         ambient = dict(context or {})
         request_id = str(
@@ -287,6 +288,8 @@ class ToolExecutionLifecycle:
             handler_args.setdefault("_user_id", user_id)
         if ambient.get("confirmed") and ("confirmed" in signature.parameters or accepts_kwargs):
             handler_args.setdefault("confirmed", True)
+        if runtime_config is not None and "_runtime_config" in signature.parameters:
+            handler_args.setdefault("_runtime_config", runtime_config)
         attempts = 2 if operation == ToolOperation.READ else 1
         for attempt in range(attempts):
             if cancellation is not None:

--- a/rex/tools/registry.py
+++ b/rex/tools/registry.py
@@ -246,7 +246,13 @@ class ToolRegistry:
 # ---------------------------------------------------------------------------
 
 
-def _web_search_handler(*, transcript: str = "", query: str = "", **kwargs: Any) -> Any:
+def _web_search_handler(
+    *,
+    transcript: str = "",
+    query: str = "",
+    _runtime_config: Any = None,
+    **kwargs: Any,
+) -> Any:
     """Execute web search through the installed provider integration."""
     search_query = (query or transcript).strip()
     if not search_query:
@@ -257,7 +263,7 @@ def _web_search_handler(*, transcript: str = "", query: str = "", **kwargs: Any)
     except ImportError as exc:
         raise RuntimeError("web_search integration is not installed") from exc
 
-    result = search_web(search_query)
+    result = search_web(search_query, config=_runtime_config)
     if result is None:
         raise RuntimeError("web_search integration is not configured")
     return result
@@ -354,7 +360,7 @@ def _build_default_registry(
                 "search providers (Brave, SerpAPI, DuckDuckGo, Google CSE)."
             ),
             capability_tags=["search", "web", "lookup"],
-            requires_config=["brave_api_key"],
+            requires_config=["search_providers"],
             handler=_web_search_handler,
         )
     )

--- a/tests/test_integration_state.py
+++ b/tests/test_integration_state.py
@@ -96,6 +96,28 @@ def test_twilio_requires_complete_credentials(monkeypatch) -> None:
     assert next(item for item in complete if item.key == "sms").state is IntegrationState.CONFIGURED
 
 
+def test_web_search_inventory_uses_actual_provider_truth(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "plugins.web_search.configured_search_providers",
+        lambda config, environ=None: ["duckduckgo"],
+    )
+    configured = build_integration_inventory(_config(search_providers="duckduckgo"), {})
+    assert (
+        next(item for item in configured if item.key == "search").state
+        is IntegrationState.CONFIGURED
+    )
+
+    monkeypatch.setattr(
+        "plugins.web_search.configured_search_providers",
+        lambda config, environ=None: [],
+    )
+    unconfigured = build_integration_inventory(_config(search_providers=""), {})
+    assert (
+        next(item for item in unconfigured if item.key == "search").state
+        is IntegrationState.UNCONFIGURED
+    )
+
+
 def test_inventory_preserves_all_visible_integrations() -> None:
     keys = {item.key for item in build_integration_inventory(_config(), {})}
     assert {

--- a/tests/test_us077_current_info.py
+++ b/tests/test_us077_current_info.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from rex.intent.router import IntentRouter
+
+NEWS_PROMPT = "what is in the news today"
+
+
+def _settings(providers: str) -> SimpleNamespace:
+    return SimpleNamespace(search_providers=providers, brave_api_key=None)
+
+
+def test_current_news_marks_configured_request_for_pre_llm_web_search() -> None:
+    router = IntentRouter()
+    with patch("plugins.web_search.configured_search_providers", return_value=["duckduckgo"]):
+        result = router.route(NEWS_PROMPT, settings=_settings("duckduckgo"))
+
+    assert result.handled is False
+    assert result.intent_type == "current_info"
+    assert result.response is None
+
+
+def test_current_news_unconfigured_explains_real_setup_path() -> None:
+    router = IntentRouter()
+    with patch("plugins.web_search.configured_search_providers", return_value=[]):
+        result = router.route(NEWS_PROMPT, settings=_settings(""))
+
+    assert result.handled is True
+    assert result.intent_type == "current_info_unavailable"
+    response = result.response or ""
+    assert "Web Search" in response
+    assert "search.providers" in response
+    assert "docs/configuration.md" in response
+    assert "DuckDuckGo" in response
+    assert "live news" not in response.lower()
+
+
+def test_historical_news_question_is_not_forced_into_live_search() -> None:
+    result = IntentRouter().route("What was in the news on July 20, 1969?", settings=_settings(""))
+
+    assert result.handled is False
+
+
+def test_current_news_setup_guidance_points_to_real_config_and_docs() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    schema = (root / "config" / "rex_config.schema.json").read_text(encoding="utf-8")
+    docs = (root / "docs" / "configuration.md").read_text(encoding="utf-8")
+
+    assert '"search"' in schema and '"providers"' in schema
+    assert "### Web Search" in docs
+    assert "search.providers" in docs
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "latest news about the 2026 election",
+        "What are the latest updates on Ukraine?",
+        "What happened today?",
+        "What's the latest on the storm?",
+    ],
+)
+def test_explicit_current_cues_route_to_verified_current_info_even_with_years(prompt: str) -> None:
+    with patch("plugins.web_search.configured_search_providers", return_value=["duckduckgo"]):
+        result = IntentRouter().route(prompt, settings=_settings("duckduckgo"))
+
+    assert result.handled is False
+    assert result.intent_type == "current_info"
+
+
+def test_year_without_current_cue_is_not_forced_into_live_search() -> None:
+    result = IntentRouter().route("Tell me about the 2026 election", settings=_settings(""))
+
+    assert result.handled is False
+    assert result.intent_type is None
+
+
+def test_current_info_intent_bypasses_response_cache() -> None:
+    from rex.assistant import Assistant
+    from rex.intent.router import IntentResult
+
+    assert (
+        Assistant._should_check_response_cache(
+            IntentResult(handled=False, response=None, intent_type="current_info")
+        )
+        is False
+    )
+    assert (
+        Assistant._should_check_response_cache(
+            IntentResult(handled=False, response=None, intent_type="general")
+        )
+        is True
+    )

--- a/tests/test_us077_current_info_dispatch.py
+++ b/tests/test_us077_current_info_dispatch.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from rex.actions.dispatcher import ActionDispatcher
+from rex.intent.router import IntentResult
+
+
+class _ResultHandler:
+    async def process(self, transcript, completion, **kwargs):
+        return completion
+
+
+class _SearchDispatcher:
+    def __init__(self, result: str) -> None:
+        self.result = result
+
+    def select_tools(self, transcript):
+        return [SimpleNamespace(name="web_search", operation="read")]
+
+    def execute_tools(self, selected, transcript, *, user_id):
+        return {"web_search": self.result}
+
+    def format_tool_context(self, results):
+        return f"web_search: {results['web_search']}"
+
+
+def _context_builder():
+    return SimpleNamespace(
+        build=lambda *args, **kwargs: SimpleNamespace(
+            messages=[
+                {"role": "system", "content": kwargs.get("tool_context", "")},
+                {"role": "user", "content": "what is in the news today"},
+            ],
+            prompt="what is in the news today",
+        )
+    )
+
+
+def _context():
+    return SimpleNamespace(
+        messages=[{"role": "user", "content": "what is in the news today"}],
+        prompt="what is in the news today",
+    )
+
+
+def test_verified_current_news_result_is_grounded_before_llm_answer() -> None:
+    llm = MagicMock()
+    llm.generate.return_value = "The verified result says the top story is current."
+    dispatcher = ActionDispatcher(
+        context_builder=_context_builder(),
+        llm=llm,
+        result_handler=_ResultHandler(),
+        tool_dispatcher=_SearchDispatcher(
+            "Top story - https://example.test/story\nVerified current snippet"
+        ),
+    )
+
+    result = asyncio.run(
+        dispatcher.dispatch(
+            IntentResult(handled=False, response=None, intent_type="current_info"),
+            _context(),
+            "what is in the news today",
+            user_id="james",
+        )
+    )
+
+    assert result.model_generated is True
+    assert "verified result" in result.response.lower()
+    messages = llm.generate.call_args.kwargs["messages"]
+    assert "Top story" in messages[0]["content"]
+    assert "CURRENT-INFO GROUNDING" in messages[0]["content"]
+    assert "supplementing with model memory" in messages[0]["content"]
+
+
+def test_failed_current_news_search_returns_honest_failure_without_llm() -> None:
+    llm = MagicMock()
+    dispatcher = ActionDispatcher(
+        context_builder=_context_builder(),
+        llm=llm,
+        result_handler=_ResultHandler(),
+        tool_dispatcher=_SearchDispatcher("[tool error: search provider unavailable]"),
+    )
+
+    result = asyncio.run(
+        dispatcher.dispatch(
+            IntentResult(handled=False, response=None, intent_type="current_info"),
+            _context(),
+            "what is in the news today",
+            user_id="james",
+        )
+    )
+
+    assert result.model_generated is False
+    assert "couldn't verify current news" in result.response.lower()
+    assert "won't guess" in result.response.lower()
+    llm.generate.assert_not_called()
+
+
+def test_missing_dispatcher_fails_closed_for_current_news() -> None:
+    llm = MagicMock()
+    dispatcher = ActionDispatcher(
+        context_builder=_context_builder(),
+        llm=llm,
+        result_handler=_ResultHandler(),
+        tool_dispatcher=None,
+    )
+
+    result = asyncio.run(
+        dispatcher.dispatch(
+            IntentResult(handled=False, response=None, intent_type="current_info"),
+            _context(),
+            "what is in the news today",
+            user_id="james",
+        )
+    )
+
+    assert "couldn't verify current news" in result.response.lower()
+    llm.generate.assert_not_called()
+
+
+def test_current_news_bypasses_pending_home_assistant_clarification() -> None:
+    llm = MagicMock()
+    llm.generate.return_value = "Verified news response"
+    ha_bridge = MagicMock()
+    ha_bridge.enabled = True
+    ha_bridge.process_transcript.return_value = "Which light did you mean?"
+    dispatcher = ActionDispatcher(
+        context_builder=_context_builder(),
+        llm=llm,
+        result_handler=_ResultHandler(),
+        tool_dispatcher=_SearchDispatcher(
+            "Top story - https://example.test/story\nVerified current snippet"
+        ),
+        ha_bridge=ha_bridge,
+    )
+
+    result = asyncio.run(
+        dispatcher.dispatch(
+            IntentResult(handled=False, response=None, intent_type="current_info"),
+            _context(),
+            "what happened today?",
+            user_id="james",
+        )
+    )
+
+    assert result.response == "Verified news response"
+    ha_bridge.process_transcript.assert_not_called()
+    ha_bridge.undo_last.assert_not_called()

--- a/tests/test_us077_search_provider_truth.py
+++ b/tests/test_us077_search_provider_truth.py
@@ -20,8 +20,9 @@ def test_disabled_provider_list_is_unconfigured() -> None:
 
 def test_brave_runtime_config_key_counts_as_configured() -> None:
     config = SimpleNamespace(
-        search_providers="brave", brave_api_key="vault-brave-key"
-    )  # pragma: allowlist secret
+        search_providers="brave",
+        brave_api_key="vault-brave-key",  # pragma: allowlist secret
+    )
 
     assert configured_search_providers(config, environ={}) == ["brave"]
 

--- a/tests/test_us077_search_provider_truth.py
+++ b/tests/test_us077_search_provider_truth.py
@@ -19,7 +19,9 @@ def test_disabled_provider_list_is_unconfigured() -> None:
 
 
 def test_brave_runtime_config_key_counts_as_configured() -> None:
-    config = SimpleNamespace(search_providers="brave", brave_api_key="vault-brave-key")
+    config = SimpleNamespace(
+        search_providers="brave", brave_api_key="vault-brave-key"
+    )  # pragma: allowlist secret
 
     assert configured_search_providers(config, environ={}) == ["brave"]
 
@@ -27,15 +29,15 @@ def test_brave_runtime_config_key_counts_as_configured() -> None:
 def test_serpapi_accepts_documented_key_name() -> None:
     config = SimpleNamespace(search_providers="serpapi", brave_api_key=None)
 
-    assert configured_search_providers(config, environ={"SERPAPI_KEY": "serp-key"}) == ["serpapi"]
+    env = {"SERPAPI_KEY": "serp-key"}  # pragma: allowlist secret
+    assert configured_search_providers(config, environ=env) == ["serpapi"]
 
 
 def test_serpapi_accepts_legacy_api_key_alias() -> None:
     config = SimpleNamespace(search_providers="serpapi", brave_api_key=None)
 
-    assert configured_search_providers(config, environ={"SERPAPI_API_KEY": "serp-key"}) == [
-        "serpapi"
-    ]
+    env = {"SERPAPI_API_KEY": "serp-key"}  # pragma: allowlist secret
+    assert configured_search_providers(config, environ=env) == ["serpapi"]
 
 
 def test_unconfigured_brave_does_not_count_vault_lookup_failure() -> None:

--- a/tests/test_us077_search_provider_truth.py
+++ b/tests/test_us077_search_provider_truth.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from plugins.web_search import configured_search_providers
+
+
+def test_duckduckgo_is_usable_without_api_key_when_enabled() -> None:
+    config = SimpleNamespace(search_providers="duckduckgo", brave_api_key=None)
+
+    assert configured_search_providers(config, environ={}) == ["duckduckgo"]
+
+
+def test_disabled_provider_list_is_unconfigured() -> None:
+    config = SimpleNamespace(search_providers="", brave_api_key=None)
+
+    assert configured_search_providers(config, environ={}) == []
+
+
+def test_brave_runtime_config_key_counts_as_configured() -> None:
+    config = SimpleNamespace(search_providers="brave", brave_api_key="vault-brave-key")
+
+    assert configured_search_providers(config, environ={}) == ["brave"]
+
+
+def test_serpapi_accepts_documented_key_name() -> None:
+    config = SimpleNamespace(search_providers="serpapi", brave_api_key=None)
+
+    assert configured_search_providers(config, environ={"SERPAPI_KEY": "serp-key"}) == ["serpapi"]
+
+
+def test_serpapi_accepts_legacy_api_key_alias() -> None:
+    config = SimpleNamespace(search_providers="serpapi", brave_api_key=None)
+
+    assert configured_search_providers(config, environ={"SERPAPI_API_KEY": "serp-key"}) == [
+        "serpapi"
+    ]
+
+
+def test_unconfigured_brave_does_not_count_vault_lookup_failure() -> None:
+    config = SimpleNamespace(search_providers="brave", brave_api_key=None)
+    with patch("rex.credentials.get_persisted_credential", return_value=None):
+        assert configured_search_providers(config, environ={}) == []
+
+
+def test_current_news_selects_web_search_in_canonical_dispatcher() -> None:
+    from rex.tools.dispatcher import ToolDispatcher
+    from rex.tools.registry import get_default_registry
+
+    config = SimpleNamespace(search_providers="duckduckgo", tool_timeout_seconds=10)
+    selected = ToolDispatcher(get_default_registry(), config=config).select_tools(
+        "web search what is in the news today"
+    )
+
+    assert "web_search" in {tool.name for tool in selected}
+
+
+def test_web_search_execution_uses_same_runtime_config_as_selection() -> None:
+    from rex.tools.dispatcher import ToolDispatcher
+    from rex.tools.registry import get_default_registry
+
+    config = SimpleNamespace(search_providers="duckduckgo", tool_timeout_seconds=10)
+    dispatcher = ToolDispatcher(get_default_registry(), config=config)
+    with patch("plugins.web_search.search_web", return_value="verified") as search:
+        result = dispatcher.dispatch("web_search", {"transcript": "latest news"})
+
+    assert result.success is True
+    assert result.output == "verified"
+    search.assert_called_once_with("latest news", config=config)
+
+
+def test_explicit_runtime_config_does_not_use_legacy_provider_env_override() -> None:
+    config = SimpleNamespace(search_providers="", brave_api_key=None)
+
+    assert configured_search_providers(config, environ={"REX_SEARCH_PROVIDERS": "duckduckgo"}) == []


### PR DESCRIPTION
## Summary
- detect narrow explicit current-info/news intent before ordinary generation without broadly browsing unrelated requests
- route configured current-info through the existing pre-LLM ToolDispatcher and bypass stale response cache
- fail closed without LLM guessing when Web Search is unavailable, unconfigured, missing, or fails
- ground successful current/live claims strictly in the verified `web_search` result
- unify Web Search provider truth across routing, capability status, selection, and execution
- preserve legacy direct-plugin provider compatibility while keeping explicit AppConfig as canonical assistant authority
- prevent pending Home Assistant clarification state from intercepting routed current-info turns
- document the real `search.providers`/credential recovery path without claiming a Web Search Settings UI that does not exist yet

## Review fixes
- fixed year-bearing current prompts such as `latest news about the 2026 election` being treated as historical
- added explicit current phrasing such as `latest updates on ...`, `what happened today`, and `what's the latest on ...`
- fixed provider selection/execution using different config authorities
- fixed legacy `REX_SEARCH_PROVIDERS` creating router/registry availability drift
- moved network work out of synchronous intent routing
- removed overly broad `current/latest` web-search tags that could trigger browsing for unrelated requests
- bypassed stale response cache for live current-info
- bypassed unrelated HA clarification interception
- added explicit current-info LLM grounding to prevent supplementing live claims from model memory
- final Codex rereview found no discrete correctness issue

## Validation
- full local US-077/tool/assistant matrix before rebase: 236 passed
- post-rebase matrix: 201 passed, including required `tests/test_assistant.py tests/test_capabilities.py tests/test_tools_registry.py`
- existing Web Search plugin tests: 4 passed
- mypy on all touched runtime modules: passed
- security release gate: 0 actionable findings, no exposed secrets
- pre-commit all-files: Ruff, Black, detect-secrets passed
- `git diff --check`: passed

The final US-077 `All relevant GitHub checks pass` criterion remains intentionally unchecked until this exact PR head passes the remote matrix.