### PR TITLE
fix(gui): bootstrap Electron binary after install

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "rex-gui",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/tsconfig": "^2.0.0",

--- a/gui/package.json
+++ b/gui/package.json
@@ -16,7 +16,8 @@
     "preview": "electron-vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "postinstall": "install-electron --no"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.1",


### PR DESCRIPTION
## Summary
- add a GUI `postinstall` hook that runs Electron's supported `install-electron --no` binary bootstrap
- ensure `npm install` prepares `node_modules/electron/path.txt` and the Electron executable before `electron-vite dev` tries to resolve them
- update the lockfile install-script metadata only

## Root cause
On the current Windows dev machine, `npm install` reported the dependency tree as up to date, but Electron 42.8.1 had no downloaded binary or `path.txt`. `electron-vite` therefore failed with `Error: Electron uninstall`. Electron 42 uses the separate `install-electron` bootstrap path, while electron-vite expects `path.txt` to already exist.

## Reproduction evidence
Before repair:
- `electron@42.8.1` and `electron-vite@3.1.0` were installed
- `node_modules/.bin/electron.cmd` existed
- `node_modules/electron/dist/electron.exe` was missing
- `node_modules/electron/path.txt` was missing
- `npm run dev` failed at `getElectronPath()` with `Error: Electron uninstall`

After running the Electron installer, both missing files were created and the GUI launched.

## Verification
- `npm install` executed `rex-gui@1.0.0 postinstall -> install-electron --no`
- original GUI launch path verified: Electron app starts and bridge scripts validate
- GUI Vitest: **183 passed, 0 failed**
- TypeScript typecheck: passed
- ESLint: **0 errors**, 3 pre-existing warnings
- production `electron-vite build`: passed
- `git diff --check`: passed
- security release gate: passed with 0 actionable source/config findings and no exposed secrets

No dependency versions were changed.