### PR TITLE
test(openclaw): stabilize successor reconnect race

### DIFF
--- a/tests/rex2/test_openclaw_reconnect.py
+++ b/tests/rex2/test_openclaw_reconnect.py
@@ -762,7 +762,6 @@ def test_outage_after_ready_before_worker_exit_reserves_successor_worker() -> No
         resync=_fresh_success,
         mark_unavailable=lambda: None,
         auto_reconnect=True,
-        wait_fn=lambda _delay: True,
     )
     controller.mark_disconnected("first_outage")
     assert recovered.wait(timeout=5)


### PR DESCRIPTION
## Summary
- removes a contradictory test-only wait stub from the successor reconnect race test
- lets the test use the controller's real stop event, so `close()` deterministically stops the successor loop
- no production reconnect behavior changes

## Evidence
- reproduced the original intermittent `probe_calls == 3` failure on the unchanged reconnect implementation
- updated fixture passed 40 consecutive focused runs
- full `tests/rex2/test_openclaw_reconnect.py`: 26 passed
- Ruff, Black, pre-commit detect-secrets, and `git diff --check`: passed

This unblocks unrelated PRs whose full Python CI can otherwise fail nondeterministically on the existing master test fixture.